### PR TITLE
[OSS PR #18036] feat(schema): Add support to write shredded variants for HoodieRecordType.SPARK

### DIFF
--- a/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/util/HoodieSchemaConverter.java
+++ b/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/util/HoodieSchemaConverter.java
@@ -554,8 +554,7 @@ public class HoodieSchemaConverter {
 
   /**
    * Converts a Variant schema to Flink's ROW type.
-   * Variant is represented as ROW<`metadata` BYTES, `value` BYTES> in Flink.
-   * // TODO: We are only supporting unshredded for now, support shredded in the future
+   * Variant is represented as ROW<`value` BYTES, `metadata` BYTES> in Flink.
    *
    * @param schema HoodieSchema to convert (must be a VARIANT type)
    * @return DataType representing the Variant as a ROW with binary fields

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/io/storage/row/HoodieRowParquetWriteSupport.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/io/storage/row/HoodieRowParquetWriteSupport.java
@@ -18,6 +18,7 @@
 
 package org.apache.hudi.io.storage.row;
 
+import org.apache.hudi.HoodieSchemaConversionUtils;
 import org.apache.hudi.HoodieSparkUtils;
 import org.apache.hudi.SparkAdapterSupport$;
 import org.apache.hudi.avro.HoodieBloomFilterWriteSupport;
@@ -26,6 +27,7 @@ import org.apache.hudi.common.config.HoodieConfig;
 import org.apache.hudi.common.config.HoodieStorageConfig;
 import org.apache.hudi.common.schema.HoodieSchema;
 import org.apache.hudi.common.schema.HoodieSchema.TimePrecision;
+import org.apache.hudi.common.schema.HoodieSchemaField;
 import org.apache.hudi.common.schema.HoodieSchemaType;
 import org.apache.hudi.common.schema.HoodieSchemaUtils;
 import org.apache.hudi.common.util.Option;
@@ -122,6 +124,12 @@ public class HoodieRowParquetWriteSupport extends WriteSupport<InternalRow> {
   private final ValueWriter[] rootFieldWriters;
   private final HoodieSchema schema;
   private final StructType structType;
+  /**
+   * The shredded schema. When Variant columns are configured for shredding, this schema has those VariantType columns replaced with their shredded struct schemas.
+   * <p>
+   * For non-shredded cases, this is identical to structType.
+   */
+  private final StructType shreddedSchema;
   private RecordConsumer recordConsumer;
 
   public HoodieRowParquetWriteSupport(Configuration conf, StructType structType, Option<BloomFilter> bloomFilterOpt, HoodieConfig config) {
@@ -140,21 +148,162 @@ public class HoodieRowParquetWriteSupport extends WriteSupport<InternalRow> {
           HoodieSchema parsedSchema = HoodieSchema.parse(schemaString);
           return HoodieSchemaUtils.addMetadataFields(parsedSchema, config.getBooleanOrDefault(ALLOW_OPERATION_METADATA_FIELD));
         });
+    // Generate shredded schema if there are shredded Variant columns.
+    // Falls back to the provided schema if no shredded Variant columns are present.
+    this.shreddedSchema = generateShreddedSchema(structType, schema);
     ParquetWriteSupport.setSchema(structType, hadoopConf);
-    this.rootFieldWriters = getFieldWriters(structType, schema);
+    // Use shreddedSchema for creating writers when shredded Variants are present
+    this.rootFieldWriters = getFieldWriters(shreddedSchema, schema);
     this.hadoopConf = hadoopConf;
     this.bloomFilterWriteSupportOpt = bloomFilterOpt.map(HoodieBloomFilterRowWriteSupport::new);
   }
 
+  /**
+   * Generates a shredded schema from the given structType and hoodieSchema.
+   * <p>
+   * For Variant fields that are configured for shredding (based on HoodieSchema.Variant.isShredded()),
+   * the VariantType is replaced with a shredded struct schema. This method recursively processes
+   * nested struct fields to handle Variant fields at any depth.
+   *
+   * @param structType The original Spark StructType
+   * @param hoodieSchema The HoodieSchema containing shredding information
+   * @return A StructType with shredded Variant fields replaced by their shredded schemas
+   */
+  private StructType generateShreddedSchema(StructType structType, HoodieSchema hoodieSchema) {
+    StructField[] fields = structType.fields();
+    StructField[] shreddedFields = new StructField[fields.length];
+    boolean hasShredding = false;
+
+    for (int i = 0; i < fields.length; i++) {
+      StructField field = fields[i];
+      DataType dataType = field.dataType();
+
+      // Get the HoodieSchema for this field (if available)
+      // Use getNonNullType() to unwrap nullable unions (e.g., ["null", "string"] -> "string")
+      HoodieSchema fieldHoodieSchema = Option.ofNullable(hoodieSchema)
+          .map(HoodieSchema::getNonNullType)
+          .flatMap(s -> s.hasFields() ? s.getField(field.name()) : Option.empty())
+          .map(HoodieSchemaField::schema)
+          .orElse(null);
+
+      // Check if this is a Variant field that should be shredded
+      if (SparkAdapterSupport$.MODULE$.sparkAdapter().isVariantType(dataType)) {
+        if (fieldHoodieSchema != null && fieldHoodieSchema.getType() == HoodieSchemaType.VARIANT) {
+          HoodieSchema.Variant variantSchema = (HoodieSchema.Variant) fieldHoodieSchema;
+          // If typed_value field exists, the variant is shredded
+          if (variantSchema.getTypedValueField().isPresent()) {
+            // Use plain types for SparkShreddingUtils (unwraps nested {value, typed_value} structs if present)
+            HoodieSchema typedValueSchema = variantSchema.getPlainTypedValueSchema().get();
+            DataType typedValueDataType = HoodieSchemaConversionUtils.convertHoodieSchemaToDataType(typedValueSchema);
+
+            // Generate the shredding schema with write metadata using SparkAdapter
+            StructType markedShreddedStruct = SparkAdapterSupport$.MODULE$.sparkAdapter()
+                .generateVariantWriteShreddingSchema(typedValueDataType, true, false);
+
+            shreddedFields[i] = new StructField(field.name(), markedShreddedStruct, field.nullable(), field.metadata());
+            hasShredding = true;
+            continue;
+          }
+        }
+      }
+
+      // Recursively process nested fields (for VariantType without shredding, or for nested structures like StructType/ArrayType/MapType)
+      DataType processedDataType = processNestedDataType(field.dataType(), fieldHoodieSchema);
+      if (processedDataType != field.dataType()) {
+        shreddedFields[i] = new StructField(field.name(), processedDataType, field.nullable(), field.metadata());
+        hasShredding = true;
+      } else {
+        // No shredding in this field or its nested fields
+        shreddedFields[i] = field;
+      }
+    }
+
+    return hasShredding ? new StructType(shreddedFields) : structType;
+  }
+
+  /**
+   * Recursively processes nested data types (structs, arrays, maps) to handle Variant shredding at any depth.
+   *
+   * @param dataType The data type to process
+   * @param hoodieSchema The corresponding HoodieSchema
+   * @return The processed data type with shredded Variants, or the original if no shredding needed
+   */
+  private DataType processNestedDataType(DataType dataType, HoodieSchema hoodieSchema) {
+    // Unwrap nullable unions (e.g., ["null", "map"] -> "map") before type checks,
+    // consistent with generateShreddedSchema and makeWriter
+    HoodieSchema resolvedSchema = hoodieSchema != null ? hoodieSchema.getNonNullType() : null;
+
+    // Check if this is a Variant type that should be shredded.
+    // Both the Spark DataType and HoodieSchema must agree that this is a Variant,
+    // consistent with generateShreddedSchema which also checks both.
+    if (SparkAdapterSupport$.MODULE$.sparkAdapter().isVariantType(dataType)
+        && resolvedSchema != null && resolvedSchema.getType() == HoodieSchemaType.VARIANT) {
+      HoodieSchema.Variant variantSchema = (HoodieSchema.Variant) resolvedSchema;
+      // If typed_value field exists, the variant is shredded
+      if (variantSchema.getTypedValueField().isPresent()) {
+        // Use plain types for SparkShreddingUtils (unwraps nested {value, typed_value} structs if present)
+        HoodieSchema typedValueSchema = variantSchema.getPlainTypedValueSchema().get();
+        DataType typedValueDataType = HoodieSchemaConversionUtils.convertHoodieSchemaToDataType(typedValueSchema);
+
+        // Generate the shredding schema with write metadata using SparkAdapter.
+        // isTopLevel=true: this is the top level of the variant's own shredding structure.
+        // isObjectField=false: this is a standalone variant column, not a field inside another variant's typed_value.
+        return SparkAdapterSupport$.MODULE$.sparkAdapter()
+            .generateVariantWriteShreddingSchema(typedValueDataType, true, false);
+      }
+      return dataType;
+    }
+
+    if (dataType instanceof StructType) {
+      StructType structType = (StructType) dataType;
+      return generateShreddedSchema(structType, resolvedSchema);
+    } else if (dataType instanceof ArrayType) {
+      ArrayType arrayType = (ArrayType) dataType;
+      HoodieSchema elementSchema = resolvedSchema != null && resolvedSchema.getType() == HoodieSchemaType.ARRAY
+          ? resolvedSchema.getElementType()
+          : null;
+      DataType processedElementType = processNestedDataType(arrayType.elementType(), elementSchema);
+      if (processedElementType != arrayType.elementType()) {
+        return new ArrayType(processedElementType, arrayType.containsNull());
+      }
+    } else if (dataType instanceof MapType) {
+      MapType mapType = (MapType) dataType;
+      HoodieSchema valueSchema = resolvedSchema != null && resolvedSchema.getType() == HoodieSchemaType.MAP
+          ? resolvedSchema.getValueType()
+          : null;
+      DataType processedValueType = processNestedDataType(mapType.valueType(), valueSchema);
+      if (processedValueType != mapType.valueType()) {
+        return new MapType(mapType.keyType(), processedValueType, mapType.valueContainsNull());
+      }
+    }
+    return dataType;
+  }
+
+  /**
+   * Creates field writers for each field in the schema.
+   *
+   * @param schema The schema to create writers for (may contain shredded Variant struct types)
+   * @param hoodieSchema The HoodieSchema for type information
+   * @return Array of ValueWriters for each field
+   */
   private ValueWriter[] getFieldWriters(StructType schema, HoodieSchema hoodieSchema) {
-    return Arrays.stream(schema.fields()).map(field -> {
+    StructField[] fields = schema.fields();
+    ValueWriter[] writers = new ValueWriter[fields.length];
+
+    for (int i = 0; i < fields.length; i++) {
+      StructField field = fields[i];
+
       HoodieSchema fieldSchema = Option.ofNullable(hoodieSchema)
-          .flatMap(s -> s.getField(field.name()))
+          .map(HoodieSchema::getNonNullType)
+          .flatMap(s -> s.hasFields() ? s.getField(field.name()) : Option.empty())
           // Note: Cannot use HoodieSchemaField::schema method reference due to Java 17 compilation ambiguity
           .map(f -> f.schema())
           .orElse(null);
-      return makeWriter(fieldSchema, field.dataType());
-    }).toArray(ValueWriter[]::new);
+
+      writers[i] = makeWriter(fieldSchema, field.dataType());
+    }
+
+    return writers;
   }
 
   @Override
@@ -171,7 +320,9 @@ public class HoodieRowParquetWriteSupport extends WriteSupport<InternalRow> {
     }
     Configuration configurationCopy = new Configuration(configuration);
     configurationCopy.set(AvroWriteSupport.WRITE_OLD_LIST_STRUCTURE, Boolean.toString(writeLegacyListFormat));
-    MessageType messageType = convert(structType, schema);
+    // Use shreddedSchema for Parquet schema conversion when shredding is enabled
+    // This ensures the Parquet file structure includes the shredded typed_value columns
+    MessageType messageType = convert(shreddedSchema, schema);
     return new WriteContext(messageType, metadata);
   }
 
@@ -391,6 +542,9 @@ public class HoodieRowParquetWriteSupport extends WriteSupport<InternalRow> {
           }
         });
       };
+    } else if (dataType instanceof StructType
+        && SparkAdapterSupport$.MODULE$.sparkAdapter().isVariantShreddingStruct((StructType) dataType)) {
+      return makeShreddedVariantWriter((StructType) dataType);
     } else if (dataType instanceof StructType) {
       StructType structType = (StructType) dataType;
       ValueWriter[] fieldWriters = getFieldWriters(structType, resolvedSchema);
@@ -401,6 +555,33 @@ public class HoodieRowParquetWriteSupport extends WriteSupport<InternalRow> {
     } else {
       throw new UnsupportedOperationException("Unsupported type: " + dataType);
     }
+  }
+
+  /**
+   * Creates a ValueWriter for a shredded Variant column.
+   * This writer converts a Variant value into its shredded components (metadata, value, typed_value) and writes them to Parquet.
+   *
+   * @param shreddedStructType The shredded StructType (with shredding metadata)
+   * @return A ValueWriter that handles shredded Variant writing
+   */
+  private ValueWriter makeShreddedVariantWriter(StructType shreddedStructType) {
+    // Create writers for the shredded struct fields
+    // The shreddedStructType contains: metadata (binary), value (binary), typed_value (optional)
+    ValueWriter[] shreddedFieldWriters = Arrays.stream(shreddedStructType.fields())
+        .map(field -> makeWriter(null, field.dataType()))
+        .toArray(ValueWriter[]::new);
+
+    // Use the SparkAdapter to create a shredded variant writer that converts Variant to shredded components
+    BiConsumer<SpecializedGetters, Integer> shreddedWriter = SparkAdapterSupport$.MODULE$.sparkAdapter()
+        .createShreddedVariantWriter(
+            shreddedStructType,
+            shreddedRow -> {
+              // Write the shredded row as a group
+              consumeGroup(() -> writeFields(shreddedRow, shreddedStructType, shreddedFieldWriters));
+            }
+        );
+
+    return shreddedWriter::accept;
   }
 
   private ValueWriter twoLevelArrayWriter(String repeatedFieldName, ValueWriter elementWriter) {

--- a/hudi-common/src/main/java/org/apache/hudi/common/schema/HoodieSchema.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/schema/HoodieSchema.java
@@ -867,6 +867,112 @@ public class HoodieSchema implements Serializable {
   }
 
   /**
+   * Creates a shredded field struct per the Parquet variant shredding spec. The returned struct contains two nullable fields:
+   * <ul>
+   *   <li>{@code value}: nullable bytes (fallback binary representation)</li>
+   *   <li>{@code typed_value}: nullable type (the typed representation)</li>
+   * </ul>
+   *
+   * <p>Example output structure:
+   * <pre>
+   *   fieldName: struct
+   *     |-- value: binary (nullable)
+   *     |-- typed_value: &lt;fieldType&gt; (nullable)
+   * </pre></p>
+   *
+   * @param fieldName the name for the record (used as the Avro record name)
+   * @param fieldType the schema for the typed_value within this field
+   * @return a new HoodieSchema representing the shredded field struct
+   */
+  public static HoodieSchema createShreddedFieldStruct(String fieldName, HoodieSchema fieldType) {
+    ValidationUtils.checkArgument(fieldName != null && !fieldName.isEmpty(), "Field name cannot be null or empty");
+    ValidationUtils.checkArgument(fieldType != null, "Field type cannot be null");
+    List<HoodieSchemaField> fields = Arrays.asList(
+        HoodieSchemaField.of(
+            Variant.VARIANT_VALUE_FIELD,
+            HoodieSchema.createNullable(HoodieSchemaType.BYTES),
+            "Fallback binary representation",
+            NULL_VALUE
+        ),
+        HoodieSchemaField.of(
+            Variant.VARIANT_TYPED_VALUE_FIELD,
+            HoodieSchema.createNullable(fieldType),
+            "Typed value representation",
+            NULL_VALUE
+        )
+    );
+    return HoodieSchema.createRecord(fieldName, null, null, fields);
+  }
+
+  /**
+   * Creates a shredded Variant schema for an object type following the Parquet variant shredding spec. Each field in shreddedFields is wrapped in a struct with
+   * {@code {value: nullable binary, typed_value: nullable type}}.
+   *
+   * <p>Example usage:
+   * <pre>{@code
+   * Map<String, HoodieSchema> fields = new LinkedHashMap<>();
+   * fields.put("a", HoodieSchema.create(HoodieSchemaType.INT));
+   * fields.put("b", HoodieSchema.create(HoodieSchemaType.STRING));
+   * fields.put("c", HoodieSchema.createDecimal(15, 1));
+   * HoodieSchema.Variant variant = HoodieSchema.createVariantShreddedObject(fields);
+   * }</pre></p>
+   *
+   * <p>Produces the following structure:
+   * <pre>
+   * variant
+   *  |-- value: binary (nullable)
+   *  |-- metadata: binary
+   *  |-- typed_value: struct
+   *  |    |-- a: struct (nullable)
+   *  |    |    |-- value: binary (nullable)
+   *  |    |    |-- typed_value: integer (nullable)
+   *  |    |-- b: struct (nullable)
+   *  |    |    |-- value: binary (nullable)
+   *  |    |    |-- typed_value: string (nullable)
+   *  |    |-- c: struct (nullable)
+   *  |    |    |-- value: binary (nullable)
+   *  |    |    |-- typed_value: decimal(15,1) (nullable)
+   * </pre></p>
+   *
+   * @param shreddedFields Map of field names to their typed value schemas. Use LinkedHashMap for ordered fields.
+   * @return a new HoodieSchema.Variant with properly nested typed_value
+   */
+  public static HoodieSchema.Variant createVariantShreddedObject(Map<String, HoodieSchema> shreddedFields) {
+    return createVariantShreddedObject(null, null, null, shreddedFields);
+  }
+
+  /**
+   * Creates a shredded Variant schema for an object type with custom name, namespace, and documentation.
+   *
+   * @param name           the variant record name (can be null, defaults to "variant")
+   * @param namespace      the namespace (can be null)
+   * @param doc            the documentation (can be null)
+   * @param shreddedFields Map of field names to their typed value schemas. Use LinkedHashMap for ordered fields.
+   * @return a new HoodieSchema.Variant with properly nested typed_value
+   */
+  public static HoodieSchema.Variant createVariantShreddedObject(
+      String name, String namespace, String doc, Map<String, HoodieSchema> shreddedFields) {
+    ValidationUtils.checkArgument(shreddedFields != null && !shreddedFields.isEmpty(),
+        "Shredded fields cannot be null or empty");
+
+    // Build typed_value fields, each wrapped in the spec-compliant {value, typed_value} struct
+    List<HoodieSchemaField> typedValueFields = new ArrayList<>();
+    for (Map.Entry<String, HoodieSchema> entry : shreddedFields.entrySet()) {
+      HoodieSchema fieldStruct = createShreddedFieldStruct(entry.getKey(), entry.getValue());
+      typedValueFields.add(HoodieSchemaField.of(
+          entry.getKey(),
+          HoodieSchema.createNullable(fieldStruct),
+          null,
+          NULL_VALUE
+      ));
+    }
+
+    HoodieSchema typedValueSchema = HoodieSchema.createRecord(
+        Variant.VARIANT_TYPED_VALUE_FIELD, null, namespace, typedValueFields);
+    return createVariantShredded(name, namespace, doc, typedValueSchema);
+  }
+
+  /**
    * Returns the Hudi schema version information.
    *
    * @return version string of the Hudi schema system
@@ -2461,6 +2567,60 @@ public class HoodieSchema implements Serializable {
      */
     public Option<HoodieSchema> getTypedValueField() {
       return typedValueSchema;
+    }
+
+    /**
+     * Returns the typed_value schema with plain (unwrapped) types suitable for Spark shredding utilities, i.e. essentially removing the `value` field
+     *
+     * <p>If the typed_value follows the variant shredding spec (each field is a struct with
+     * {@code {value: bytes, typed_value: <type>}}), this extracts only the inner typed_value types and returns a record schema containing just those plain types.</p>
+     *
+     * <p>If the typed_value is already in plain form (created with {@code createVariantShredded}),
+     * returns the schema as-is.</p>
+     *
+     * @return Option containing the plain typed_value schema, or Option.empty() if not present
+     */
+    public Option<HoodieSchema> getPlainTypedValueSchema() {
+      if (!typedValueSchema.isPresent()) {
+        return Option.empty();
+      }
+      HoodieSchema tvSchema = typedValueSchema.get();
+      if (tvSchema.getType() != HoodieSchemaType.RECORD) {
+        return typedValueSchema;
+      }
+
+      List<HoodieSchemaField> fields = tvSchema.getFields();
+      // Check if all fields follow the nested shredding pattern: each field is a record with {value, typed_value}
+      boolean isNestedForm = !fields.isEmpty() && fields.stream().allMatch(field -> {
+        HoodieSchema fieldSchema = field.schema();
+        if (fieldSchema.isNullable()) {
+          fieldSchema = fieldSchema.getNonNullType();
+        }
+        if (fieldSchema.getType() != HoodieSchemaType.RECORD) {
+          return false;
+        }
+        Option<HoodieSchemaField> valueSubField = fieldSchema.getField(VARIANT_VALUE_FIELD);
+        Option<HoodieSchemaField> typedValueSubField = fieldSchema.getField(VARIANT_TYPED_VALUE_FIELD);
+        return valueSubField.isPresent() && typedValueSubField.isPresent()
+            && fieldSchema.getFields().size() == 2;
+      });
+
+      if (!isNestedForm) {
+        return typedValueSchema;
+      }
+
+      // Extract the plain types from the nested form
+      List<HoodieSchemaField> plainFields = new ArrayList<>();
+      for (HoodieSchemaField field : fields) {
+        HoodieSchema fieldSchema = field.schema();
+        if (fieldSchema.isNullable()) {
+          fieldSchema = fieldSchema.getNonNullType();
+        }
+        HoodieSchema innerTypedValue = fieldSchema.getField(VARIANT_TYPED_VALUE_FIELD).get().schema();
+        plainFields.add(HoodieSchemaField.of(field.name(), innerTypedValue));
+      }
+      return Option.of(HoodieSchema.createRecord(
+          tvSchema.getAvroSchema().getName() + "_plain", null, null, plainFields));
     }
 
     @Override

--- a/hudi-common/src/test/java/org/apache/hudi/common/schema/TestHoodieSchema.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/schema/TestHoodieSchema.java
@@ -39,6 +39,7 @@ import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -2844,5 +2845,205 @@ public class TestHoodieSchema {
     HoodieSchema parsed = HoodieSchema.parseTypeDescriptor(typeString);
     assertEquals(HoodieSchemaType.BLOB, parsed.getType());
     assertInstanceOf(HoodieSchema.Blob.class, parsed);
+  }
+
+  @Test
+  public void testCreateShreddedFieldStruct() {
+    HoodieSchema fieldStruct = HoodieSchema.createShreddedFieldStruct("age", HoodieSchema.create(HoodieSchemaType.INT));
+
+    assertNotNull(fieldStruct);
+    assertEquals(HoodieSchemaType.RECORD, fieldStruct.getType());
+    assertEquals("age", fieldStruct.getAvroSchema().getName());
+
+    List<HoodieSchemaField> fields = fieldStruct.getFields();
+    assertEquals(2, fields.size());
+
+    // value: nullable bytes
+    assertEquals("value", fields.get(0).name());
+    assertTrue(fields.get(0).schema().isNullable());
+    assertEquals(HoodieSchemaType.BYTES, fields.get(0).schema().getNonNullType().getType());
+
+    // typed_value: nullable int
+    assertEquals("typed_value", fields.get(1).name());
+    assertTrue(fields.get(1).schema().isNullable());
+    assertEquals(HoodieSchemaType.INT, fields.get(1).schema().getNonNullType().getType());
+  }
+
+  @Test
+  public void testCreateShreddedFieldStructWithDecimal() {
+    HoodieSchema decimalSchema = HoodieSchema.createDecimal(15, 1);
+    HoodieSchema fieldStruct = HoodieSchema.createShreddedFieldStruct("price", decimalSchema);
+
+    assertNotNull(fieldStruct);
+    List<HoodieSchemaField> fields = fieldStruct.getFields();
+    assertEquals(2, fields.size());
+
+    // typed_value: nullable decimal(15,1)
+    HoodieSchema typedValueSchema = fields.get(1).schema().getNonNullType();
+    assertInstanceOf(HoodieSchema.Decimal.class, typedValueSchema);
+    assertEquals(15, ((HoodieSchema.Decimal) typedValueSchema).getPrecision());
+    assertEquals(1, ((HoodieSchema.Decimal) typedValueSchema).getScale());
+  }
+
+  @Test
+  public void testCreateVariantShreddedObject() {
+    Map<String, HoodieSchema> shreddedFields = new LinkedHashMap<>();
+    shreddedFields.put("a", HoodieSchema.create(HoodieSchemaType.INT));
+    shreddedFields.put("b", HoodieSchema.create(HoodieSchemaType.STRING));
+    shreddedFields.put("c", HoodieSchema.createDecimal(15, 1));
+
+    HoodieSchema.Variant variant = HoodieSchema.createVariantShreddedObject(shreddedFields);
+
+    assertNotNull(variant);
+    assertInstanceOf(HoodieSchema.Variant.class, variant);
+    assertTrue(variant.isShredded());
+    assertTrue(variant.getTypedValueField().isPresent());
+
+    // Top-level fields: value, metadata, typed_value
+    List<HoodieSchemaField> topFields = variant.getFields();
+    assertEquals(3, topFields.size());
+    assertEquals("metadata", topFields.get(0).name());
+    assertEquals("value", topFields.get(1).name());
+    assertEquals("typed_value", topFields.get(2).name());
+
+    // typed_value is a RECORD containing the shredded fields
+    HoodieSchema typedValueSchema = variant.getTypedValueField().get();
+    assertEquals(HoodieSchemaType.RECORD, typedValueSchema.getType());
+    List<HoodieSchemaField> typedValueFields = typedValueSchema.getFields();
+    assertEquals(3, typedValueFields.size());
+
+    // Verify field "a": nullable struct { value: nullable bytes, typed_value: nullable int }
+    HoodieSchemaField aField = typedValueFields.get(0);
+    assertEquals("a", aField.name());
+    assertTrue(aField.schema().isNullable());
+    HoodieSchema aStruct = aField.schema().getNonNullType();
+    assertEquals(HoodieSchemaType.RECORD, aStruct.getType());
+    List<HoodieSchemaField> aSubFields = aStruct.getFields();
+    assertEquals(2, aSubFields.size());
+    assertEquals("value", aSubFields.get(0).name());
+    assertTrue(aSubFields.get(0).schema().isNullable());
+    assertEquals(HoodieSchemaType.BYTES, aSubFields.get(0).schema().getNonNullType().getType());
+    assertEquals("typed_value", aSubFields.get(1).name());
+    assertTrue(aSubFields.get(1).schema().isNullable());
+    assertEquals(HoodieSchemaType.INT, aSubFields.get(1).schema().getNonNullType().getType());
+
+    // Verify field "b": nullable struct { value: nullable bytes, typed_value: nullable string }
+    HoodieSchemaField bField = typedValueFields.get(1);
+    assertEquals("b", bField.name());
+    HoodieSchema bStruct = bField.schema().getNonNullType();
+    List<HoodieSchemaField> bSubFields = bStruct.getFields();
+    assertEquals("typed_value", bSubFields.get(1).name());
+    assertEquals(HoodieSchemaType.STRING, bSubFields.get(1).schema().getNonNullType().getType());
+
+    // Verify field "c": nullable struct { value: nullable bytes, typed_value: nullable decimal(15,1) }
+    HoodieSchemaField cField = typedValueFields.get(2);
+    assertEquals("c", cField.name());
+    HoodieSchema cStruct = cField.schema().getNonNullType();
+    List<HoodieSchemaField> cSubFields = cStruct.getFields();
+    HoodieSchema cTypedValue = cSubFields.get(1).schema().getNonNullType();
+    assertInstanceOf(HoodieSchema.Decimal.class, cTypedValue);
+    assertEquals(15, ((HoodieSchema.Decimal) cTypedValue).getPrecision());
+    assertEquals(1, ((HoodieSchema.Decimal) cTypedValue).getScale());
+  }
+
+  @Test
+  public void testCreateVariantShreddedObjectWithCustomName() {
+    Map<String, HoodieSchema> shreddedFields = new LinkedHashMap<>();
+    shreddedFields.put("age", HoodieSchema.create(HoodieSchemaType.INT));
+
+    HoodieSchema.Variant variant = HoodieSchema.createVariantShreddedObject(
+        "my_variant", "org.apache.hudi", "A shredded variant", shreddedFields);
+
+    assertNotNull(variant);
+    assertEquals("my_variant", variant.getAvroSchema().getName());
+    assertEquals("org.apache.hudi", variant.getAvroSchema().getNamespace());
+    assertTrue(variant.isShredded());
+    assertTrue(TestHoodieSchema.isVariantSchema(variant.getAvroSchema()));
+  }
+
+  @Test
+  public void testCreateVariantShreddedObjectRoundTrip() {
+    Map<String, HoodieSchema> shreddedFields = new LinkedHashMap<>();
+    shreddedFields.put("a", HoodieSchema.create(HoodieSchemaType.INT));
+    shreddedFields.put("b", HoodieSchema.create(HoodieSchemaType.STRING));
+
+    HoodieSchema.Variant original = HoodieSchema.createVariantShreddedObject(shreddedFields);
+    String jsonSchema = original.toString();
+
+    // Parse back from JSON
+    HoodieSchema parsed = HoodieSchema.parse(jsonSchema);
+    assertInstanceOf(HoodieSchema.Variant.class, parsed);
+    HoodieSchema.Variant parsedVariant = (HoodieSchema.Variant) parsed;
+
+    assertTrue(parsedVariant.isShredded());
+    assertTrue(parsedVariant.getTypedValueField().isPresent());
+
+    // Verify typed_value structure is preserved
+    HoodieSchema typedValueSchema = parsedVariant.getTypedValueField().get();
+    assertEquals(HoodieSchemaType.RECORD, typedValueSchema.getType());
+    List<HoodieSchemaField> fields = typedValueSchema.getFields();
+    assertEquals(2, fields.size());
+    assertEquals("a", fields.get(0).name());
+    assertEquals("b", fields.get(1).name());
+
+    // Verify inner struct structure is preserved
+    HoodieSchema aStruct = fields.get(0).schema().getNonNullType();
+    assertEquals(HoodieSchemaType.RECORD, aStruct.getType());
+    assertEquals(2, aStruct.getFields().size());
+    assertEquals("value", aStruct.getFields().get(0).name());
+    assertEquals("typed_value", aStruct.getFields().get(1).name());
+  }
+
+  @Test
+  public void testGetPlainTypedValueSchemaFromNestedForm() {
+    // Create a variant using createVariantShreddedObject (nested form)
+    Map<String, HoodieSchema> shreddedFields = new LinkedHashMap<>();
+    shreddedFields.put("a", HoodieSchema.create(HoodieSchemaType.INT));
+    shreddedFields.put("b", HoodieSchema.create(HoodieSchemaType.STRING));
+    shreddedFields.put("c", HoodieSchema.createDecimal(15, 1));
+
+    HoodieSchema.Variant variant = HoodieSchema.createVariantShreddedObject(shreddedFields);
+
+    // getPlainTypedValueSchema should unwrap the nested {value, typed_value} structs
+    Option<HoodieSchema> plainOpt = variant.getPlainTypedValueSchema();
+    assertTrue(plainOpt.isPresent());
+    HoodieSchema plainSchema = plainOpt.get();
+    assertEquals(HoodieSchemaType.RECORD, plainSchema.getType());
+
+    List<HoodieSchemaField> fields = plainSchema.getFields();
+    assertEquals(3, fields.size());
+    assertEquals("a", fields.get(0).name());
+    assertEquals(HoodieSchemaType.INT, fields.get(0).schema().getNonNullType().getType());
+    assertEquals("b", fields.get(1).name());
+    assertEquals(HoodieSchemaType.STRING, fields.get(1).schema().getNonNullType().getType());
+    assertEquals("c", fields.get(2).name());
+    assertInstanceOf(HoodieSchema.Decimal.class, fields.get(2).schema().getNonNullType());
+  }
+
+  @Test
+  public void testGetPlainTypedValueSchemaFromPlainForm() {
+    // Create a variant using createVariantShredded (plain form)
+    HoodieSchema typedValueSchema = HoodieSchema.createRecord("TypedValue", null, null,
+        Collections.singletonList(HoodieSchemaField.of("data", HoodieSchema.create(HoodieSchemaType.STRING))));
+    HoodieSchema.Variant variant = HoodieSchema.createVariantShredded(typedValueSchema);
+
+    // getPlainTypedValueSchema should return as-is since it's already in plain form
+    Option<HoodieSchema> plainOpt = variant.getPlainTypedValueSchema();
+    assertTrue(plainOpt.isPresent());
+    HoodieSchema plainSchema = plainOpt.get();
+    assertEquals(HoodieSchemaType.RECORD, plainSchema.getType());
+    assertEquals(1, plainSchema.getFields().size());
+    assertEquals("data", plainSchema.getFields().get(0).name());
+  }
+
+  @Test
+  public void testGetPlainTypedValueSchemaEmpty() {
+    // Shredded variant without typed_value
+    HoodieSchema.Variant variant = HoodieSchema.createVariantShredded(null);
+    assertFalse(variant.getPlainTypedValueSchema().isPresent());
+
+    // Unshredded variant
+    HoodieSchema.Variant unshreddedVariant = HoodieSchema.createVariant();
+    assertFalse(unshreddedVariant.getPlainTypedValueSchema().isPresent());
   }
 }

--- a/hudi-spark-datasource/hudi-spark3-common/src/main/scala/org/apache/spark/sql/adapter/BaseSpark3Adapter.scala
+++ b/hudi-spark-datasource/hudi-spark3-common/src/main/scala/org/apache/spark/sql/adapter/BaseSpark3Adapter.scala
@@ -211,4 +211,19 @@ abstract class BaseSpark3Adapter extends SparkAdapter with Logging {
   ): Type = {
     throw new UnsupportedOperationException("Spark 3.x does not support VariantType")
   }
+  override def isVariantShreddingStruct(structType: StructType): Boolean = {
+    // Spark 3.x does not support Variant shredding
+    false
+  }
+
+  override def generateVariantWriteShreddingSchema(dataType: DataType, isTopLevel: Boolean, isObjectField: Boolean): StructType = {
+    throw new UnsupportedOperationException("Spark 3.x does not support Variant shredding")
+  }
+
+  override def createShreddedVariantWriter(
+    shreddedStructType: StructType,
+    writeStruct: Consumer[InternalRow]
+  ): BiConsumer[SpecializedGetters, Integer] = {
+    throw new UnsupportedOperationException("Spark 3.x does not support Variant shredding")
+  }
 }

--- a/hudi-spark-datasource/hudi-spark4-common/src/main/scala/org/apache/spark/sql/adapter/BaseSpark4Adapter.scala
+++ b/hudi-spark-datasource/hudi-spark4-common/src/main/scala/org/apache/spark/sql/adapter/BaseSpark4Adapter.scala
@@ -46,13 +46,14 @@ import org.apache.spark.sql.catalyst.util.DateFormatter
 import org.apache.spark.sql.classic.ColumnConversions
 import org.apache.spark.sql.execution.{PartitionedFileUtil, QueryExecution, SQLExecution}
 import org.apache.spark.sql.execution.datasources._
-import org.apache.spark.sql.execution.datasources.parquet.{HoodieFormatTrait, ParquetFilters}
+import org.apache.spark.sql.execution.datasources.parquet.{HoodieFormatTrait, ParquetFilters, SparkShreddingUtils}
 import org.apache.spark.sql.hudi.SparkAdapter
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.sources.{BaseRelation, Filter}
 import org.apache.spark.sql.types.{BinaryType, DataType, StructType, VariantType}
 import org.apache.spark.sql.vectorized.{ColumnarBatch, ColumnVector}
 import org.apache.spark.storage.StorageLevel
+import org.apache.spark.types.variant.Variant
 import org.apache.spark.unsafe.types.UTF8String
 
 import java.time.ZoneId
@@ -276,5 +277,28 @@ abstract class BaseSpark4Adapter extends SparkAdapter with Logging {
       .addField(Types.primitive(PrimitiveType.PrimitiveTypeName.BINARY, Repetition.REQUIRED).named(HoodieSchema.Variant.VARIANT_METADATA_FIELD))
       .addField(Types.primitive(PrimitiveType.PrimitiveTypeName.BINARY, valueRepetition).named(HoodieSchema.Variant.VARIANT_VALUE_FIELD))
       .named(fieldName)
+  }
+
+  override def isVariantShreddingStruct(structType: StructType): Boolean = {
+    SparkShreddingUtils.isVariantShreddingStruct(structType)
+  }
+
+  override def generateVariantWriteShreddingSchema(dataType: DataType, isTopLevel: Boolean, isObjectField: Boolean): StructType = {
+    SparkShreddingUtils.addWriteShreddingMetadata(
+      SparkShreddingUtils.variantShreddingSchema(dataType, isTopLevel, isObjectField))
+  }
+
+  override def createShreddedVariantWriter(
+    shreddedStructType: StructType,
+    writeStruct: Consumer[InternalRow]
+  ): BiConsumer[SpecializedGetters, Integer] = {
+    val variantShreddingSchema = SparkShreddingUtils.buildVariantSchema(shreddedStructType)
+
+    (row: SpecializedGetters, ordinal: Integer) => {
+      val variantVal = row.getVariant(ordinal)
+      val variant = new Variant(variantVal.getValue, variantVal.getMetadata)
+      val shreddedValues = SparkShreddingUtils.castShredded(variant, variantShreddingSchema)
+      writeStruct.accept(shreddedValues)
+    }
   }
 }

--- a/hudi-spark-datasource/hudi-spark4.0.x/src/main/scala/org/apache/spark/sql/avro/AvroDeserializer.scala
+++ b/hudi-spark-datasource/hudi-spark4.0.x/src/main/scala/org/apache/spark/sql/avro/AvroDeserializer.scala
@@ -253,10 +253,11 @@ private[sql] class AvroDeserializer(rootAvroType: Schema,
         val decimal = createDecimal(bigDecimal, d.getPrecision, d.getScale)
         updater.setDecimal(ordinal, decimal)
 
-      case (RECORD, VariantType) if avroType.getProp("logicalType") == HoodieSchema.VARIANT_TYPE_NAME =>
+      case (RECORD, VariantType) if avroType.getLogicalType != null
+        && avroType.getLogicalType.getName == HoodieSchema.VARIANT_TYPE_NAME =>
         // Validation & Pre-calculation with fail fast logic
-        val valueField = avroType.getField("value")
-        val metadataField = avroType.getField("metadata")
+        val valueField = avroType.getField(HoodieSchema.Variant.VARIANT_VALUE_FIELD)
+        val metadataField = avroType.getField(HoodieSchema.Variant.VARIANT_METADATA_FIELD)
 
         if (valueField == null || metadataField == null) {
           throw new IncompatibleSchemaException(incompatibleMsg +

--- a/hudi-spark-datasource/hudi-spark4.0.x/src/test/java/org/apache/hudi/io/storage/row/TestHoodieRowParquetWriteSupportVariant.java
+++ b/hudi-spark-datasource/hudi-spark4.0.x/src/test/java/org/apache/hudi/io/storage/row/TestHoodieRowParquetWriteSupportVariant.java
@@ -22,36 +22,50 @@ import org.apache.hudi.common.config.HoodieConfig;
 import org.apache.hudi.common.config.TypedProperties;
 import org.apache.hudi.common.schema.HoodieSchema;
 import org.apache.hudi.common.schema.HoodieSchemaField;
+import org.apache.hudi.common.schema.HoodieSchemaType;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.config.HoodieWriteConfig;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
+import org.apache.parquet.format.converter.ParquetMetadataConverter;
 import org.apache.parquet.hadoop.ParquetFileReader;
 import org.apache.parquet.hadoop.ParquetWriter;
 import org.apache.parquet.hadoop.metadata.ParquetMetadata;
 import org.apache.parquet.schema.GroupType;
+import org.apache.parquet.schema.LogicalTypeAnnotation;
 import org.apache.parquet.schema.MessageType;
 import org.apache.parquet.schema.Type;
 import org.apache.spark.sql.catalyst.InternalRow;
 import org.apache.spark.sql.catalyst.expressions.GenericInternalRow;
+import org.apache.spark.sql.catalyst.util.ArrayBasedMapData;
+import org.apache.spark.sql.catalyst.util.ArrayData;
+import org.apache.spark.sql.catalyst.util.GenericArrayData;
 import org.apache.spark.sql.types.DataTypes;
 import org.apache.spark.sql.types.Metadata;
 import org.apache.spark.sql.types.StructField;
 import org.apache.spark.sql.types.StructType;
+import org.apache.spark.unsafe.types.UTF8String;
 import org.apache.spark.unsafe.types.VariantVal;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
 
 import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.BINARY;
+import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.INT32;
+import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.INT64;
 import static org.apache.parquet.schema.Type.Repetition.OPTIONAL;
 import static org.apache.parquet.schema.Type.Repetition.REQUIRED;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Tests for Variant type support in {@link HoodieRowParquetWriteSupport}.
@@ -114,17 +128,38 @@ public class TestHoodieRowParquetWriteSupportVariant {
   /**
    * Tests that a Shredded Variant (defined by HoodieSchema) is written as:
    * <pre>
-   * group {
-   * required binary metadata;
-   * optional binary value;
-   * }
+   *   group {
+   *     required binary metadata;
+   *     optional binary value;
+   *   }
+   * </pre>
+   * <p>
+   * The schema that we are using here is as such:
+   * <pre>
+   *   root
+   *    |-- v: struct (nullable = true)
+   *    |    |-- metadata: binary (nullable = true)
+   *    |    |-- value: binary (nullable = true)
+   *    |    |-- typed_value: struct (nullable = true)
+   *    |    |    |-- a: struct (nullable = true)
+   *    |    |    |    |-- value: binary (nullable = true)
+   *    |    |    |    |-- typed_value: integer (nullable = true)
+   *    |    |    |-- b: struct (nullable = true)
+   *    |    |    |    |-- value: binary (nullable = true)
+   *    |    |    |    |-- typed_value: string (nullable = true)
+   *    |    |    |-- c: struct (nullable = true)
+   *    |    |    |    |-- value: binary (nullable = true)
+   *    |    |    |    |-- typed_value: decimal(15,1) (nullable = true)
    * </pre>
    * Note: Even though typed_value is not populated, the schema must indicate 'value' is OPTIONAL.
    */
   @Test
   public void testWriteShreddedVariant() throws IOException {
-    // Setup Hoodie Schema: Shredded
-    HoodieSchema.Variant variantSchema = HoodieSchema.createVariantShredded("v", null, "Shredded variant", null);
+    HoodieSchema.Variant variantSchema = HoodieSchema.createVariantShreddedObject("v", null, "Shredded variant",
+        // These does not need to be nullable, #createVariantShreddedObject will handle the nullable coercion
+        Map.of("a", HoodieSchema.create(HoodieSchemaType.INT),
+            "b", HoodieSchema.create(HoodieSchemaType.STRING),
+            "c", HoodieSchema.createDecimal(15, 1)));
     HoodieSchema recordSchema = HoodieSchema.createRecord("record", null, null,
         Collections.singletonList(HoodieSchemaField.of("v", variantSchema, null, null)));
 
@@ -155,9 +190,71 @@ public class TestHoodieRowParquetWriteSupportVariant {
     assertEquals(BINARY, valueField.asPrimitiveType().getPrimitiveTypeName());
     assertEquals(OPTIONAL, valueField.getRepetition(), "Shredded variant value must be OPTIONAL");
 
-    // Verify typed_value is omitted (as implementation skips it)
     boolean hasTypedValue = vGroup.getFields().stream().anyMatch(f -> f.getName().equals("typed_value"));
-    assertFalse(hasTypedValue, "typed_value field should be omitted in this writer implementation");
+    assertTrue(hasTypedValue, "typed_value field should be omitted in this writer implementation");
+
+    // Check parquet metadata in the footer that shredded schemas are created
+    ParquetMetadata fileFooter = ParquetFileReader.readFooter(new Configuration(), new Path(outputFile.toURI()), ParquetMetadataConverter.NO_FILTER);
+    MessageType footerSchema = fileFooter.getFileMetaData().getSchema();
+    assertEquals(INT32, footerSchema.getType("v", "typed_value", "a", "typed_value").asPrimitiveType().getPrimitiveTypeName());
+    assertEquals(LogicalTypeAnnotation.stringType(), footerSchema.getType("v", "typed_value", "b", "typed_value").getLogicalTypeAnnotation());
+    assertEquals(LogicalTypeAnnotation.decimalType(1, 15), footerSchema.getType("v", "typed_value", "c", "typed_value").getLogicalTypeAnnotation());
+  }
+
+  /**
+   * Tests that a root-level scalar shredded Variant is written as:
+   * <pre>
+   *   group {
+   *     required binary metadata;
+   *     optional binary value;
+   *     optional int64 typed_value;
+   *   }
+   * </pre>
+   * This verifies that scalar typed_value (e.g. LONG) is correctly shredded at the root level,
+   * as opposed to object shredding where typed_value is a nested struct.
+   */
+  @Test
+  public void testWriteShreddedVariantRootLevelScalar() throws IOException {
+    HoodieSchema.Variant variantSchema = HoodieSchema.createVariantShredded("v", null, "Scalar shredded variant",
+        HoodieSchema.create(HoodieSchemaType.LONG));
+    HoodieSchema recordSchema = HoodieSchema.createRecord("record", null, null,
+        Collections.singletonList(HoodieSchemaField.of("v", variantSchema, null, null)));
+
+    // Spark Schema: Uses actual VariantType
+    StructType sparkSchema = new StructType(new StructField[] {
+        new StructField("v", DataTypes.VariantType, false, Metadata.empty())
+    });
+
+    // Setup Data: integer variant value 100
+    VariantVal variantVal = getSampleVariantValWithRootLevelScalar();
+    InternalRow row = new GenericInternalRow(new Object[] {variantVal});
+
+    // Write to Parquet
+    File outputFile = new File(tempDir, "shredded_scalar.parquet");
+    writeRows(outputFile, sparkSchema, recordSchema, row);
+
+    // Verify Parquet Structure
+    ParquetMetadata fileFooter = ParquetFileReader.readFooter(new Configuration(), new Path(outputFile.toURI()), ParquetMetadataConverter.NO_FILTER);
+    MessageType footerSchema = fileFooter.getFileMetaData().getSchema();
+    GroupType vGroup = footerSchema.getType("v").asGroupType();
+
+    // Should have 3 fields: metadata, value, typed_value
+    assertEquals(3, vGroup.getFieldCount(), "Scalar shredded variant should have 3 fields");
+
+    // Metadata (Required)
+    Type metaField = vGroup.getType("metadata");
+    assertEquals(BINARY, metaField.asPrimitiveType().getPrimitiveTypeName());
+    assertEquals(REQUIRED, metaField.getRepetition());
+
+    // Value (OPTIONAL for Shredded)
+    Type valueField = vGroup.getType("value");
+    assertEquals(BINARY, valueField.asPrimitiveType().getPrimitiveTypeName());
+    assertEquals(OPTIONAL, valueField.getRepetition(), "Shredded variant value must be OPTIONAL");
+
+    // typed_value (OPTIONAL, INT64 for LONG)
+    Type typedValueField = vGroup.getType("typed_value");
+    assertEquals(INT64, typedValueField.asPrimitiveType().getPrimitiveTypeName());
+    assertEquals(OPTIONAL, typedValueField.getRepetition(), "Scalar typed_value must be OPTIONAL");
   }
 
   private void writeRows(File outputFile, StructType sparkSchema, HoodieSchema recordSchema, InternalRow row) throws IOException {
@@ -182,14 +279,467 @@ public class TestHoodieRowParquetWriteSupportVariant {
   }
 
   /**
+   * Tests that a Variant nested inside a struct field is correctly shredded.
+   * <pre>
+   * record {
+   *   id: int,
+   *   nested: struct {
+   *     variant_field: variant (shredded)
+   *   }
+   * }
+   * </pre>
+   */
+  @Test
+  public void testWriteNestedVariantInStruct() throws IOException {
+    // Setup: Create a shredded variant schema
+    LinkedHashMap<String, HoodieSchema> shreddedFields = new LinkedHashMap<>();
+    shreddedFields.put("a", HoodieSchema.create(HoodieSchemaType.INT));
+    shreddedFields.put("b", HoodieSchema.create(HoodieSchemaType.STRING));
+    HoodieSchema.Variant variantSchema = HoodieSchema.createVariantShreddedObject(shreddedFields);
+
+    // Create a nested struct containing the variant
+    HoodieSchema nestedStructSchema = HoodieSchema.createRecord("NestedStruct", null, null,
+        Collections.singletonList(HoodieSchemaField.of("variant_field", variantSchema, null, null)));
+
+    // Create the top-level record schema
+    HoodieSchema recordSchema = HoodieSchema.createRecord("record", null, null, Arrays.asList(
+        HoodieSchemaField.of("id", HoodieSchema.create(HoodieSchemaType.INT), null, null),
+        HoodieSchemaField.of("nested", nestedStructSchema, null, null)
+    ));
+
+    // Create Spark schema
+    StructType nestedSparkStruct = new StructType(new StructField[] {
+        new StructField("variant_field", DataTypes.VariantType, false, Metadata.empty())
+    });
+    StructType sparkSchema = new StructType(new StructField[] {
+        new StructField("id", DataTypes.IntegerType, false, Metadata.empty()),
+        new StructField("nested", nestedSparkStruct, false, Metadata.empty())
+    });
+
+    // Write data
+    File outputFile = new File(tempDir, "nested_variant_struct.parquet");
+
+    // Create nested struct with variant
+    GenericInternalRow nestedRow = new GenericInternalRow(1);
+    nestedRow.update(0, getSampleVariantVal());
+
+    // Create top-level row
+    GenericInternalRow row = new GenericInternalRow(2);
+    row.update(0, 123);
+    row.update(1, nestedRow);
+
+    writeRows(outputFile, sparkSchema, recordSchema, row);
+
+    // Verify the Parquet schema has shredded structure in the nested field
+    MessageType schema = readParquetSchema(outputFile);
+
+    // Verify nested.variant_field has shredded structure
+    GroupType nestedGroup = schema.getType("nested").asGroupType();
+    GroupType variantGroup = nestedGroup.getType("variant_field").asGroupType();
+
+    assertNotNull(variantGroup.getType("typed_value"), "Nested variant should have typed_value field (shredded)");
+    assertEquals(Type.Repetition.OPTIONAL, variantGroup.getType("value").getRepetition(),
+        "Shredded nested variant value should be OPTIONAL");
+  }
+
+  /**
+   * Tests that a Variant nested deeply (struct -> struct -> variant) is correctly shredded.
+   */
+  @Test
+  public void testWriteDeeplyNestedVariant() throws IOException {
+    // Setup: Create shredded variant
+    LinkedHashMap<String, HoodieSchema> shreddedFields = new LinkedHashMap<>();
+    shreddedFields.put("x", HoodieSchema.create(HoodieSchemaType.LONG));
+    HoodieSchema.Variant variantSchema = HoodieSchema.createVariantShreddedObject(shreddedFields);
+
+    // Create deeply nested structure: level2 -> level1 -> variant
+    HoodieSchema level2Schema = HoodieSchema.createRecord("Level2", null, null,
+        Collections.singletonList(HoodieSchemaField.of("variant_field", variantSchema, null, null)));
+
+    HoodieSchema level1Schema = HoodieSchema.createRecord("Level1", null, null,
+        Collections.singletonList(HoodieSchemaField.of("level2", level2Schema, null, null)));
+
+    HoodieSchema recordSchema = HoodieSchema.createRecord("record", null, null,
+        Collections.singletonList(HoodieSchemaField.of("level1", level1Schema, null, null)));
+
+    // Create corresponding Spark schema
+    StructType level2Spark = new StructType(new StructField[] {
+        new StructField("variant_field", DataTypes.VariantType, false, Metadata.empty())
+    });
+    StructType level1Spark = new StructType(new StructField[] {
+        new StructField("level2", level2Spark, false, Metadata.empty())
+    });
+    StructType sparkSchema = new StructType(new StructField[] {
+        new StructField("level1", level1Spark, false, Metadata.empty())
+    });
+
+    // Write data
+    File outputFile = new File(tempDir, "deeply_nested_variant.parquet");
+
+    // Create level2 with variant
+    GenericInternalRow level2Row = new GenericInternalRow(1);
+    level2Row.update(0, getSampleVariantVal());
+
+    // Create level1 with level2
+    GenericInternalRow level1Row = new GenericInternalRow(1);
+    level1Row.update(0, level2Row);
+
+    // Create top-level row
+    GenericInternalRow row = new GenericInternalRow(1);
+    row.update(0, level1Row);
+
+    writeRows(outputFile, sparkSchema, recordSchema, row);
+
+    // Verify shredding at depth
+    MessageType schema = readParquetSchema(outputFile);
+
+    GroupType level1 = schema.getType("level1").asGroupType();
+    GroupType level2 = level1.getType("level2").asGroupType();
+    GroupType variantGroup = level2.getType("variant_field").asGroupType();
+
+    assertNotNull(variantGroup.getType("typed_value"),
+        "Deeply nested variant should have typed_value field (shredded)");
+  }
+
+  /**
+   * Tests that Variants in array elements are correctly handled.
+   * Note: Arrays of Variants themselves can contain shredded or unshredded variants.
+   */
+  @Test
+  public void testWriteVariantInArray() throws IOException {
+    // Setup: Array of shredded variants
+    LinkedHashMap<String, HoodieSchema> shreddedFields = new LinkedHashMap<>();
+    shreddedFields.put("item", HoodieSchema.create(HoodieSchemaType.STRING));
+    HoodieSchema.Variant variantSchema = HoodieSchema.createVariantShreddedObject(shreddedFields);
+
+    HoodieSchema arraySchema = HoodieSchema.createArray(variantSchema);
+    HoodieSchema recordSchema = HoodieSchema.createRecord("record", null, null,
+        Collections.singletonList(HoodieSchemaField.of("items", arraySchema, null, null)));
+
+    // Spark schema
+    StructType sparkSchema = new StructType(new StructField[] {
+        new StructField("items", DataTypes.createArrayType(DataTypes.VariantType, false),
+            false, Metadata.empty())
+    });
+
+    // Write data
+    File outputFile = new File(tempDir, "variant_array.parquet");
+
+    VariantVal[] variants = new VariantVal[] {getSampleVariantVal(), getSampleVariantVal()};
+    GenericInternalRow row = new GenericInternalRow(1);
+    row.update(0, new org.apache.spark.sql.catalyst.util.GenericArrayData(variants));
+
+    writeRows(outputFile, sparkSchema, recordSchema, row);
+
+    // Verify array element has shredded structure
+    MessageType schema = readParquetSchema(outputFile);
+
+    // Navigate Parquet LIST structure: items -> list -> element
+    GroupType itemsGroup = schema.getType("items").asGroupType();
+    GroupType listGroup = itemsGroup.getType("list").asGroupType();
+    GroupType elementGroup = listGroup.getType("element").asGroupType();
+
+    assertNotNull(elementGroup.getType("typed_value"),
+        "Array element variant should have typed_value field (shredded)");
+  }
+
+  /**
+   * Tests mixed scenario: struct containing array of structs, each with a Variant field.
+   */
+  @Test
+  public void testWriteMixedNestedVariant() throws IOException {
+    // Setup: Variant in struct, inside array, inside struct
+    LinkedHashMap<String, HoodieSchema> shreddedFields = new LinkedHashMap<>();
+    shreddedFields.put("data", HoodieSchema.create(HoodieSchemaType.INT));
+    HoodieSchema.Variant variantSchema = HoodieSchema.createVariantShreddedObject(shreddedFields);
+
+    // Inner struct with variant
+    HoodieSchema innerStructSchema = HoodieSchema.createRecord("InnerStruct", null, null,
+        Collections.singletonList(HoodieSchemaField.of("v", variantSchema, null, null)));
+
+    // Array of inner structs
+    HoodieSchema arraySchema = HoodieSchema.createArray(innerStructSchema);
+
+    // Outer struct with array
+    HoodieSchema outerStructSchema = HoodieSchema.createRecord("OuterStruct", null, null,
+        Collections.singletonList(HoodieSchemaField.of("items", arraySchema, null, null)));
+
+    HoodieSchema recordSchema = HoodieSchema.createRecord("record", null, null,
+        Collections.singletonList(HoodieSchemaField.of("outer", outerStructSchema, null, null)));
+
+    // Spark schema
+    StructType innerSparkStruct = new StructType(new StructField[] {
+        new StructField("v", DataTypes.VariantType, false, Metadata.empty())
+    });
+    StructType outerSparkStruct = new StructType(new StructField[] {
+        new StructField("items", DataTypes.createArrayType(innerSparkStruct, false),
+            false, Metadata.empty())
+    });
+    StructType sparkSchema = new StructType(new StructField[] {
+        new StructField("outer", outerSparkStruct, false, Metadata.empty())
+    });
+
+    // Write data
+    File outputFile = new File(tempDir, "mixed_nested_variant.parquet");
+
+    // Create inner struct with variant
+    GenericInternalRow innerRow = new GenericInternalRow(1);
+    innerRow.update(0, getSampleVariantVal());
+
+    // Create array of inner structs
+    GenericInternalRow[] array = new GenericInternalRow[] {innerRow};
+
+    // Create outer struct with array
+    GenericInternalRow outerRow = new GenericInternalRow(1);
+    outerRow.update(0, new org.apache.spark.sql.catalyst.util.GenericArrayData(array));
+
+    // Create top-level row
+    GenericInternalRow row = new GenericInternalRow(1);
+    row.update(0, outerRow);
+
+    writeRows(outputFile, sparkSchema, recordSchema, row);
+
+    // Verify complex nested shredding
+    MessageType schema = readParquetSchema(outputFile);
+
+    // Navigate: outer -> items (LIST) -> list -> element (struct) -> v (variant)
+    GroupType outer = schema.getType("outer").asGroupType();
+    GroupType items = outer.getType("items").asGroupType();
+    GroupType list = items.getType("list").asGroupType();
+    GroupType element = list.getType("element").asGroupType();
+    GroupType variantGroup = element.getType("v").asGroupType();
+
+    assertNotNull(variantGroup.getType("typed_value"),
+        "Variant in complex nested structure should have typed_value field (shredded)");
+  }
+
+  /**
+   * Tests that a shredded Variant inside a nullable map value is correctly handled.
+   * This verifies that nullable unions in HoodieSchema are properly unwrapped via getNonNullType()
+   * when processing map value schemas.
+   */
+  @Test
+  public void testWriteVariantInNullableMapValue() throws IOException {
+    // Setup: Map with nullable shredded variant values
+    LinkedHashMap<String, HoodieSchema> shreddedFields = new LinkedHashMap<>();
+    shreddedFields.put("score", HoodieSchema.create(HoodieSchemaType.INT));
+    HoodieSchema.Variant variantSchema = HoodieSchema.createVariantShreddedObject(shreddedFields);
+
+    // Wrap the variant in a nullable union, as would occur in real schemas
+    HoodieSchema nullableVariantSchema = HoodieSchema.createNullable(variantSchema);
+    HoodieSchema mapSchema = HoodieSchema.createMap(nullableVariantSchema);
+    HoodieSchema recordSchema = HoodieSchema.createRecord("record", null, null,
+        Collections.singletonList(HoodieSchemaField.of("data", mapSchema, null, null)));
+
+    // Spark schema: Map<String, Variant>
+    StructType sparkSchema = new StructType(new StructField[] {
+        new StructField("data", DataTypes.createMapType(DataTypes.StringType, DataTypes.VariantType, true),
+            false, Metadata.empty())
+    });
+
+    // Write data
+    File outputFile = new File(tempDir, "variant_nullable_map.parquet");
+
+    ArrayData keyArray = new GenericArrayData(new Object[] {UTF8String.fromString("key1")});
+    ArrayData valueArray = new GenericArrayData(new Object[] {getSampleVariantVal()});
+    ArrayBasedMapData sparkMap = new ArrayBasedMapData(keyArray, valueArray);
+
+    GenericInternalRow row = new GenericInternalRow(new Object[] {sparkMap});
+    writeRows(outputFile, sparkSchema, recordSchema, row);
+
+    // Verify map value has shredded structure
+    MessageType schema = readParquetSchema(outputFile);
+
+    // Navigate Parquet MAP structure: data -> key_value -> value (variant group)
+    GroupType dataGroup = schema.getType("data").asGroupType();
+    GroupType keyValueGroup = dataGroup.getType("key_value").asGroupType();
+    GroupType valueGroup = keyValueGroup.getType("value").asGroupType();
+
+    assertNotNull(valueGroup.getType("typed_value"),
+        "Map value variant with nullable schema should have typed_value field (shredded)");
+  }
+
+  /**
+   * Tests that a shredded Variant inside a nullable array element is correctly handled.
+   * This verifies that nullable unions in HoodieSchema are properly unwrapped via getNonNullType()
+   * when processing array element schemas.
+   */
+  @Test
+  public void testWriteVariantInNullableArrayElement() throws IOException {
+    // Setup: Array with nullable shredded variant elements
+    LinkedHashMap<String, HoodieSchema> shreddedFields = new LinkedHashMap<>();
+    shreddedFields.put("tag", HoodieSchema.create(HoodieSchemaType.STRING));
+    HoodieSchema.Variant variantSchema = HoodieSchema.createVariantShreddedObject(shreddedFields);
+
+    // Wrap the variant in a nullable union
+    HoodieSchema nullableVariantSchema = HoodieSchema.createNullable(variantSchema);
+    HoodieSchema arraySchema = HoodieSchema.createArray(nullableVariantSchema);
+    HoodieSchema recordSchema = HoodieSchema.createRecord("record", null, null,
+        Collections.singletonList(HoodieSchemaField.of("items", arraySchema, null, null)));
+
+    // Spark schema: Array<Variant> (nullable elements)
+    StructType sparkSchema = new StructType(new StructField[] {
+        new StructField("items", DataTypes.createArrayType(DataTypes.VariantType, true),
+            false, Metadata.empty())
+    });
+
+    // Write data
+    File outputFile = new File(tempDir, "variant_nullable_array.parquet");
+
+    VariantVal[] variants = new VariantVal[] {getSampleVariantVal(), getSampleVariantVal()};
+    GenericInternalRow row = new GenericInternalRow(1);
+    row.update(0, new org.apache.spark.sql.catalyst.util.GenericArrayData(variants));
+
+    writeRows(outputFile, sparkSchema, recordSchema, row);
+
+    // Verify array element has shredded structure
+    MessageType schema = readParquetSchema(outputFile);
+
+    // Navigate Parquet LIST structure: items -> list -> element
+    GroupType itemsGroup = schema.getType("items").asGroupType();
+    GroupType listGroup = itemsGroup.getType("list").asGroupType();
+    GroupType elementGroup = listGroup.getType("element").asGroupType();
+
+    assertNotNull(elementGroup.getType("typed_value"),
+        "Array element variant with nullable schema should have typed_value field (shredded)");
+  }
+
+  // ==================== Negative / Failure Mode Tests ====================
+
+  /**
+   * Tests that a null Variant value is correctly handled (skipped during write).
+   * The Parquet file should be written successfully with the null field omitted.
+   */
+  @Test
+  public void testWriteNullVariantValue() throws IOException {
+    // Setup: Unshredded variant
+    HoodieSchema.Variant variantSchema = HoodieSchema.createVariant("v", null, "Nullable variant");
+    HoodieSchema recordSchema = HoodieSchema.createRecord("record", null, null, Arrays.asList(
+        HoodieSchemaField.of("id", HoodieSchema.create(HoodieSchemaType.INT), null, null),
+        HoodieSchemaField.of("v", variantSchema, null, null)
+    ));
+
+    // Spark schema: nullable variant
+    StructType sparkSchema = new StructType(new StructField[] {
+        new StructField("id", DataTypes.IntegerType, false, Metadata.empty()),
+        new StructField("v", DataTypes.VariantType, true, Metadata.empty())
+    });
+
+    // Row with null variant
+    GenericInternalRow row = new GenericInternalRow(new Object[] {1, null});
+
+    File outputFile = new File(tempDir, "null_variant.parquet");
+    writeRows(outputFile, sparkSchema, recordSchema, row);
+
+    // Verify file was written and schema is correct
+    MessageType parquetSchema = readParquetSchema(outputFile);
+    GroupType vGroup = parquetSchema.getType("v").asGroupType();
+    assertEquals(OPTIONAL, vGroup.getRepetition(), "Nullable variant should be OPTIONAL");
+    assertEquals(2, vGroup.getFieldCount(), "Unshredded variant should have 2 fields");
+  }
+
+  /**
+   * Tests that a null shredded Variant value is correctly handled.
+   */
+  @Test
+  public void testWriteNullShreddedVariantValue() throws IOException {
+    // Setup: Shredded variant
+    HoodieSchema.Variant variantSchema = HoodieSchema.createVariantShredded("v", null, "Nullable shredded variant",
+        HoodieSchema.create(HoodieSchemaType.LONG));
+    HoodieSchema recordSchema = HoodieSchema.createRecord("record", null, null, Arrays.asList(
+        HoodieSchemaField.of("id", HoodieSchema.create(HoodieSchemaType.INT), null, null),
+        HoodieSchemaField.of("v", variantSchema, null, null)
+    ));
+
+    // Spark schema: nullable variant
+    StructType sparkSchema = new StructType(new StructField[] {
+        new StructField("id", DataTypes.IntegerType, false, Metadata.empty()),
+        new StructField("v", DataTypes.VariantType, true, Metadata.empty())
+    });
+
+    // Row with null variant
+    GenericInternalRow row = new GenericInternalRow(new Object[] {1, null});
+
+    File outputFile = new File(tempDir, "null_shredded_variant.parquet");
+    writeRows(outputFile, sparkSchema, recordSchema, row);
+
+    // Verify file was written and schema has shredded structure
+    MessageType parquetSchema = readParquetSchema(outputFile);
+    GroupType vGroup = parquetSchema.getType("v").asGroupType();
+    assertEquals(OPTIONAL, vGroup.getRepetition(), "Nullable variant should be OPTIONAL");
+    assertTrue(vGroup.getFields().stream().anyMatch(f -> f.getName().equals("typed_value")),
+        "Shredded variant schema should still contain typed_value even when value is null");
+  }
+
+  /**
+   * Tests that when HoodieSchema says shredded but Spark schema doesn't have VariantType,
+   * the shredding is not applied (graceful fallback).
+   */
+  @Test
+  public void testSchemaMismatchNonVariantSparkType() throws IOException {
+    // Setup: HoodieSchema says shredded variant, but Spark schema uses StringType instead
+    HoodieSchema.Variant variantSchema = HoodieSchema.createVariantShredded("v", null, "Shredded variant",
+        HoodieSchema.create(HoodieSchemaType.LONG));
+    HoodieSchema recordSchema = HoodieSchema.createRecord("record", null, null, Arrays.asList(
+        HoodieSchemaField.of("id", HoodieSchema.create(HoodieSchemaType.INT), null, null),
+        HoodieSchemaField.of("v", variantSchema, null, null)
+    ));
+
+    // Spark schema uses StringType instead of VariantType — mismatch
+    StructType sparkSchema = new StructType(new StructField[] {
+        new StructField("id", DataTypes.IntegerType, false, Metadata.empty()),
+        new StructField("v", DataTypes.StringType, false, Metadata.empty())
+    });
+
+    // Row with string value
+    GenericInternalRow row = new GenericInternalRow(new Object[] {1, UTF8String.fromString("hello")});
+
+    File outputFile = new File(tempDir, "mismatch_variant.parquet");
+    writeRows(outputFile, sparkSchema, recordSchema, row);
+
+    // Verify: shredding was NOT applied since Spark type is not VariantType
+    MessageType parquetSchema = readParquetSchema(outputFile);
+    Type vField = parquetSchema.getType("v");
+    // Should be a primitive string, not a group with typed_value
+    assertTrue(vField.isPrimitive(), "Non-variant Spark type should remain primitive even if HoodieSchema says VARIANT");
+  }
+
+  /**
+   * Tests that createVariantShreddedObject rejects an empty shredded fields map.
+   */
+  @Test
+  public void testEmptyShreddedFieldsMapThrows() {
+    assertThrows(IllegalArgumentException.class,
+        () -> HoodieSchema.createVariantShreddedObject(Collections.emptyMap()),
+        "Empty shredded fields map should throw IllegalArgumentException");
+  }
+
+  /**
    * Helper method to create a VariantVal with sample data derived from Spark 4.0 investigation.
-   * Represents JSON: {"a":1,"b":"2","c":3.3,"d":4.4}
+   * Represents JSON:
+   * <pre>{"a":1,"b":"2","c":3.3,"d":4.4}</pre>
+   * <p>
+   * The values are obtained by following these steps:
+   * <a href="https://github.com/apache/hudi/issues/17744#issuecomment-3822180385">how to obtain raw bytes</a>
    */
   private static VariantVal getSampleVariantVal() {
-    // Metadata: [01 04 00 01 02 03 04 61 62 63 64]
     byte[] metadata = new byte[] {0x01, 0x04, 0x00, 0x01, 0x02, 0x03, 0x04, 0x61, 0x62, 0x63, 0x64};
-    // Value: [02 01 03 00 06 20 01 2C 00 00 00]
-    byte[] value = new byte[] {0x02, 0x01, 0x03, 0x00, 0x06, 0x20, 0x01, 0x2C, 0x00, 0x00, 0x00};
+    byte[] value = new byte[] {0x02, 0x04, 0x00, 0x01, 0x02, 0x03, 0x00, 0x02, 0x04, 0x0a, 0x10, 0x0c,
+        0x01, 0x05, 0x32, 0x20, 0x01, 0x21, 0x00, 0x00, 0x00, 0x20, 0x01, 0x2c, 0x00, 0x00, 0x00};
+    return new VariantVal(value, metadata);
+  }
+
+  /**
+   * Helper method to create a VariantVal with sample data derived from Spark 4.0 investigation.
+   * Represents JSON:
+   * <pre>100</pre>
+   * <p>
+   * The values are obtained by following these steps:
+   * <a href="https://github.com/apache/hudi/issues/17744#issuecomment-3822180385">how to obtain raw bytes</a>
+   */
+  private static VariantVal getSampleVariantValWithRootLevelScalar() {
+    byte[] metadata = new byte[] {0x01, 0x00, 0x00};
+    byte[] value = new byte[] {0x0c, 0x64};
     return new VariantVal(value, metadata);
   }
 }


### PR DESCRIPTION
Mirror of https://github.com/apache/hudi/pull/18036 for automated bot review.

**Original author:** @voonhous
**Base branch:** master


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced support for variant data type handling with new schema construction and shredding operations.
  * Improved Parquet write support for variant fields with structured shredding capabilities.
  * Extended Spark compatibility with version-specific variant processing.

* **Tests**
  * Expanded test coverage for variant shredding across multiple nesting scenarios and edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->