### PR TITLE
[OSS PR #18372] feat(index): Refactor metadata table update logic based on index abstraction

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/HoodieBackedTableMetadataWriter.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/HoodieBackedTableMetadataWriter.java
@@ -26,7 +26,6 @@ import org.apache.hudi.avro.model.HoodieRestorePlan;
 import org.apache.hudi.avro.model.HoodieRollbackMetadata;
 import org.apache.hudi.client.BaseHoodieWriteClient;
 import org.apache.hudi.client.WriteStatus;
-import org.apache.hudi.common.config.HoodieMetadataConfig;
 import org.apache.hudi.common.data.HoodieData;
 import org.apache.hudi.common.engine.EngineType;
 import org.apache.hudi.common.engine.HoodieEngineContext;
@@ -34,21 +33,16 @@ import org.apache.hudi.common.fs.FSUtils;
 import org.apache.hudi.common.function.SerializableBiFunction;
 import org.apache.hudi.common.function.SerializableFunction;
 import org.apache.hudi.common.model.FileSlice;
-import org.apache.hudi.common.model.HoodieBaseFile;
 import org.apache.hudi.common.model.HoodieCommitMetadata;
 import org.apache.hudi.common.model.HoodieFailedWritesCleaningPolicy;
 import org.apache.hudi.common.model.HoodieFileFormat;
 import org.apache.hudi.common.model.HoodieFileGroup;
 import org.apache.hudi.common.model.HoodieFileGroupId;
-import org.apache.hudi.common.model.HoodieIndexDefinition;
 import org.apache.hudi.common.model.HoodieLogFile;
 import org.apache.hudi.common.model.HoodieRecord;
 import org.apache.hudi.common.model.HoodieRecordLocation;
-import org.apache.hudi.common.model.HoodieReplaceCommitMetadata;
 import org.apache.hudi.common.model.HoodieTableType;
 import org.apache.hudi.common.model.HoodieWriteStat;
-import org.apache.hudi.common.model.WriteOperationType;
-import org.apache.hudi.common.schema.HoodieSchema;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.common.table.log.HoodieLogFormat;
 import org.apache.hudi.common.table.log.block.HoodieDeleteBlock;
@@ -73,6 +67,7 @@ import org.apache.hudi.exception.HoodieMetadataException;
 import org.apache.hudi.exception.TableNotFoundException;
 import org.apache.hudi.metadata.index.ExpressionIndexRecordGenerator;
 import org.apache.hudi.metadata.index.model.DataPartitionAndRecords;
+import org.apache.hudi.metadata.index.model.IndexPartitionAndRecords;
 import org.apache.hudi.metadata.index.model.IndexPartitionInitialization;
 import org.apache.hudi.metadata.index.Indexer;
 import org.apache.hudi.metadata.index.IndexerFactory;
@@ -96,7 +91,6 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -119,19 +113,15 @@ import static org.apache.hudi.common.table.timeline.InstantComparison.compareTim
 import static org.apache.hudi.metadata.HoodieMetadataWriteUtils.createMetadataWriteConfig;
 import static org.apache.hudi.metadata.HoodieTableMetadata.METADATA_TABLE_NAME_SUFFIX;
 import static org.apache.hudi.metadata.HoodieTableMetadata.SOLO_COMMIT_TIMESTAMP;
-import static org.apache.hudi.metadata.HoodieTableMetadataUtil.PARTITION_NAME_COLUMN_STATS;
 import static org.apache.hudi.metadata.HoodieTableMetadataUtil.PARTITION_NAME_SECONDARY_INDEX_PREFIX;
 import static org.apache.hudi.metadata.HoodieTableMetadataUtil.existingIndexVersionOrDefault;
 import static org.apache.hudi.metadata.HoodieTableMetadataUtil.getInflightMetadataPartitions;
 import static org.apache.hudi.metadata.HoodieTableMetadataUtil.getPartitionLatestFileSlicesIncludingInflight;
-import static org.apache.hudi.metadata.HoodieTableMetadataUtil.readRecordKeysFromBaseFiles;
 import static org.apache.hudi.metadata.MetadataPartitionType.COLUMN_STATS;
-import static org.apache.hudi.metadata.MetadataPartitionType.EXPRESSION_INDEX;
 import static org.apache.hudi.metadata.MetadataPartitionType.FILES;
 import static org.apache.hudi.metadata.MetadataPartitionType.RECORD_INDEX;
 import static org.apache.hudi.metadata.MetadataPartitionType.SECONDARY_INDEX;
 import static org.apache.hudi.metadata.MetadataPartitionType.fromPartitionPath;
-import static org.apache.hudi.metadata.SecondaryIndexRecordGenerationUtils.convertWriteStatsToSecondaryIndexRecords;
 
 /**
  * Writer implementation backed by an internal hudi table. Partition and file listing are saved within an internal MOR table
@@ -775,7 +765,7 @@ public abstract class HoodieBackedTableMetadataWriter<I, O> implements HoodieTab
    * Updates of different commit metadata uses the same method to convert to HoodieRecords and hence.
    */
   interface ConvertMetadataFunction {
-    Map<String, HoodieData<HoodieRecord>> convertMetadata();
+    List<IndexPartitionAndRecords> convertMetadata();
   }
 
   /**
@@ -788,9 +778,10 @@ public abstract class HoodieBackedTableMetadataWriter<I, O> implements HoodieTab
     Set<String> partitionsToUpdate = getMetadataPartitionsToUpdate();
     if (initialized && metadata != null) {
       // convert metadata and filter only the entries whose partition path are in partitionsToUpdate
-      Map<String, HoodieData<HoodieRecord>> partitionRecordsMap = convertMetadataFunction.convertMetadata().entrySet().stream()
-          .filter(entry -> partitionsToUpdate.contains(entry.getKey())).collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
-      commit(instantTime, partitionRecordsMap);
+      List<IndexPartitionAndRecords> partitionRecords = convertMetadataFunction.convertMetadata().stream()
+          .filter(entry -> partitionsToUpdate.contains(entry.indexPartitionName()))
+          .collect(Collectors.toList());
+      commit(instantTime, partitionRecords);
     }
   }
 
@@ -980,7 +971,7 @@ public abstract class HoodieBackedTableMetadataWriter<I, O> implements HoodieTab
 
   private HoodieData<WriteStatus> prepareAndWriteToNonStreamingPartitions(HoodieCommitMetadata commitMetadata, String instantTime) {
     Set<String> partitionsToUpdate = getNonStreamingMetadataPartitionsToUpdate();
-    Map<String, HoodieData<HoodieRecord>> mdtPartitionsAndUnTaggedRecords = new BatchMetadataConversionFunction(instantTime, commitMetadata, partitionsToUpdate)
+    List<IndexPartitionAndRecords> mdtPartitionsAndUnTaggedRecords = new BatchMetadataConversionFunction(instantTime, commitMetadata, partitionsToUpdate)
         .convertMetadata();
 
     // write to mdt table for non-streaming mdt partitions
@@ -1115,102 +1106,15 @@ public abstract class HoodieBackedTableMetadataWriter<I, O> implements HoodieTab
     }
 
     @Override
-    public Map<String, HoodieData<HoodieRecord>> convertMetadata() {
-      Map<String, HoodieData<HoodieRecord>> partitionToRecordMap =
-          HoodieMetadataWriteUtils.convertMetadataToRecords(
-              engineContext, dataWriteConfig, commitMetadata, instantTime, dataMetaClient, getTableMetadata(),
-              dataWriteConfig.getMetadataConfig(),
-              partitionsToUpdate, dataWriteConfig.getBloomFilterType(),
-              dataWriteConfig.getBloomIndexParallelism(), dataWriteConfig.getWritesFileIdEncoding(), getEngineType(),
-              Option.of(dataWriteConfig.getRecordMerger().getRecordType()));
-
-      // Updates for record index are created by parsing the WriteStatus which is a hudi-client object. Hence, we cannot yet move this code
-      // to the HoodieTableMetadataUtil class in hudi-common.
-      if (partitionsToUpdate.contains(RECORD_INDEX.getPartitionPath())) {
-        HoodieData<HoodieRecord> additionalUpdates = getRecordIndexAdditionalUpserts(partitionToRecordMap.get(RECORD_INDEX.getPartitionPath()), commitMetadata);
-        partitionToRecordMap.put(RECORD_INDEX.getPartitionPath(), partitionToRecordMap.get(RECORD_INDEX.getPartitionPath()).union(additionalUpdates));
-      }
-      if (partitionsToUpdate.stream().anyMatch(partition -> partition.startsWith(EXPRESSION_INDEX.getPartitionPath()))) {
-        updateExpressionIndexIfPresent(commitMetadata, instantTime, partitionToRecordMap);
-      }
-      if (partitionsToUpdate.stream().anyMatch(partition -> partition.startsWith(SECONDARY_INDEX.getPartitionPath()))) {
-        updateSecondaryIndexIfPresent(commitMetadata, partitionToRecordMap, instantTime);
-      }
-      return partitionToRecordMap;
+    public List<IndexPartitionAndRecords> convertMetadata() {
+      return partitionsToUpdate.stream().flatMap(indexPartition -> {
+        MetadataPartitionType partitionType = MetadataPartitionType.fromPartitionPath(indexPartition);
+        Indexer indexer = enabledIndexerMap.get(partitionType);
+        ValidationUtils.checkArgument(indexer != null,
+            String.format("Index partition %s should be included in the enabled index partitions: %s", indexPartition, enabledIndexerMap.keySet()));
+        return indexer.buildUpdate(instantTime, getTableMetadata(), Lazy.lazily(() -> getMetadataView()), commitMetadata).stream();
+      }).collect(Collectors.toList());
     }
-  }
-
-  /**
-   * Update expression index from {@link HoodieCommitMetadata}.
-   */
-  private void updateExpressionIndexIfPresent(HoodieCommitMetadata commitMetadata, String instantTime,
-                                              Map<String, HoodieData<HoodieRecord>> partitionToRecordMap) {
-    if (!MetadataPartitionType.EXPRESSION_INDEX.isMetadataPartitionAvailable(dataMetaClient)) {
-      return;
-    }
-    dataMetaClient.getTableConfig().getMetadataPartitions()
-        .stream()
-        .filter(partition -> partition.startsWith(HoodieTableMetadataUtil.PARTITION_NAME_EXPRESSION_INDEX_PREFIX))
-        .forEach(partition -> {
-          HoodieData<HoodieRecord> expressionIndexRecords;
-          try {
-            expressionIndexRecords = getExpressionIndexUpdates(commitMetadata, partition, instantTime);
-          } catch (Exception e) {
-            throw new HoodieMetadataException(String.format("Failed to get expression index updates for partition %s", partition), e);
-          }
-          partitionToRecordMap.put(partition, expressionIndexRecords);
-        });
-  }
-
-  /**
-   * Loads the file slices touched by the commit due to given instant time and returns the records for the expression index.
-   *
-   * @param commitMetadata {@code HoodieCommitMetadata}
-   * @param indexPartition partition name of the expression index
-   * @param instantTime    timestamp at of the current update commit
-   */
-  protected HoodieData<HoodieRecord> getExpressionIndexUpdates(HoodieCommitMetadata commitMetadata, String indexPartition, String instantTime) throws Exception {
-    throw new UnsupportedOperationException("Expression Index only supported with SPARK engine.");
-  }
-
-  private void updateSecondaryIndexIfPresent(HoodieCommitMetadata commitMetadata, Map<String, HoodieData<HoodieRecord>> partitionToRecordMap,
-                                             String instantTime) {
-    boolean secondaryIndexMetadataPartitionAvailable = SECONDARY_INDEX.isMetadataPartitionAvailable(dataMetaClient);
-    if (!secondaryIndexMetadataPartitionAvailable) {
-      return;
-    }
-    // If write operation type based on commit metadata is COMPACT or CLUSTER then no need to update,
-    // because these operations do not change the secondary key - record key mapping.
-    WriteOperationType operationType = commitMetadata.getOperationType();
-    if (operationType.isInsertOverwriteOrDeletePartition()) {
-      throw new HoodieIndexException(String.format("Can not perform operation %s on secondary index", operationType));
-    } else if (operationType == WriteOperationType.COMPACT || operationType == WriteOperationType.CLUSTER) {
-      return;
-    }
-
-    dataMetaClient.getTableConfig().getMetadataPartitions()
-        .stream()
-        .filter(partition -> partition.startsWith(PARTITION_NAME_SECONDARY_INDEX_PREFIX))
-        .forEach(partition -> {
-          HoodieData<HoodieRecord> secondaryIndexRecords;
-          try {
-            secondaryIndexRecords = getSecondaryIndexUpdates(commitMetadata, partition, instantTime);
-          } catch (Exception e) {
-            throw new HoodieMetadataException("Failed to get secondary index updates for partition " + partition, e);
-          }
-          partitionToRecordMap.put(partition, secondaryIndexRecords);
-        });
-  }
-
-  private HoodieData<HoodieRecord> getSecondaryIndexUpdates(HoodieCommitMetadata commitMetadata, String indexPartition, String instantTime) {
-    List<HoodieWriteStat> allWriteStats = commitMetadata.getPartitionToWriteStats().values().stream()
-        .flatMap(Collection::stream).collect(Collectors.toList());
-    // Return early if there are no write stats.
-    if (allWriteStats.isEmpty() || WriteOperationType.isCompactionOrClustering(commitMetadata.getOperationType())) {
-      return engineContext.emptyHoodieData();
-    }
-    HoodieIndexDefinition indexDefinition = HoodieTableMetadataUtil.getHoodieIndexDefinition(indexPartition, dataMetaClient);
-    return convertWriteStatsToSecondaryIndexRecords(allWriteStats, instantTime, indexDefinition, dataWriteConfig.getMetadataConfig(), dataMetaClient, engineContext, dataWriteConfig);
   }
 
   /**
@@ -1222,9 +1126,15 @@ public abstract class HoodieBackedTableMetadataWriter<I, O> implements HoodieTab
   @Override
   public void update(HoodieCleanMetadata cleanMetadata, String instantTime) {
     mayBeReinitMetadataReader();
-    processAndCommit(instantTime, () -> HoodieMetadataWriteUtils.convertMetadataToRecords(engineContext,
-        cleanMetadata, instantTime, dataMetaClient, dataWriteConfig.getMetadataConfig(), enabledIndexerMap,
-        dataWriteConfig.getBloomIndexParallelism(), Option.of(dataWriteConfig.getRecordMerger().getRecordType())));
+    processAndCommit(instantTime, new ConvertMetadataFunction() {
+      @Override
+      public List<IndexPartitionAndRecords> convertMetadata() {
+        // for index partitions not needed to handle, `buildClean` will return an empty list.
+        return enabledIndexerMap.entrySet().stream()
+            .flatMap(entry -> entry.getValue().buildClean(instantTime, cleanMetadata).stream())
+            .collect(Collectors.toList());
+      }
+    });
     closeInternal();
   }
 
@@ -1286,55 +1196,22 @@ public abstract class HoodieBackedTableMetadataWriter<I, O> implements HoodieTab
       // or a new timestamp which we use for MDT clean, compaction etc.
       String syncCommitTime = createRestoreInstantTime();
       processAndCommit(syncCommitTime, () -> {
-        // For Files partition.
-        Map<String, HoodieData<HoodieRecord>> partitionRecords = new HashMap<>();
-        partitionRecords.putAll(HoodieTableMetadataUtil.convertMissingPartitionRecords(engineContext,
-            partitionsToDelete, partitionFilesToAdd, partitionFilesToDelete, syncCommitTime));
-        // For ColumnStats partition if enabled.
+        // build update records for Files And COLUMN_STATS partition.
+        List<MetadataPartitionType> indexPartitions = new ArrayList<>();
+        indexPartitions.add(FILES);
         if (dataMetaClient.getTableConfig().getMetadataPartitions().contains(COLUMN_STATS.getPartitionPath())) {
-          partitionRecords.putAll(convertToColumnStatsRecord(
-              partitionFilesToAdd, partitionFilesToDelete, engineContext, dataMetaClient,
-              dataWriteConfig.getMetadataConfig(), Option.of(dataWriteConfig.getRecordMerger().getRecordType()),
-              dataWriteConfig.getMetadataConfig().getColumnStatsIndexParallelism()));
+          indexPartitions.add(COLUMN_STATS);
         }
-        return partitionRecords;
+        return indexPartitions.stream().flatMap(indexPartition -> {
+          Indexer filesIndexer = this.enabledIndexerMap.get(indexPartition);
+          ValidationUtils.checkArgument(filesIndexer != null, indexPartition + " index should be enabled.");
+          return filesIndexer.buildRestore(syncCommitTime, partitionsToDelete, partitionFilesToAdd, partitionFilesToDelete).stream();
+        }).collect(Collectors.toList());
       });
       closeInternal();
     } catch (IOException e) {
       throw new HoodieMetadataException("IOException during MDT restore sync", e);
     }
-  }
-
-  static Map<String, HoodieData<HoodieRecord>> convertToColumnStatsRecord(Map<String, List<FileInfo>> partitionFilesToAdd,
-                                                                          Map<String, List<String>> partitionFilesToDelete,
-                                                                          HoodieEngineContext engineContext,
-                                                                          HoodieTableMetaClient dataMetaClient,
-                                                                          HoodieMetadataConfig metadataConfig,
-                                                                          Option<HoodieRecord.HoodieRecordType> recordTypeOpt,
-                                                                          int columnStatsIndexParallelism) {
-    if (partitionFilesToDelete.isEmpty() && partitionFilesToAdd.isEmpty()) {
-      return Collections.emptyMap();
-    }
-    Lazy<Option<HoodieSchema>> tableSchema =
-        Lazy.lazily(() -> HoodieTableMetadataUtil.tryResolveSchemaForTable(dataMetaClient));
-    final List<String> columnsToIndex = new ArrayList<>(HoodieTableMetadataUtil.getColumnsToIndex(
-        dataMetaClient.getTableConfig(),
-        metadataConfig,
-        tableSchema,
-        false,
-        recordTypeOpt,
-        HoodieTableMetadataUtil.existingIndexVersionOrDefault(PARTITION_NAME_COLUMN_STATS, dataMetaClient)).keySet());
-    if (columnsToIndex.isEmpty()) {
-      LOG.info("Since there are no columns to index, stop to generate ColumnStats records.");
-      return Collections.emptyMap();
-    }
-    HoodieData<HoodieRecord> records = HoodieTableMetadataUtil.convertFilesToColumnStatsRecords(
-        engineContext, partitionFilesToDelete,
-        partitionFilesToAdd, dataMetaClient,
-        columnStatsIndexParallelism,
-        metadataConfig.getMaxReaderBufferSize(),
-        columnsToIndex);
-    return Collections.singletonMap(COLUMN_STATS.getPartitionPath(), records);
   }
 
   String createRestoreInstantTime() {
@@ -1418,10 +1295,10 @@ public abstract class HoodieBackedTableMetadataWriter<I, O> implements HoodieTab
   /**
    * Commit the {@code HoodieRecord}s to Metadata Table as a new delta-commit.
    *
-   * @param instantTime         - Action instant time for this commit
-   * @param partitionRecordsMap - Map of partition type to its records to commit
+   * @param instantTime      - Action instant time for this commit
+   * @param partitionRecords - List of the partition type and its records to commit
    */
-  protected abstract void commit(String instantTime, Map<String, HoodieData<HoodieRecord>> partitionRecordsMap);
+  protected abstract void commit(String instantTime, List<IndexPartitionAndRecords> partitionRecords);
 
   /**
    * Converts the input records to the input format expected by the write client.
@@ -1433,10 +1310,10 @@ public abstract class HoodieBackedTableMetadataWriter<I, O> implements HoodieTab
 
   protected abstract HoodieData<WriteStatus> convertEngineSpecificDataToHoodieData(O records);
 
-  protected void commitInternal(String instantTime, Map<String, HoodieData<HoodieRecord>> partitionRecordsMap, boolean isInitializing,
+  protected void commitInternal(String instantTime, List<IndexPartitionAndRecords> partitionRecords, boolean isInitializing,
                                 Option<BulkInsertPartitioner> bulkInsertPartitioner) {
     ValidationUtils.checkState(metadataMetaClient != null, "Metadata table is not fully initialized yet.");
-    Pair<HoodieData<HoodieRecord>, List<HoodieFileGroupId>> result = tagRecordsWithLocation(partitionRecordsMap, isInitializing);
+    Pair<HoodieData<HoodieRecord>, List<HoodieFileGroupId>> result = tagRecordsWithLocation(partitionRecords, isInitializing);
     HoodieData<HoodieRecord> preppedRecords = result.getKey();
     I preppedRecordInputs = convertHoodieDataToEngineSpecificData(preppedRecords);
 
@@ -1534,14 +1411,14 @@ public abstract class HoodieBackedTableMetadataWriter<I, O> implements HoodieTab
    * @return Pair of {@link HoodieData} of {@link HoodieRecord} referring to the prepared records to be ingested to metadata table and
    * List of {@link HoodieFileGroupId} containing all file groups from the partitions being written in metadata table.
    */
-  protected Pair<HoodieData<HoodieRecord>, List<HoodieFileGroupId>> tagRecordsWithLocation(Map<String, HoodieData<HoodieRecord>> partitionRecordsMap, boolean isInitializing) {
+  protected Pair<HoodieData<HoodieRecord>, List<HoodieFileGroupId>> tagRecordsWithLocation(List<IndexPartitionAndRecords> partitionRecords, boolean isInitializing) {
     // The result set
     HoodieData<HoodieRecord> allPartitionRecords = engineContext.emptyHoodieData();
     try (HoodieTableFileSystemView fsView = HoodieTableMetadataUtil.getFileSystemViewForMetadataTable(metadataMetaClient)) {
       List<HoodieFileGroupId> hoodieFileGroupIdList = new ArrayList<>();
-      for (Map.Entry<String, HoodieData<HoodieRecord>> entry : partitionRecordsMap.entrySet()) {
-        final String partitionPath = entry.getKey();
-        HoodieData<HoodieRecord> records = entry.getValue();
+      for (IndexPartitionAndRecords entry : partitionRecords) {
+        final String partitionPath = entry.indexPartitionName();
+        HoodieData<HoodieRecord> records = entry.indexRecords();
         boolean isNonGlobalRLI = Objects.equals(partitionPath, RECORD_INDEX.getPartitionPath()) && dataWriteConfig.isRecordLevelIndexEnabled();
         List<FileSlice> fileSlices =
             HoodieTableMetadataUtil.getPartitionLatestFileSlices(metadataMetaClient, Option.ofNullable(fsView), partitionPath);
@@ -1839,53 +1716,6 @@ public abstract class HoodieBackedTableMetadataWriter<I, O> implements HoodieTab
           partitionFilesToDelete.put(partitionId, filesDeleted);
         }
       }
-    }
-  }
-
-  private HoodieData<HoodieRecord> getRecordIndexReplacedRecords(HoodieReplaceCommitMetadata replaceCommitMetadata) {
-    HoodieTableFileSystemView fsView = getMetadataView();
-    List<Pair<String, HoodieBaseFile>> partitionBaseFilePairs = replaceCommitMetadata
-        .getPartitionToReplaceFileIds()
-        .keySet().stream()
-        .flatMap(partition -> fsView.getLatestBaseFiles(partition).map(f -> Pair.of(partition, f)))
-        .collect(Collectors.toList());
-    return readRecordKeysFromBaseFiles(
-        engineContext,
-        dataWriteConfig,
-        partitionBaseFilePairs,
-        true,
-        dataWriteConfig.getMetadataConfig().getRecordIndexMaxParallelism(),
-        dataMetaClient.getBasePath(),
-        storageConf,
-        this.getClass().getSimpleName(),
-        dataWriteConfig.isRecordLevelIndexEnabled());
-  }
-
-  private HoodieData<HoodieRecord> getRecordIndexAdditionalUpserts(HoodieData<HoodieRecord> updatesFromWriteStatuses, HoodieCommitMetadata commitMetadata) {
-    WriteOperationType operationType = commitMetadata.getOperationType();
-    if (operationType == WriteOperationType.INSERT_OVERWRITE) {
-      // load existing records from replaced filegroups and left anti join overwriting records
-      // return partition-level unmatched records (with newLocation being null) to be deleted from RLI
-      return getRecordIndexReplacedRecords((HoodieReplaceCommitMetadata) commitMetadata)
-          .mapToPair(r -> Pair.of(r.getKey(), r))
-          .leftOuterJoin(updatesFromWriteStatuses.mapToPair(r -> Pair.of(r.getKey(), r)))
-          .values()
-          .filter(p -> !p.getRight().isPresent())
-          .map(Pair::getLeft);
-    } else if (operationType == WriteOperationType.INSERT_OVERWRITE_TABLE) {
-      // load existing records from replaced filegroups and left anti join overwriting records
-      // return globally unmatched records (with newLocation being null) to be deleted from RLI
-      return getRecordIndexReplacedRecords((HoodieReplaceCommitMetadata) commitMetadata)
-          .mapToPair(r -> Pair.of(r.getRecordKey(), r))
-          .leftOuterJoin(updatesFromWriteStatuses.mapToPair(r -> Pair.of(r.getRecordKey(), r)))
-          .values()
-          .filter(p -> !p.getRight().isPresent())
-          .map(Pair::getLeft);
-    } else if (operationType == WriteOperationType.DELETE_PARTITION) {
-      // all records from the target partition(s) to be deleted from RLI
-      return getRecordIndexReplacedRecords((HoodieReplaceCommitMetadata) commitMetadata);
-    } else {
-      return engineContext.emptyHoodieData();
     }
   }
 

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/HoodieBackedTableMetadataWriter.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/HoodieBackedTableMetadataWriter.java
@@ -26,13 +26,10 @@ import org.apache.hudi.avro.model.HoodieRestorePlan;
 import org.apache.hudi.avro.model.HoodieRollbackMetadata;
 import org.apache.hudi.client.BaseHoodieWriteClient;
 import org.apache.hudi.client.WriteStatus;
-import org.apache.hudi.common.config.HoodieConfig;
 import org.apache.hudi.common.config.HoodieMetadataConfig;
 import org.apache.hudi.common.data.HoodieData;
 import org.apache.hudi.common.engine.EngineType;
 import org.apache.hudi.common.engine.HoodieEngineContext;
-import org.apache.hudi.common.engine.HoodieReaderContext;
-import org.apache.hudi.common.engine.ReaderContextFactory;
 import org.apache.hudi.common.fs.FSUtils;
 import org.apache.hudi.common.function.SerializableBiFunction;
 import org.apache.hudi.common.function.SerializableFunction;
@@ -52,13 +49,10 @@ import org.apache.hudi.common.model.HoodieTableType;
 import org.apache.hudi.common.model.HoodieWriteStat;
 import org.apache.hudi.common.model.WriteOperationType;
 import org.apache.hudi.common.schema.HoodieSchema;
-import org.apache.hudi.common.schema.HoodieSchemaCache;
-import org.apache.hudi.common.schema.HoodieSchemaUtils;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.common.table.log.HoodieLogFormat;
 import org.apache.hudi.common.table.log.block.HoodieDeleteBlock;
 import org.apache.hudi.common.table.log.block.HoodieLogBlock.HeaderMetadataType;
-import org.apache.hudi.common.table.read.HoodieFileGroupReader;
 import org.apache.hudi.common.table.timeline.HoodieActiveTimeline;
 import org.apache.hudi.common.table.timeline.HoodieInstant;
 import org.apache.hudi.common.table.timeline.HoodieInstantTimeGenerator;
@@ -70,7 +64,6 @@ import org.apache.hudi.common.util.HoodieTimer;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.common.util.StringUtils;
 import org.apache.hudi.common.util.ValidationUtils;
-import org.apache.hudi.common.util.collection.CloseableMappingIterator;
 import org.apache.hudi.common.util.collection.Pair;
 import org.apache.hudi.config.HoodieWriteConfig;
 import org.apache.hudi.exception.HoodieException;
@@ -78,12 +71,14 @@ import org.apache.hudi.exception.HoodieIOException;
 import org.apache.hudi.exception.HoodieIndexException;
 import org.apache.hudi.exception.HoodieMetadataException;
 import org.apache.hudi.exception.TableNotFoundException;
-import org.apache.hudi.index.record.HoodieRecordIndex;
-import org.apache.hudi.internal.schema.InternalSchema;
-import org.apache.hudi.internal.schema.utils.SerDeHelper;
-import org.apache.hudi.io.storage.HoodieAvroFileReader;
-import org.apache.hudi.io.storage.HoodieIOFactory;
-import org.apache.hudi.metadata.HoodieTableMetadataUtil.DirectoryInfo;
+import org.apache.hudi.metadata.index.ExpressionIndexRecordGenerator;
+import org.apache.hudi.metadata.index.model.DataPartitionAndRecords;
+import org.apache.hudi.metadata.index.model.IndexPartitionInitialization;
+import org.apache.hudi.metadata.index.Indexer;
+import org.apache.hudi.metadata.index.IndexerFactory;
+import org.apache.hudi.metadata.model.DirectoryInfo;
+import org.apache.hudi.metadata.model.FileInfo;
+import org.apache.hudi.metadata.model.FileSliceAndPartition;
 import org.apache.hudi.storage.HoodieStorage;
 import org.apache.hudi.storage.HoodieStorageUtils;
 import org.apache.hudi.storage.StorageConfiguration;
@@ -93,6 +88,7 @@ import org.apache.hudi.table.BulkInsertPartitioner;
 import org.apache.hudi.util.Lazy;
 
 import lombok.Getter;
+import lombok.SneakyThrows;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -100,26 +96,21 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Queue;
 import java.util.Set;
-import java.util.TreeMap;
 import java.util.function.Function;
-import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 import static org.apache.hudi.common.config.HoodieMetadataConfig.DEFAULT_METADATA_POPULATE_META_FIELDS;
-import static org.apache.hudi.common.schema.HoodieSchemaUtils.getRecordKeySchema;
 import static org.apache.hudi.common.table.HoodieTableConfig.TIMELINE_HISTORY_PATH;
 import static org.apache.hudi.common.table.timeline.HoodieInstant.State.REQUESTED;
 import static org.apache.hudi.common.table.timeline.HoodieTimeline.COMMIT_ACTION;
@@ -130,24 +121,17 @@ import static org.apache.hudi.metadata.HoodieTableMetadata.METADATA_TABLE_NAME_S
 import static org.apache.hudi.metadata.HoodieTableMetadata.SOLO_COMMIT_TIMESTAMP;
 import static org.apache.hudi.metadata.HoodieTableMetadataUtil.PARTITION_NAME_COLUMN_STATS;
 import static org.apache.hudi.metadata.HoodieTableMetadataUtil.PARTITION_NAME_SECONDARY_INDEX_PREFIX;
-import static org.apache.hudi.metadata.HoodieTableMetadataUtil.createRecordIndexDefinition;
 import static org.apache.hudi.metadata.HoodieTableMetadataUtil.existingIndexVersionOrDefault;
-import static org.apache.hudi.metadata.HoodieTableMetadataUtil.getExpressionIndexPartitionsToInit;
 import static org.apache.hudi.metadata.HoodieTableMetadataUtil.getInflightMetadataPartitions;
 import static org.apache.hudi.metadata.HoodieTableMetadataUtil.getPartitionLatestFileSlicesIncludingInflight;
-import static org.apache.hudi.metadata.HoodieTableMetadataUtil.getProjectedSchemaForExpressionIndex;
-import static org.apache.hudi.metadata.HoodieTableMetadataUtil.getSecondaryIndexPartitionsToInit;
 import static org.apache.hudi.metadata.HoodieTableMetadataUtil.readRecordKeysFromBaseFiles;
-import static org.apache.hudi.metadata.MetadataPartitionType.BLOOM_FILTERS;
 import static org.apache.hudi.metadata.MetadataPartitionType.COLUMN_STATS;
 import static org.apache.hudi.metadata.MetadataPartitionType.EXPRESSION_INDEX;
 import static org.apache.hudi.metadata.MetadataPartitionType.FILES;
-import static org.apache.hudi.metadata.MetadataPartitionType.PARTITION_STATS;
 import static org.apache.hudi.metadata.MetadataPartitionType.RECORD_INDEX;
 import static org.apache.hudi.metadata.MetadataPartitionType.SECONDARY_INDEX;
 import static org.apache.hudi.metadata.MetadataPartitionType.fromPartitionPath;
 import static org.apache.hudi.metadata.SecondaryIndexRecordGenerationUtils.convertWriteStatsToSecondaryIndexRecords;
-import static org.apache.hudi.metadata.SecondaryIndexRecordGenerationUtils.readSecondaryKeysFromFileSlices;
 
 /**
  * Writer implementation backed by an internal hudi table. Partition and file listing are saved within an internal MOR table
@@ -181,7 +165,8 @@ public abstract class HoodieBackedTableMetadataWriter<I, O> implements HoodieTab
   private boolean hasPartitionsStateChanged = false;
   protected final transient HoodieEngineContext engineContext;
   @Getter
-  protected final List<MetadataPartitionType> enabledPartitionTypes;
+  protected final transient Map<MetadataPartitionType, Indexer> enabledIndexerMap;
+  protected final transient ExpressionIndexRecordGenerator expressionIndexRecordGenerator;
 
   // Is the MDT bootstrapped and ready to be read from
   @Getter
@@ -193,8 +178,9 @@ public abstract class HoodieBackedTableMetadataWriter<I, O> implements HoodieTab
                                             HoodieWriteConfig writeConfig,
                                             HoodieFailedWritesCleaningPolicy failedWritesCleaningPolicy,
                                             HoodieEngineContext engineContext,
+                                            ExpressionIndexRecordGenerator expressionIndexRecordGenerator,
                                             Option<String> inflightInstantTimestamp) {
-    this(storageConf, writeConfig, failedWritesCleaningPolicy, engineContext, inflightInstantTimestamp, false);
+    this(storageConf, writeConfig, failedWritesCleaningPolicy, engineContext, expressionIndexRecordGenerator, inflightInstantTimestamp, false);
   }
 
   /**
@@ -211,6 +197,7 @@ public abstract class HoodieBackedTableMetadataWriter<I, O> implements HoodieTab
                                             HoodieWriteConfig writeConfig,
                                             HoodieFailedWritesCleaningPolicy failedWritesCleaningPolicy,
                                             HoodieEngineContext engineContext,
+                                            ExpressionIndexRecordGenerator expressionIndexRecordGenerator,
                                             Option<String> inflightInstantTimestamp,
                                             boolean streamingWritesEnabled) {
     this.dataWriteConfig = writeConfig;
@@ -220,7 +207,8 @@ public abstract class HoodieBackedTableMetadataWriter<I, O> implements HoodieTab
     this.dataMetaClient = HoodieTableMetaClient.builder().setConf(storageConf.newInstance())
         .setBasePath(dataWriteConfig.getBasePath())
         .setTimeGeneratorConfig(dataWriteConfig.getTimeGeneratorConfig()).build();
-    this.enabledPartitionTypes = getEnabledPartitions(dataWriteConfig.getMetadataConfig(), dataMetaClient);
+    this.enabledIndexerMap = IndexerFactory.getEnabledIndexerMap(engineContext, dataWriteConfig, dataMetaClient, expressionIndexRecordGenerator);
+    this.expressionIndexRecordGenerator = expressionIndexRecordGenerator;
     if (writeConfig.isMetadataTableEnabled()) {
       this.metadataWriteConfig = createMetadataWriteConfig(writeConfig, failedWritesCleaningPolicy, dataMetaClient.getTableConfig().getTableVersion());
       try {
@@ -232,10 +220,6 @@ public abstract class HoodieBackedTableMetadataWriter<I, O> implements HoodieTab
     }
     ValidationUtils.checkArgument(!initialized || this.metadata != null, "MDT Reader should have been opened post initialization");
     this.streamingWritesEnabled = streamingWritesEnabled;
-  }
-
-  List<MetadataPartitionType> getEnabledPartitions(HoodieMetadataConfig metadataConfig, HoodieTableMetaClient metaClient) {
-    return MetadataPartitionType.getEnabledPartitions(metadataConfig, metaClient);
   }
 
   private void mayBeReinitMetadataReader() {
@@ -286,13 +270,13 @@ public abstract class HoodieBackedTableMetadataWriter<I, O> implements HoodieTab
   protected boolean initializeIfNeeded(HoodieTableMetaClient dataMetaClient,
                                        Option<String> inflightInstantTimestamp) throws IOException {
     HoodieTimer timer = HoodieTimer.start();
-    List<MetadataPartitionType> metadataPartitionsToInit = new ArrayList<>(MetadataPartitionType.getValidValues().length);
+    Map<MetadataPartitionType, Indexer> indexerMapForPartitionsToInit = new HashMap<>();
 
     try {
       boolean exists = metadataTableExists(dataMetaClient);
       if (!exists) {
         // FILES partition is always required
-        metadataPartitionsToInit.add(FILES);
+        indexerMapForPartitionsToInit.put(FILES, enabledIndexerMap.get(FILES));
       }
 
       // check if any of the enabled partition types needs to be initialized
@@ -300,12 +284,12 @@ public abstract class HoodieBackedTableMetadataWriter<I, O> implements HoodieTab
       if (!dataWriteConfig.isMetadataAsyncIndex()) {
         Set<String> completedPartitions = dataMetaClient.getTableConfig().getMetadataPartitions();
         LOG.info("Async metadata indexing disabled and following partitions already initialized: {}", completedPartitions);
-        this.enabledPartitionTypes.stream()
-            .filter(p -> !completedPartitions.contains(p.getPartitionPath()) && !FILES.equals(p))
-            .forEach(metadataPartitionsToInit::add);
+        this.enabledIndexerMap.entrySet().stream()
+            .filter(p -> !completedPartitions.contains(p.getKey().getPartitionPath()) && FILES != p.getKey())
+            .forEach(e -> indexerMapForPartitionsToInit.put(e.getKey(), e.getValue()));
       }
 
-      if (metadataPartitionsToInit.isEmpty()) {
+      if (indexerMapForPartitionsToInit.isEmpty()) {
         // No partitions left to initialize, since all the metadata enabled partitions are either initialized before
         // or current in the process of initialization.
         initMetadataReader();
@@ -315,7 +299,7 @@ public abstract class HoodieBackedTableMetadataWriter<I, O> implements HoodieTab
       // If there is no commit on the dataset yet, use the SOLO_COMMIT_TIMESTAMP as the instant time for initial commit
       // Otherwise, we use the timestamp of the latest completed action.
       String dataTableInstantTime = dataMetaClient.getActiveTimeline().filterCompletedInstants().lastInstant().map(HoodieInstant::requestedTime).orElse(SOLO_COMMIT_TIMESTAMP);
-      if (!initializeFromFilesystem(dataTableInstantTime, metadataPartitionsToInit, inflightInstantTimestamp)) {
+      if (!initializeFromFilesystem(dataTableInstantTime, indexerMapForPartitionsToInit, inflightInstantTimestamp)) {
         LOG.error("Failed to initialize MDT from filesystem");
         return false;
       }
@@ -388,11 +372,13 @@ public abstract class HoodieBackedTableMetadataWriter<I, O> implements HoodieTab
   /**
    * Initialize the Metadata Table by listing files and partitions from the file system.
    *
-   * @param dataTableInstantTime     Timestamp to use for the commit
-   * @param partitionsToInit         List of MDT partitions to initialize
-   * @param inflightInstantTimestamp Current action instant responsible for this initialization
+   * @param dataTableInstantTime          timestamp to use for the commit
+   * @param indexerMapForPartitionsToInit map of metadata partition type to indexer for partitions to initialize
+   * @param inflightInstantTimestamp      current action instant responsible for this initialization
    */
-  private boolean initializeFromFilesystem(String dataTableInstantTime, List<MetadataPartitionType> partitionsToInit, Option<String> inflightInstantTimestamp) throws IOException {
+  private boolean initializeFromFilesystem(String dataTableInstantTime,
+                                           Map<MetadataPartitionType, Indexer> indexerMapForPartitionsToInit,
+                                           Option<String> inflightInstantTimestamp) throws IOException {
     Set<String> pendingDataInstants = getPendingDataInstants(dataMetaClient);
     if (!shouldInitializeFromFilesystem(pendingDataInstants, inflightInstantTimestamp)) {
       return false;
@@ -401,8 +387,6 @@ public abstract class HoodieBackedTableMetadataWriter<I, O> implements HoodieTab
     // FILES partition is always required and is initialized first
     boolean filesPartitionAvailable = dataMetaClient.getTableConfig().isMetadataPartitionAvailable(FILES);
     if (!filesPartitionAvailable) {
-      partitionsToInit.remove(FILES);
-      partitionsToInit.add(0, FILES);
       // Initialize the metadata table for the first time
       metadataMetaClient = initializeMetaClient();
     } else {
@@ -417,7 +401,16 @@ public abstract class HoodieBackedTableMetadataWriter<I, O> implements HoodieTab
     }
 
     // Already initialized partitions can be ignored
-    partitionsToInit.removeIf(metadataPartition -> dataMetaClient.getTableConfig().isMetadataPartitionAvailable((metadataPartition)));
+    indexerMapForPartitionsToInit.keySet().removeIf(
+        metadataPartition -> dataMetaClient.getTableConfig().isMetadataPartitionAvailable(metadataPartition));
+
+    // For a fresh table, defer RLI initialization
+    if (dataWriteConfig.getMetadataConfig().shouldDeferRliInitForFreshTable()
+        && this.enabledIndexerMap.containsKey(RECORD_INDEX)
+        && dataMetaClient.getActiveTimeline().filterCompletedInstants().countInstants() == 0) {
+      this.enabledIndexerMap.remove(RECORD_INDEX);
+      indexerMapForPartitionsToInit.remove(RECORD_INDEX);
+    }
 
     // Get a complete list of files and partitions from the file system or from already initialized FILES partition of MDT
     List<DirectoryInfo> partitionInfoList;
@@ -432,107 +425,78 @@ public abstract class HoodieBackedTableMetadataWriter<I, O> implements HoodieTab
         partitionInfoList = Collections.emptyList();
       }
     }
-    Map<String, Map<String, Long>> partitionIdToAllFilesMap = partitionInfoList.stream()
-        .map(p -> {
-          String partitionName = HoodieTableMetadataUtil.getPartitionIdentifierForFilesPartition(p.getRelativePath());
-          return Pair.of(partitionName, p.getFilenameToSizeMap());
-        })
-        .collect(Collectors.toMap(Pair::getKey, Pair::getValue));
+    Map<String, List<FileInfo>> partitionIdToAllFilesMap = DirectoryInfo.getPartitionToFileInfo(partitionInfoList);
+    Lazy<List<FileSliceAndPartition>> lazyLatestMergedPartitionFileSliceList = getLazyLatestMergedPartitionFileSliceList();
 
-    // validate that each index is eligible to be initialized
-    Iterator<MetadataPartitionType> iterator = partitionsToInit.iterator();
-    while (iterator.hasNext()) {
-      MetadataPartitionType partitionType = iterator.next();
-      if (partitionType == PARTITION_STATS && !dataMetaClient.getTableConfig().isTablePartitioned()) {
-        // Partition stats index cannot be enabled for a non-partitioned table
-        iterator.remove();
-        this.enabledPartitionTypes.remove(partitionType);
-      }
+    // FILES partition should always be initialized first if enabled
+    if (!filesPartitionAvailable) {
+      initializeMetadataPartition(FILES, indexerMapForPartitionsToInit.get(FILES),
+          dataTableInstantTime, partitionIdToAllFilesMap, lazyLatestMergedPartitionFileSliceList);
+      hasPartitionsStateChanged = true;
     }
 
-    // For a fresh table, defer RLI initialization
-    if (dataWriteConfig.getMetadataConfig().shouldDeferRliInitForFreshTable() && this.enabledPartitionTypes.contains(RECORD_INDEX)
-        && dataMetaClient.getActiveTimeline().filterCompletedInstants().countInstants() == 0) {
-      this.enabledPartitionTypes.remove(RECORD_INDEX);
-      partitionsToInit.remove(RECORD_INDEX);
-    }
-
-    Lazy<List<Pair<String, FileSlice>>> lazyLatestMergedPartitionFileSliceList = getLazyLatestMergedPartitionFileSliceList();
-    for (MetadataPartitionType partitionType : partitionsToInit) {
-      // Find the commit timestamp to use for this partition. Each initialization should use its own unique commit time.
-      String instantTimeForPartition = generateUniqueInstantTime(dataTableInstantTime);
-      String partitionTypeName = partitionType.name();
-      LOG.info("Initializing MDT partition {} at instant {}", partitionTypeName, instantTimeForPartition);
-      String relativePartitionPath;
-      Pair<Integer, HoodieData<HoodieRecord>> fileGroupCountAndRecordsPair;
-      Lazy<Option<HoodieSchema>> tableSchema = Lazy.lazily(() -> HoodieTableMetadataUtil.tryResolveSchemaForTable(dataMetaClient));
-      try {
-        switch (partitionType) {
-          case FILES:
-            fileGroupCountAndRecordsPair = initializeFilesPartition(partitionIdToAllFilesMap);
-            initializeFilegroupsAndCommit(partitionType, FILES.getPartitionPath(), fileGroupCountAndRecordsPair, instantTimeForPartition);
-            break;
-          case BLOOM_FILTERS:
-            fileGroupCountAndRecordsPair = initializeBloomFiltersPartition(dataTableInstantTime, partitionIdToAllFilesMap);
-            initializeFilegroupsAndCommit(partitionType, BLOOM_FILTERS.getPartitionPath(), fileGroupCountAndRecordsPair, instantTimeForPartition);
-            break;
-          case COLUMN_STATS:
-            Pair<List<String>, Pair<Integer, HoodieData<HoodieRecord>>> colStatsColumnsAndRecord = initializeColumnStatsPartition(partitionIdToAllFilesMap, tableSchema);
-            fileGroupCountAndRecordsPair = colStatsColumnsAndRecord.getValue();
-            initializeFilegroupsAndCommit(partitionType, COLUMN_STATS.getPartitionPath(), fileGroupCountAndRecordsPair, instantTimeForPartition, colStatsColumnsAndRecord.getKey());
-            break;
-          case RECORD_INDEX:
-            boolean isPartitionedRLI = dataWriteConfig.isRecordLevelIndexEnabled();
-            initializeFilegroupsAndCommitToRecordIndexPartition(instantTimeForPartition, lazyLatestMergedPartitionFileSliceList, isPartitionedRLI);
-            break;
-          case EXPRESSION_INDEX:
-            Set<String> expressionIndexPartitionsToInit = getExpressionIndexPartitionsToInit(partitionType, dataWriteConfig.getMetadataConfig(), dataMetaClient);
-            if (expressionIndexPartitionsToInit.size() != 1) {
-              if (expressionIndexPartitionsToInit.size() > 1) {
-                LOG.warn("Skipping expression index initialization as only one expression index bootstrap at a time is supported for now. Provided: {}", expressionIndexPartitionsToInit);
-              }
-              continue;
-            }
-            relativePartitionPath = expressionIndexPartitionsToInit.iterator().next();
-            fileGroupCountAndRecordsPair = initializeExpressionIndexPartition(relativePartitionPath, dataTableInstantTime, lazyLatestMergedPartitionFileSliceList, tableSchema);
-            initializeFilegroupsAndCommit(partitionType, relativePartitionPath, fileGroupCountAndRecordsPair, instantTimeForPartition);
-            break;
-          case PARTITION_STATS:
-            // For PARTITION_STATS, COLUMN_STATS should also be enabled
-            if (!dataWriteConfig.isMetadataColumnStatsIndexEnabled()) {
-              LOG.debug("Skipping partition stats initialization as column stats index is not enabled. Please enable {}",
-                  HoodieMetadataConfig.ENABLE_METADATA_INDEX_COLUMN_STATS.key());
-              continue;
-            }
-            fileGroupCountAndRecordsPair = initializePartitionStatsIndex(lazyLatestMergedPartitionFileSliceList, tableSchema);
-            initializeFilegroupsAndCommit(partitionType, PARTITION_STATS.getPartitionPath(), fileGroupCountAndRecordsPair, instantTimeForPartition);
-            break;
-          case SECONDARY_INDEX:
-            Set<String> secondaryIndexPartitionsToInit = getSecondaryIndexPartitionsToInit(partitionType, dataWriteConfig.getMetadataConfig(), dataMetaClient);
-            if (secondaryIndexPartitionsToInit.size() != 1) {
-              if (secondaryIndexPartitionsToInit.size() > 1) {
-                LOG.warn("Skipping secondary index initialization as only one secondary index bootstrap at a time is supported for now. Provided: {}", secondaryIndexPartitionsToInit);
-              }
-              continue;
-            }
-            relativePartitionPath = secondaryIndexPartitionsToInit.iterator().next();
-            fileGroupCountAndRecordsPair = initializeSecondaryIndexPartition(relativePartitionPath, lazyLatestMergedPartitionFileSliceList);
-            initializeFilegroupsAndCommit(partitionType, relativePartitionPath, fileGroupCountAndRecordsPair, instantTimeForPartition);
-            break;
-          default:
-            throw new HoodieMetadataException(String.format("Unsupported MDT partition type: %s", partitionType));
-        }
-      } catch (Exception e) {
-        String metricKey = partitionType.getPartitionPath() + "_" + HoodieMetadataMetrics.BOOTSTRAP_ERR_STR;
-        metrics.ifPresent(m -> m.setMetric(metricKey, 1));
-        String errMsg = String.format("Bootstrap on %s partition failed for %s",
-            partitionType.getPartitionPath(), metadataMetaClient.getBasePath());
-        LOG.error(errMsg, e);
-        throw new HoodieMetadataException(errMsg, e);
-      }
+    for (Map.Entry<MetadataPartitionType, Indexer> entry :
+        indexerMapForPartitionsToInit.entrySet().stream()
+            .filter(e -> e.getKey() != FILES).collect(Collectors.toList())) {
+      initializeMetadataPartition(entry.getKey(), entry.getValue(),
+          dataTableInstantTime, partitionIdToAllFilesMap, lazyLatestMergedPartitionFileSliceList);
       hasPartitionsStateChanged = true;
     }
     return true;
+  }
+
+  @SneakyThrows
+  private void initializeMetadataPartition(
+      MetadataPartitionType partitionType,
+      Indexer indexer,
+      String dataTableInstantTime,
+      Map<String, List<FileInfo>> partitionToAllFilesMap,
+      Lazy<List<FileSliceAndPartition>> lazyLatestMergedPartitionFileSliceList) {
+    String instantTimeForPartition = generateUniqueInstantTime(dataTableInstantTime);
+    // initialize metadata partitions
+    List<IndexPartitionInitialization> initializationList;
+    try {
+      initializationList = indexer.buildInitialization(
+          dataTableInstantTime, instantTimeForPartition, partitionToAllFilesMap, lazyLatestMergedPartitionFileSliceList);
+    } catch (Exception e) {
+      String metricKey = partitionType.getPartitionPath() + "_" + HoodieMetadataMetrics.BOOTSTRAP_ERR_STR;
+      metrics.ifPresent(m -> m.setMetric(metricKey, 1));
+      String errMsg = String.format("Bootstrap on %s partition failed for %s",
+          partitionType.getPartitionPath(), metadataMetaClient.getBasePath());
+      LOG.error(errMsg, e);
+      throw new HoodieMetadataException(errMsg, e);
+    }
+
+    if (initializationList.isEmpty()) {
+      LOG.info("Skip building {} index in metadata table", partitionType.getPartitionPath());
+      return;
+    }
+
+    ValidationUtils.checkArgument(initializationList.size() == 1,
+        "Only support the initialization of one partition per index type "
+            + "(HUDI-9358 for the feature support)");
+
+    IndexPartitionInitialization initialIndexPartitionData = initializationList.get(0);
+    final int numFileGroup = initialIndexPartitionData.totalFileGroups();
+    String relativePartitionPath = initialIndexPartitionData.indexPartitionName();
+    LOG.info("Initializing {} index with {} file groups", relativePartitionPath, numFileGroup);
+
+    HoodieTimer partitionInitTimer = HoodieTimer.start();
+    clearExistingMetadataPartition(relativePartitionPath);
+    HoodieData<HoodieRecord> records = engineContext.emptyHoodieData();
+    for (DataPartitionAndRecords dataPartitionAndRecords: initialIndexPartitionData.dataPartitionAndRecords()) {
+      initializeFileGroups(dataMetaClient, partitionType, instantTimeForPartition,
+          dataPartitionAndRecords.numFileGroups(), relativePartitionPath, dataPartitionAndRecords.dataPartition());
+      records = records.union(dataPartitionAndRecords.indexRecords());
+    }
+
+    bulkCommit(instantTimeForPartition, relativePartitionPath, records, initialIndexPartitionData.indexParser());
+
+    indexer.postInitialization(metadataMetaClient, records, numFileGroup, relativePartitionPath);
+    // initialize metadata reader
+    initMetadataReader();
+    long totalInitTime = partitionInitTimer.endTimer();
+    LOG.info("Initializing {} index in metadata table took {} in ms", partitionType, totalInitTime);
   }
 
   /**
@@ -567,131 +531,9 @@ public abstract class HoodieBackedTableMetadataWriter<I, O> implements HoodieTab
     }
   }
 
-  private Pair<Integer, HoodieData<HoodieRecord>> initializePartitionStatsIndex(
-      Lazy<List<Pair<String, FileSlice>>> lazyLatestMergedPartitionFileSliceList,
-      Lazy<Option<HoodieSchema>> tableSchemaOpt) {
-    HoodieData<HoodieRecord> records = HoodieTableMetadataUtil.convertFilesToPartitionStatsRecords(
-        engineContext, lazyLatestMergedPartitionFileSliceList.get(), dataWriteConfig.getMetadataConfig(),
-        dataMetaClient, tableSchemaOpt, Option.of(dataWriteConfig.getRecordMerger().getRecordType()));
-    final int fileGroupCount = dataWriteConfig.getMetadataConfig().getPartitionStatsIndexFileGroupCount();
-    return Pair.of(fileGroupCount, records);
-  }
-
-  private Pair<List<String>, Pair<Integer, HoodieData<HoodieRecord>>> initializeColumnStatsPartition(Map<String, Map<String, Long>> partitionIdToAllFilesMap,
-                                                                                                     Lazy<Option<HoodieSchema>> tableSchema) {
-    final int fileGroupCount = dataWriteConfig.getMetadataConfig().getColumnStatsIndexFileGroupCount();
-    if (partitionIdToAllFilesMap.isEmpty()) {
-      return Pair.of(Collections.emptyList(), Pair.of(fileGroupCount, engineContext.emptyHoodieData()));
-    }
-    HoodieIndexVersion columnStatsIndexVersion = existingIndexVersionOrDefault(PARTITION_NAME_COLUMN_STATS, dataMetaClient);
-    // Find the columns to index
-    final List<String> columnsToIndex = new ArrayList<>(HoodieTableMetadataUtil.getColumnsToIndex(dataMetaClient.getTableConfig(),
-        dataWriteConfig.getMetadataConfig(), tableSchema, true,
-        Option.of(dataWriteConfig.getRecordMerger().getRecordType()), columnStatsIndexVersion).keySet());
-
-    if (columnsToIndex.isEmpty()) {
-      // this can only happen if meta fields are disabled and cols to index is not explicitly overridden.
-      return Pair.of(columnsToIndex, Pair.of(fileGroupCount, engineContext.emptyHoodieData()));
-    }
-
-    LOG.info("Indexing {} columns for column stats index", columnsToIndex.size());
-
-    // during initialization, we need stats for base and log files.
-    HoodieData<HoodieRecord> records = HoodieTableMetadataUtil.convertFilesToColumnStatsRecords(engineContext, Collections.emptyMap(), partitionIdToAllFilesMap,
-        dataMetaClient, dataWriteConfig.getMetadataConfig(),
-        dataWriteConfig.getColumnStatsIndexParallelism(),
-        dataWriteConfig.getMetadataConfig().getMaxReaderBufferSize(),
-        columnsToIndex);
-
-    return Pair.of(columnsToIndex, Pair.of(fileGroupCount, records));
-  }
-
-  private Pair<Integer, HoodieData<HoodieRecord>> initializeBloomFiltersPartition(String createInstantTime, Map<String, Map<String, Long>> partitionIdToAllFilesMap) {
-    HoodieData<HoodieRecord> records = HoodieTableMetadataUtil.convertFilesToBloomFilterRecords(
-        engineContext, Collections.emptyMap(), partitionIdToAllFilesMap, createInstantTime, dataMetaClient,
-        dataWriteConfig.getBloomIndexParallelism(), dataWriteConfig.getBloomFilterType());
-
-    final int fileGroupCount = dataWriteConfig.getMetadataConfig().getBloomFilterIndexFileGroupCount();
-    return Pair.of(fileGroupCount, records);
-  }
-
-  /**
-   * Generates expression index records
-   *
-   * @param partitionFilePathAndSizeTriplet Triplet of file path, file size and partition name to which file belongs
-   * @param indexDefinition                 Hoodie Index Definition for the expression index for which records need to be generated
-   * @param metaClient                      Hoodie Table Meta Client
-   * @param parallelism                     Parallelism to use for engine operations
-   * @param tableSchema                     Schema of the table
-   * @param readerSchema                    Schema of reader
-   * @param storageConf                     Storage Config
-   * @param instantTime                     Instant time
-   * @return HoodieData wrapper of expression index HoodieRecords
-   */
-  protected abstract HoodieData<HoodieRecord> getExpressionIndexRecords(List<Pair<String, Pair<String, Long>>> partitionFilePathAndSizeTriplet,
-                                                                        HoodieIndexDefinition indexDefinition,
-                                                                        HoodieTableMetaClient metaClient,
-                                                                        int parallelism, HoodieSchema tableSchema, HoodieSchema readerSchema,
-                                                                        StorageConfiguration<?> storageConf,
-                                                                        String instantTime);
-
   protected abstract EngineType getEngineType();
 
-  private Pair<Integer, HoodieData<HoodieRecord>> initializeExpressionIndexPartition(
-      String indexName, String dataTableInstantTime, Lazy<List<Pair<String, FileSlice>>> lazyLatestMergedPartitionFileSliceList,
-      Lazy<Option<HoodieSchema>> tableSchemaOpt) {
-    HoodieIndexDefinition indexDefinition = getIndexDefinition(indexName);
-    ValidationUtils.checkState(indexDefinition != null, "Expression Index definition is not present for index " + indexName);
-    List<Pair<String, FileSlice>> partitionFileSlicePairs = lazyLatestMergedPartitionFileSliceList.get();
-    List<Pair<String, Pair<String, Long>>> partitionFilePathSizeTriplet = new ArrayList<>();
-    partitionFileSlicePairs.forEach(entry -> {
-      if (entry.getValue().getBaseFile().isPresent()) {
-        partitionFilePathSizeTriplet.add(Pair.of(entry.getKey(), Pair.of(entry.getValue().getBaseFile().get().getPath(), entry.getValue().getBaseFile().get().getFileSize())));
-      }
-      entry.getValue().getLogFiles()
-          .forEach(hoodieLogFile -> partitionFilePathSizeTriplet.add(Pair.of(entry.getKey(), Pair.of(hoodieLogFile.getPath().toString(), hoodieLogFile.getFileSize()))));
-    });
-
-    int fileGroupCount = dataWriteConfig.getMetadataConfig().getExpressionIndexFileGroupCount();
-    if (partitionFileSlicePairs.isEmpty()) {
-      return Pair.of(fileGroupCount, engineContext.emptyHoodieData());
-    }
-    int parallelism = Math.min(partitionFilePathSizeTriplet.size(), dataWriteConfig.getMetadataConfig().getExpressionIndexParallelism());
-    HoodieSchema tableSchema = tableSchemaOpt.get().orElseThrow(() -> new HoodieMetadataException("Table schema is not available for expression index initialization"));
-    HoodieSchema readerSchema = getProjectedSchemaForExpressionIndex(indexDefinition, dataMetaClient, tableSchema);
-    return Pair.of(fileGroupCount, getExpressionIndexRecords(partitionFilePathSizeTriplet, indexDefinition, dataMetaClient, parallelism, tableSchema, readerSchema, storageConf, dataTableInstantTime));
-  }
-
-  HoodieIndexDefinition getIndexDefinition(String indexName) {
-    return HoodieTableMetadataUtil.getHoodieIndexDefinition(indexName, dataMetaClient);
-  }
-
-  private Pair<Integer, HoodieData<HoodieRecord>> initializeSecondaryIndexPartition(
-      String indexName, Lazy<List<Pair<String, FileSlice>>> lazyLatestMergedPartitionFileSliceList) {
-    HoodieIndexDefinition indexDefinition = getIndexDefinition(indexName);
-    ValidationUtils.checkState(indexDefinition != null, "Secondary Index definition is not present for index " + indexName);
-    List<Pair<String, FileSlice>> partitionFileSlicePairs = lazyLatestMergedPartitionFileSliceList.get();
-
-    int parallelism = Math.min(partitionFileSlicePairs.size(), dataWriteConfig.getMetadataConfig().getSecondaryIndexParallelism());
-    HoodieData<HoodieRecord> records = readSecondaryKeysFromFileSlices(
-        engineContext,
-        partitionFileSlicePairs,
-        parallelism,
-        this.getClass().getSimpleName(),
-        dataMetaClient,
-        indexDefinition,
-        dataWriteConfig.getProps());
-
-    // Initialize the file groups - using the same estimation logic as that of record index
-    final int fileGroupCount = HoodieTableMetadataUtil.estimateFileGroupCount(RECORD_INDEX, records::count,
-        RECORD_INDEX_AVERAGE_RECORD_SIZE, dataWriteConfig.getGlobalRecordLevelIndexMinFileGroupCount(),
-        dataWriteConfig.getGlobalRecordLevelIndexMaxFileGroupCount(), dataWriteConfig.getRecordIndexGrowthFactor(),
-        dataWriteConfig.getRecordIndexMaxFileGroupSizeBytes());
-
-    return Pair.of(fileGroupCount, records);
-  }
-
-  private Lazy<List<Pair<String, FileSlice>>> getLazyLatestMergedPartitionFileSliceList() {
+  private Lazy<List<FileSliceAndPartition>> getLazyLatestMergedPartitionFileSliceList() {
     return Lazy.lazily(() -> {
       String latestInstant = dataMetaClient.getActiveTimeline().filterCompletedAndCompactionInstants().lastInstant()
           .map(HoodieInstant::requestedTime).orElse(SOLO_COMMIT_TIMESTAMP);
@@ -699,326 +541,14 @@ public abstract class HoodieBackedTableMetadataWriter<I, O> implements HoodieTab
         // Collect the list of latest file slices present in each partition
         List<String> partitions = metadata.getAllPartitionPaths();
         fsView.loadAllPartitions();
-        List<Pair<String, FileSlice>> partitionFileSlicePairs = new ArrayList<>();
+        List<FileSliceAndPartition> partitionFileSlicePairs = new ArrayList<>();
         partitions.forEach(partition -> fsView.getLatestMergedFileSlicesBeforeOrOn(partition, latestInstant)
-            .forEach(fs -> partitionFileSlicePairs.add(Pair.of(partition, fs))));
+            .forEach(fs -> partitionFileSlicePairs.add(FileSliceAndPartition.of(partition, fs))));
         return partitionFileSlicePairs;
       } catch (IOException e) {
         throw new HoodieIOException("Cannot get the latest merged file slices", e);
       }
     });
-  }
-
-  void initializeFilegroupsAndCommit(MetadataPartitionType partitionType,
-                                     String relativePartitionPath,
-                                     Pair<Integer, HoodieData<HoodieRecord>> fileGroupCountAndRecordsPair,
-                                     String instantTimeForPartition) throws IOException {
-    initializeFilegroupsAndCommit(partitionType, relativePartitionPath, fileGroupCountAndRecordsPair,
-        instantTimeForPartition, Collections.emptyList());
-  }
-
-  void initializeFilegroupsAndCommit(MetadataPartitionType partitionType,
-                                     String relativePartitionPath,
-                                     Pair<Integer, HoodieData<HoodieRecord>> fileGroupCountAndRecordsPair,
-                                     String instantTimeForPartition,
-                                     List<String> columnsToIndex) throws IOException {
-    String partitionTypeName = partitionType.name();
-    LOG.info("Initializing {} index with {} mappings", partitionTypeName, fileGroupCountAndRecordsPair.getKey());
-    HoodieTimer partitionInitTimer = HoodieTimer.start();
-
-    // Generate the file groups
-    final int fileGroupCount = fileGroupCountAndRecordsPair.getKey();
-    ValidationUtils.checkArgument(fileGroupCount > 0, "FileGroup count for MDT partition " + partitionTypeName + " should be > 0");
-    clearExistingMetadataPartition(relativePartitionPath);
-    initializeFileGroups(dataMetaClient, partitionType, instantTimeForPartition, fileGroupCount, relativePartitionPath, Option.empty());
-
-    // Perform the commit using bulkCommit
-    HoodieData<HoodieRecord> records = fileGroupCountAndRecordsPair.getValue();
-    bulkCommit(instantTimeForPartition, relativePartitionPath, records, new DefaultMetadataTableFileGroupIndexParser(fileGroupCount));
-    if (partitionType == COLUMN_STATS) {
-      // initialize Col Stats index definition
-      updateColumnsToIndexWithColStats(columnsToIndex);
-    }
-    dataMetaClient.getTableConfig().setMetadataPartitionState(dataMetaClient, relativePartitionPath, true);
-    // initialize the metadata reader again so the MDT partition can be read after initialization
-    initMetadataReader();
-    long totalInitTime = partitionInitTimer.endTimer();
-    LOG.info("Initializing {} index in metadata table took {} in ms", partitionTypeName, totalInitTime);
-  }
-
-  private void initializeFilegroupsAndCommitToRecordIndexPartition(String commitTimeForPartition,
-                                                                   Lazy<List<Pair<String, FileSlice>>> lazyLatestMergedPartitionFileSliceList, boolean isPartitionedRLI) throws IOException {
-    createRecordIndexDefinition(dataMetaClient, Collections.singletonMap(HoodieRecordIndex.IS_PARTITIONED_OPTION, String.valueOf(isPartitionedRLI)));
-    HoodieData<HoodieRecord> recordIndexRecords;
-    int fileGroupCount;
-    if (isPartitionedRLI) {
-      Pair<Integer, HoodieData<HoodieRecord>> fgCountAndRecords = initializeFilegroupsAndCommitToPartitionedRecordIndexPartition(commitTimeForPartition, lazyLatestMergedPartitionFileSliceList);
-      fileGroupCount = fgCountAndRecords.getKey();
-      recordIndexRecords = fgCountAndRecords.getValue();
-    } else {
-      Pair<Integer, HoodieData<HoodieRecord>> fgCountAndRecordIndexRecords = initializeRecordIndexPartition(lazyLatestMergedPartitionFileSliceList.get(),
-          dataWriteConfig.getMetadataConfig().getRecordIndexMaxParallelism());
-      fileGroupCount = fgCountAndRecordIndexRecords.getKey();
-      recordIndexRecords = fgCountAndRecordIndexRecords.getRight();
-      initializeFilegroupsAndCommit(RECORD_INDEX, RECORD_INDEX.getPartitionPath(), fgCountAndRecordIndexRecords, commitTimeForPartition);
-    }
-    // Validate record index after commit if validation is enabled
-    if (dataWriteConfig.getMetadataConfig().isRecordIndexInitializationValidationEnabled()) {
-      validateRecordIndex(recordIndexRecords, fileGroupCount);
-    }
-    recordIndexRecords.unpersist();
-  }
-
-  private Pair<Integer, HoodieData<HoodieRecord>> initializeFilegroupsAndCommitToPartitionedRecordIndexPartition(String commitTimeForPartition,
-                                                                              Lazy<List<Pair<String, FileSlice>>> lazyLatestMergedPartitionFileSliceList) throws IOException {
-    Map<String, List<Pair<String, FileSlice>>> partitionFileSlicePairsMap = lazyLatestMergedPartitionFileSliceList.get().stream()
-        .collect(Collectors.groupingBy(Pair::getKey));
-    Map<String, Pair<Integer, HoodieData<HoodieRecord>>> fileGroupCountAndRecordsPairMap = new HashMap<>(partitionFileSlicePairsMap.size());
-    int maxParallelismPerHudiPartition = partitionFileSlicePairsMap.isEmpty() ? 1 : Math.max(1, dataWriteConfig.getMetadataConfig().getRecordIndexMaxParallelism() / partitionFileSlicePairsMap.size());
-    for (String partition : partitionFileSlicePairsMap.keySet()) {
-      LOG.info("Initializing partitioned record index from data partition {}", partition);
-      fileGroupCountAndRecordsPairMap.put(partition, initializeRecordIndexPartition(partitionFileSlicePairsMap.get(partition), maxParallelismPerHudiPartition));
-    }
-
-    int totalFileGroupCount = fileGroupCountAndRecordsPairMap.values().stream().mapToInt(Pair::getLeft).sum();
-    if (LOG.isInfoEnabled()) {
-      LOG.info("Initializing partitioned record index with {} mappings", totalFileGroupCount);
-    }
-
-    HoodieTimer partitionInitTimer = HoodieTimer.start();
-
-    // Generate the file groups
-    HoodieData<HoodieRecord> records = engineContext.emptyHoodieData();
-    clearExistingMetadataPartition(RECORD_INDEX.getPartitionPath());
-    TreeMap<String, Integer> partitionSizes = new TreeMap<>();
-    for (String dataPartition : fileGroupCountAndRecordsPairMap.keySet()) {
-      Pair<Integer, HoodieData<HoodieRecord>> fileGroupCountAndRecordsPair = fileGroupCountAndRecordsPairMap.get(dataPartition);
-      ValidationUtils.checkArgument(fileGroupCountAndRecordsPair.getKey() > 0, "FileGroup count for partitioned RLI data partition " + dataPartition + " should be > 0");
-      partitionSizes.put(dataPartition, fileGroupCountAndRecordsPair.getKey());
-      initializeFileGroups(dataMetaClient, RECORD_INDEX, commitTimeForPartition, fileGroupCountAndRecordsPair.getKey(), RECORD_INDEX.getPartitionPath(), Option.of(dataPartition));
-      records = records.union(fileGroupCountAndRecordsPair.getValue());
-    }
-
-    // Perform the commit using bulkCommit
-    bulkCommit(commitTimeForPartition, RECORD_INDEX.getPartitionPath(), records,  new BucketizedMetadataTableFileGroupIndexParser(partitionSizes));
-    dataMetaClient.getTableConfig().setMetadataPartitionState(dataMetaClient, RECORD_INDEX.getPartitionPath(), true);
-    // initialize the metadata reader again so the MDT partition can be read after initialization
-    initMetadataReader();
-    long totalInitTime = partitionInitTimer.endTimer();
-    LOG.info("Initializing partitioned record index in metadata table took {} in ms", totalInitTime);
-    return Pair.of(totalFileGroupCount, records);
-  }
-
-  private Pair<Integer, HoodieData<HoodieRecord>> initializeRecordIndexPartition(
-      List<Pair<String, FileSlice>> latestMergedPartitionFileSliceList,
-      int recordIndexMaxParallelism) {
-    LOG.info("Initializing record index from {} file slices", latestMergedPartitionFileSliceList.size());
-    HoodieData<HoodieRecord> records = readRecordKeysFromFileSliceSnapshot(
-        engineContext,
-        latestMergedPartitionFileSliceList,
-        recordIndexMaxParallelism,
-        this.getClass().getSimpleName(),
-        dataMetaClient,
-        dataWriteConfig);
-
-    // Initialize the file groups
-    final int fileGroupCount = estimateFileGroupCount(records);
-    LOG.info("Initializing record index with {} file groups.", fileGroupCount);
-    return Pair.of(fileGroupCount, records);
-  }
-
-  private int estimateFileGroupCount(HoodieData<HoodieRecord> records) {
-    int minFileGroupCount;
-    int maxFileGroupCount;
-    if (dataWriteConfig.isRecordLevelIndexEnabled()) {
-      minFileGroupCount = dataWriteConfig.getRecordLevelIndexMinFileGroupCount();
-      maxFileGroupCount = dataWriteConfig.getRecordLevelIndexMaxFileGroupCount();
-    } else {
-      minFileGroupCount = dataWriteConfig.getGlobalRecordLevelIndexMinFileGroupCount();
-      maxFileGroupCount = dataWriteConfig.getGlobalRecordLevelIndexMaxFileGroupCount();
-    }
-    Supplier<Long> recordCountSupplier = () -> {
-      records.persist("MEMORY_AND_DISK_SER");
-      long count = records.count();
-      LOG.info("Initializing record index with {} mappings", count);
-      return count;
-    };
-    return HoodieTableMetadataUtil.estimateFileGroupCount(
-        MetadataPartitionType.RECORD_INDEX,
-        recordCountSupplier,
-        RECORD_INDEX_AVERAGE_RECORD_SIZE,
-        minFileGroupCount,
-        maxFileGroupCount,
-        dataWriteConfig.getRecordIndexGrowthFactor(),
-        dataWriteConfig.getRecordIndexMaxFileGroupSizeBytes()
-    );
-  }
-
-  /**
-   * Validates the record index after bootstrap by comparing the expected record count with the actual
-   * record count stored in the metadata table. The validation is performed in a distributed manner
-   * using the engine context to count records from HFiles in parallel.
-   *
-   * @param recordIndexRecords the HoodieData containing the expected records
-   * @param fileGroupCount the expected number of file groups
-   */
-  private void validateRecordIndex(HoodieData<HoodieRecord> recordIndexRecords, int fileGroupCount) {
-    String partitionName = MetadataPartitionType.RECORD_INDEX.getPartitionPath();
-    HoodieTableFileSystemView fsView = HoodieTableMetadataUtil.getFileSystemViewForMetadataTable(metadataMetaClient);
-    try {
-      // Use merged file slices to handle cases with pending compactions
-      List<FileSlice> fileSlices = HoodieTableMetadataUtil.getPartitionLatestMergedFileSlices(metadataMetaClient, fsView, partitionName);
-
-      // Filter to only file slices with base files and extract their storage paths
-      List<StoragePath> baseFilePaths = fileSlices.stream()
-          .filter(fs -> fs.getBaseFile().isPresent())
-          .map(fs -> fs.getBaseFile().get().getStoragePath())
-          .collect(Collectors.toList());
-
-      // Count records in a distributed manner using the engine context
-      long totalRecords = countRecordsInHFiles(baseFilePaths);
-      long expectedRecordCount = recordIndexRecords.count();
-
-      ValidationUtils.checkArgument(totalRecords == expectedRecordCount, "Record Count Validation failed with "
-          + totalRecords + " present in record index vs the expected " + expectedRecordCount);
-      LOG.info(String.format("Record index initialized on %d shards (expected = %d) with %d records (expected = %d)",
-          fileSlices.size(), fileGroupCount, totalRecords, expectedRecordCount));
-    } finally {
-      fsView.close();
-    }
-  }
-
-  /**
-   * Counts the total number of records in HFiles in a distributed manner.
-   *
-   * @param baseFilePaths list of storage paths to HFiles
-   * @return total number of records across all HFiles
-   */
-  private long countRecordsInHFiles(List<StoragePath> baseFilePaths) {
-    if (baseFilePaths.isEmpty()) {
-      return 0L;
-    }
-
-    int parallelism = Math.min(baseFilePaths.size(), dataWriteConfig.getMetadataConfig().getRecordIndexMaxParallelism());
-    StorageConfiguration<?> storageConfBroadcast = storageConf;
-    HoodieFileFormat baseFileFormat = metadataMetaClient.getTableConfig().getBaseFileFormat();
-
-    return engineContext.parallelize(baseFilePaths, parallelism)
-        .mapPartitions(pathIterator -> {
-          long count = 0L;
-          while (pathIterator.hasNext()) {
-            StoragePath path = pathIterator.next();
-            try {
-              HoodieStorage storage = HoodieStorageUtils.getStorage(path, storageConfBroadcast);
-              HoodieConfig readerConfig = new HoodieConfig();
-              HoodieAvroFileReader reader = (HoodieAvroFileReader) HoodieIOFactory.getIOFactory(storage)
-                  .getReaderFactory(HoodieRecord.HoodieRecordType.AVRO)
-                  .getFileReader(readerConfig, path, baseFileFormat, Option.empty());
-              try {
-                count += reader.getTotalRecords();
-              } finally {
-                reader.close();
-              }
-            } catch (IOException e) {
-              throw new HoodieIOException("Error reading total records from file " + path, e);
-            }
-          }
-          return Collections.singletonList(count).iterator();
-        }, true)
-        .collectAsList()
-        .stream()
-        .mapToLong(Long::longValue)
-        .sum();
-  }
-
-  /**
-   * Fetch record locations from FileSlice snapshot.
-   *
-   * @param engineContext             context ot use.
-   * @param partitionFileSlicePairs   list of pairs of partition and file slice.
-   * @param recordIndexMaxParallelism parallelism to use.
-   * @param activeModule              active module of interest.
-   * @param metaClient                metaclient instance to use.
-   * @param dataWriteConfig           write config to use.
-   * @return
-   */
-  private static <T> HoodieData<HoodieRecord> readRecordKeysFromFileSliceSnapshot(HoodieEngineContext engineContext,
-                                                                                  List<Pair<String, FileSlice>> partitionFileSlicePairs,
-                                                                                  int recordIndexMaxParallelism,
-                                                                                  String activeModule,
-                                                                                  HoodieTableMetaClient metaClient,
-                                                                                  HoodieWriteConfig dataWriteConfig) {
-    if (partitionFileSlicePairs.isEmpty()) {
-      return engineContext.emptyHoodieData();
-    }
-
-    Option<String> instantTime = metaClient.getActiveTimeline().getCommitsTimeline()
-        .filterCompletedInstants()
-        .lastInstant()
-        .map(HoodieInstant::requestedTime);
-    if (!instantTime.isPresent()) {
-      return engineContext.emptyHoodieData();
-    }
-
-    engineContext.setJobStatus(activeModule, "Record Index: reading record keys from " + partitionFileSlicePairs.size() + " file slices");
-    final int parallelism = Math.min(partitionFileSlicePairs.size(), recordIndexMaxParallelism);
-    ReaderContextFactory<T> readerContextFactory = engineContext.getReaderContextFactory(metaClient);
-    return engineContext.parallelize(partitionFileSlicePairs, parallelism).flatMap(partitionAndFileSlice -> {
-      final String partition = partitionAndFileSlice.getKey();
-      final FileSlice fileSlice = partitionAndFileSlice.getValue();
-      final String fileId = fileSlice.getFileId();
-      HoodieReaderContext<T> readerContext = readerContextFactory.getContext();
-      HoodieSchema dataSchema = HoodieSchemaCache.intern(HoodieSchemaUtils.addMetadataFields(HoodieSchema.parse(dataWriteConfig.getWriteSchema()), dataWriteConfig.allowOperationMetadataField()));
-      HoodieSchema requestedSchema = metaClient.getTableConfig().populateMetaFields() ? getRecordKeySchema()
-          : HoodieSchemaUtils.projectSchema(dataSchema, Arrays.asList(metaClient.getTableConfig().getRecordKeyFields().orElse(new String[0])));
-      Option<InternalSchema> internalSchemaOption = SerDeHelper.fromJson(dataWriteConfig.getInternalSchema());
-      HoodieFileGroupReader<T> fileGroupReader = HoodieFileGroupReader.<T>newBuilder()
-          .withReaderContext(readerContext)
-          .withHoodieTableMetaClient(metaClient)
-          .withFileSlice(fileSlice)
-          .withLatestCommitTime(instantTime.get())
-          .withDataSchema(dataSchema)
-          .withRequestedSchema(requestedSchema)
-          .withInternalSchema(internalSchemaOption)
-          .withShouldUseRecordPosition(false)
-          .withProps(metaClient.getTableConfig().getProps())
-          .build();
-      String baseFileInstantTime = fileSlice.getBaseInstantTime();
-      return new CloseableMappingIterator<>(fileGroupReader.getClosableIterator(), record -> {
-        String recordKey = readerContext.getRecordContext().getRecordKey(record, requestedSchema);
-        return HoodieMetadataPayload.createRecordIndexUpdate(recordKey, partition, fileId,
-            baseFileInstantTime, 0);
-      });
-    });
-  }
-
-  private Pair<Integer, HoodieData<HoodieRecord>> initializeFilesPartition(Map<String, Map<String, Long>> partitionIdToAllFilesMap) {
-    // FILES partition uses a single file group
-    final int fileGroupCount = 1;
-
-    Set<String> partitions = partitionIdToAllFilesMap.keySet();
-    final int totalDataFilesCount = partitionIdToAllFilesMap.values().stream().mapToInt(Map::size).sum();
-    LOG.info("Committing total {} partitions and {} files to metadata", partitions.size(), totalDataFilesCount);
-
-    // Record which saves the list of all partitions
-    HoodieRecord record = HoodieMetadataPayload.createPartitionListRecord(partitions);
-    HoodieData<HoodieRecord> allPartitionsRecord = engineContext.parallelize(Collections.singletonList(record), 1);
-    if (partitionIdToAllFilesMap.isEmpty()) {
-      return Pair.of(fileGroupCount, allPartitionsRecord);
-    }
-
-    // Records which save the file listing of each partition
-    engineContext.setJobStatus(this.getClass().getSimpleName(), "Creating records for metadata FILES partition");
-    HoodieData<HoodieRecord> fileListRecords = engineContext.parallelize(
-            new ArrayList<>(partitionIdToAllFilesMap.entrySet()), partitionIdToAllFilesMap.size())
-        .map(partitionInfo -> {
-          Map<String, Long> fileNameToSizeMap = partitionInfo.getValue();
-          return HoodieMetadataPayload.createPartitionFilesRecord(
-              partitionInfo.getKey(), fileNameToSizeMap, Collections.emptyList());
-        });
-    ValidationUtils.checkState(fileListRecords.count() == partitions.size());
-
-    return Pair.of(fileGroupCount, allPartitionsRecord.union(fileListRecords));
   }
 
   private Set<String> getPendingDataInstants(HoodieTableMetaClient dataMetaClient) {
@@ -1189,7 +719,7 @@ public abstract class HoodieBackedTableMetadataWriter<I, O> implements HoodieTab
     }, fileGroupFileIds.size());
   }
 
-  void clearExistingMetadataPartition(String relativePartitionPath) throws IOException {
+  private void clearExistingMetadataPartition(String relativePartitionPath) throws IOException {
     // Remove all existing file groups or leftover files in the partition
     final StoragePath partitionPath = new StoragePath(metadataWriteConfig.getBasePath(), relativePartitionPath);
     HoodieStorage storage = metadataMetaClient.getStorage();
@@ -1277,7 +807,7 @@ public abstract class HoodieBackedTableMetadataWriter<I, O> implements HoodieTab
     }
     // fallback to all enabled partitions if table config returned no partitions
     LOG.debug("There are no partitions to update according to table config. Falling back to enabled partition types in the write config.");
-    return getEnabledPartitionTypes().stream().map(MetadataPartitionType::getPartitionPath).collect(Collectors.toSet());
+    return enabledIndexerMap.keySet().stream().map(MetadataPartitionType::getPartitionPath).collect(Collectors.toSet());
   }
 
   public void buildMetadataPartitions(HoodieEngineContext engineContext, List<HoodieIndexPartitionInfo> indexPartitionInfos, String instantTime) throws IOException {
@@ -1295,7 +825,7 @@ public abstract class HoodieBackedTableMetadataWriter<I, O> implements HoodieTab
 
       // return early and populate enabledPartitionTypes correctly (check in initialCommit)
       MetadataPartitionType partitionType = fromPartitionPath(relativePartitionPath);
-      if (!enabledPartitionTypes.contains(partitionType)) {
+      if (!enabledIndexerMap.containsKey(partitionType)) {
         throw new HoodieIndexException(String.format("Indexing for metadata partition: %s is not enabled", partitionType));
       }
       partitionTypes.add(partitionType);
@@ -1306,7 +836,7 @@ public abstract class HoodieBackedTableMetadataWriter<I, O> implements HoodieTab
     dataMetaClient.getTableConfig().setMetadataPartitionsInflight(dataMetaClient, partitionPaths);
 
     // initialize partitions
-    initializeFromFilesystem(instantTime, partitionTypes, Option.empty());
+    initializeFromFilesystem(instantTime, partitionTypes.stream().collect(Collectors.toMap(Function.identity(), enabledIndexerMap::get)), Option.empty());
   }
 
   public void startCommit(String instantTime) {
@@ -1398,7 +928,7 @@ public abstract class HoodieBackedTableMetadataWriter<I, O> implements HoodieTab
   private Pair<List<MetadataPartitionType>, Set<String>> getStreamingMetadataPartitionsToUpdate() {
     Set<MetadataPartitionType> mdtPartitionsToTag = new HashSet<>();
     // Add record index
-    if (enabledPartitionTypes.contains(RECORD_INDEX)) {
+    if (enabledIndexerMap.containsKey(RECORD_INDEX)) {
       mdtPartitionsToTag.add(RECORD_INDEX);
     }
     // Add secondary indexes
@@ -1462,7 +992,7 @@ public abstract class HoodieBackedTableMetadataWriter<I, O> implements HoodieTab
   private Set<String> getNonStreamingMetadataPartitionsToUpdate() {
     Set<String> toReturn = new HashSet<>();
     Set<MetadataPartitionType> streamingMDTPartitions = new HashSet<>(getStreamingMetadataPartitionsToUpdate().getLeft());
-    for (MetadataPartitionType partitionType: enabledPartitionTypes) {
+    for (MetadataPartitionType partitionType: enabledIndexerMap.keySet()) {
       if (!streamingMDTPartitions.contains(partitionType)) {
         toReturn.add(partitionType.getPartitionPath());
       }
@@ -1679,7 +1209,7 @@ public abstract class HoodieBackedTableMetadataWriter<I, O> implements HoodieTab
     if (allWriteStats.isEmpty() || WriteOperationType.isCompactionOrClustering(commitMetadata.getOperationType())) {
       return engineContext.emptyHoodieData();
     }
-    HoodieIndexDefinition indexDefinition = getIndexDefinition(indexPartition);
+    HoodieIndexDefinition indexDefinition = HoodieTableMetadataUtil.getHoodieIndexDefinition(indexPartition, dataMetaClient);
     return convertWriteStatsToSecondaryIndexRecords(allWriteStats, instantTime, indexDefinition, dataWriteConfig.getMetadataConfig(), dataMetaClient, engineContext, dataWriteConfig);
   }
 
@@ -1692,8 +1222,8 @@ public abstract class HoodieBackedTableMetadataWriter<I, O> implements HoodieTab
   @Override
   public void update(HoodieCleanMetadata cleanMetadata, String instantTime) {
     mayBeReinitMetadataReader();
-    processAndCommit(instantTime, () -> HoodieTableMetadataUtil.convertMetadataToRecords(engineContext,
-        cleanMetadata, instantTime, dataMetaClient, dataWriteConfig.getMetadataConfig(), enabledPartitionTypes,
+    processAndCommit(instantTime, () -> HoodieMetadataWriteUtils.convertMetadataToRecords(engineContext,
+        cleanMetadata, instantTime, dataMetaClient, dataWriteConfig.getMetadataConfig(), enabledIndexerMap,
         dataWriteConfig.getBloomIndexParallelism(), Option.of(dataWriteConfig.getRecordMerger().getRecordType())));
     closeInternal();
   }
@@ -1745,7 +1275,7 @@ public abstract class HoodieBackedTableMetadataWriter<I, O> implements HoodieTab
     // is required to bring back those cleans.
     try {
       initMetadataReader();
-      Map<String, Map<String, Long>> partitionFilesToAdd = new HashMap<>();
+      Map<String, List<FileInfo>> partitionFilesToAdd = new HashMap<>();
       Map<String, List<String>> partitionFilesToDelete = new HashMap<>();
       List<String> partitionsToDelete = new ArrayList<>();
       fetchOutofSyncFilesRecordsFromMetadataTable(dirInfoMap, partitionFilesToAdd, partitionFilesToDelete, partitionsToDelete);
@@ -1775,7 +1305,7 @@ public abstract class HoodieBackedTableMetadataWriter<I, O> implements HoodieTab
     }
   }
 
-  static Map<String, HoodieData<HoodieRecord>> convertToColumnStatsRecord(Map<String, Map<String, Long>> partitionFilesToAdd,
+  static Map<String, HoodieData<HoodieRecord>> convertToColumnStatsRecord(Map<String, List<FileInfo>> partitionFilesToAdd,
                                                                           Map<String, List<String>> partitionFilesToDelete,
                                                                           HoodieEngineContext engineContext,
                                                                           HoodieTableMetaClient dataMetaClient,
@@ -1801,7 +1331,6 @@ public abstract class HoodieBackedTableMetadataWriter<I, O> implements HoodieTab
     HoodieData<HoodieRecord> records = HoodieTableMetadataUtil.convertFilesToColumnStatsRecords(
         engineContext, partitionFilesToDelete,
         partitionFilesToAdd, dataMetaClient,
-        metadataConfig,
         columnStatsIndexParallelism,
         metadataConfig.getMaxReaderBufferSize(),
         columnsToIndex);
@@ -2272,7 +1801,7 @@ public abstract class HoodieBackedTableMetadataWriter<I, O> implements HoodieTab
     return true;
   }
 
-  private void fetchOutofSyncFilesRecordsFromMetadataTable(Map<String, DirectoryInfo> dirInfoMap, Map<String, Map<String, Long>> partitionFilesToAdd,
+  private void fetchOutofSyncFilesRecordsFromMetadataTable(Map<String, DirectoryInfo> dirInfoMap, Map<String, List<FileInfo>> partitionFilesToAdd,
                                                            Map<String, List<String>> partitionFilesToDelete, List<String> partitionsToDelete) throws IOException {
 
     for (String partition : metadata.fetchAllPartitionPaths()) {
@@ -2296,11 +1825,11 @@ public abstract class HoodieBackedTableMetadataWriter<I, O> implements HoodieTab
         List<String> mdtFiles = metadataFiles.stream().map(mdtFile -> mdtFile.getPath().getName()).collect(Collectors.toList());
         List<String> filesDeleted = metadataFiles.stream().map(f -> f.getPath().getName())
             .filter(n -> !fsFiles.containsKey(n)).collect(Collectors.toList());
-        Map<String, Long> filesToAdd = new HashMap<>();
+        List<FileInfo> filesToAdd = new ArrayList<>();
         // new files could be added to DT due to restore that just happened which may not be tracked in RestoreMetadata.
         dirInfoMap.get(partition).getFilenameToSizeMap().forEach((k, v) -> {
           if (!mdtFiles.contains(k)) {
-            filesToAdd.put(k, v);
+            filesToAdd.add(FileInfo.of(k, v));
           }
         });
         if (!filesToAdd.isEmpty()) {

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/HoodieBackedTableMetadataWriterTableVersionSix.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/HoodieBackedTableMetadataWriterTableVersionSix.java
@@ -21,8 +21,10 @@ package org.apache.hudi.metadata;
 import org.apache.hudi.avro.model.HoodieRollbackMetadata;
 import org.apache.hudi.client.BaseHoodieWriteClient;
 import org.apache.hudi.common.config.HoodieMetadataConfig;
+import org.apache.hudi.common.data.HoodieData;
 import org.apache.hudi.common.engine.HoodieEngineContext;
 import org.apache.hudi.common.model.HoodieFailedWritesCleaningPolicy;
+import org.apache.hudi.common.model.HoodieRecord;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.common.table.timeline.HoodieActiveTimeline;
 import org.apache.hudi.common.table.timeline.HoodieInstant;
@@ -34,9 +36,11 @@ import org.apache.hudi.common.util.collection.Pair;
 import org.apache.hudi.config.HoodieWriteConfig;
 import org.apache.hudi.exception.HoodieMetadataException;
 import org.apache.hudi.metadata.index.ExpressionIndexRecordGenerator;
+import org.apache.hudi.metadata.index.model.IndexPartitionAndRecords;
 import org.apache.hudi.storage.StorageConfiguration;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -225,7 +229,7 @@ public abstract class HoodieBackedTableMetadataWriterTableVersionSix<I, O> exten
       // a. any log files as part of RB commit metadata that was added
       // b. log files added by the commit in DT being rolled back. By rolled back, we mean, a rollback block will be added and does not mean it will be deleted.
       // both above list should only be added to FILES partition.
-      processAndCommit(instantTime, () -> HoodieTableMetadataUtil.convertMetadataToRecords(engineContext, dataMetaClient, rollbackMetadata, instantTime));
+      processAndCommit(instantTime, () -> convertMetadataToRecords(engineContext, rollbackMetadata, instantTime));
 
       String rollbackInstantTime = createRollbackTimestamp(instantTime);
       if (metadataMetaClient.getActiveTimeline().containsInstant(deltaCommitInstant)) {
@@ -239,6 +243,22 @@ public abstract class HoodieBackedTableMetadataWriterTableVersionSix<I, O> exten
       }
       closeInternal();
     }
+  }
+
+  /**
+   * Convert rollback action metadata to metadata table records.
+   * <p>
+   * We only need to handle FILES partition here as HUDI rollbacks on MOR table may end up adding a new log file. All other partitions
+   * are handled by actual rollback of the deltacommit which added records to those partitions.
+   */
+  public static List<IndexPartitionAndRecords> convertMetadataToRecords(
+      HoodieEngineContext engineContext, HoodieRollbackMetadata rollbackMetadata, String instantTime) {
+
+    List<HoodieRecord> filesPartitionRecords = HoodieTableMetadataUtil.convertMetadataToRollbackRecords(rollbackMetadata, instantTime);
+    final HoodieData<HoodieRecord> rollbackRecordsRDD = filesPartitionRecords.isEmpty() ? engineContext.emptyHoodieData()
+        : engineContext.parallelize(filesPartitionRecords, filesPartitionRecords.size());
+
+    return Collections.singletonList(IndexPartitionAndRecords.of(MetadataPartitionType.FILES.getPartitionPath(), rollbackRecordsRDD));
   }
 
   private void validateRollbackVersionSix(

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/HoodieBackedTableMetadataWriterTableVersionSix.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/HoodieBackedTableMetadataWriterTableVersionSix.java
@@ -33,6 +33,7 @@ import org.apache.hudi.common.util.Option;
 import org.apache.hudi.common.util.collection.Pair;
 import org.apache.hudi.config.HoodieWriteConfig;
 import org.apache.hudi.exception.HoodieMetadataException;
+import org.apache.hudi.metadata.index.ExpressionIndexRecordGenerator;
 import org.apache.hudi.storage.StorageConfiguration;
 
 import java.util.Arrays;
@@ -72,17 +73,9 @@ public abstract class HoodieBackedTableMetadataWriterTableVersionSix<I, O> exten
                                                            HoodieWriteConfig writeConfig,
                                                            HoodieFailedWritesCleaningPolicy failedWritesCleaningPolicy,
                                                            HoodieEngineContext engineContext,
+                                                           ExpressionIndexRecordGenerator expressionIndexRecordGenerator,
                                                            Option<String> inflightInstantTimestamp) {
-    super(storageConf, writeConfig, failedWritesCleaningPolicy, engineContext, inflightInstantTimestamp);
-  }
-
-  @Override
-  List<MetadataPartitionType> getEnabledPartitions(HoodieMetadataConfig metadataConfig, HoodieTableMetaClient metaClient) {
-    return MetadataPartitionType.getEnabledPartitions(metadataConfig, metaClient).stream()
-        .filter(partition -> !partition.equals(MetadataPartitionType.SECONDARY_INDEX))
-        .filter(partition -> !partition.equals(MetadataPartitionType.EXPRESSION_INDEX))
-        .filter(partition -> !partition.equals(MetadataPartitionType.PARTITION_STATS))
-        .collect(Collectors.toList());
+    super(storageConf, writeConfig, failedWritesCleaningPolicy, engineContext, expressionIndexRecordGenerator, inflightInstantTimestamp);
   }
 
   @Override

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/HoodieMetadataWriteUtils.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/HoodieMetadataWriteUtils.java
@@ -18,6 +18,7 @@
 
 package org.apache.hudi.metadata;
 
+import org.apache.hudi.avro.model.HoodieCleanMetadata;
 import org.apache.hudi.avro.model.HoodieMetadataRecord;
 import org.apache.hudi.client.FailOnFirstErrorWriteStatus;
 import org.apache.hudi.client.transaction.lock.InProcessLockProvider;
@@ -73,6 +74,7 @@ import org.apache.hudi.config.metrics.HoodieMetricsM3Config;
 import org.apache.hudi.config.metrics.HoodieMetricsPrometheusConfig;
 import org.apache.hudi.exception.HoodieException;
 import org.apache.hudi.exception.HoodieMetadataException;
+import org.apache.hudi.metadata.index.Indexer;
 import org.apache.hudi.stats.HoodieColumnRangeMetadata;
 import org.apache.hudi.storage.StoragePath;
 import org.apache.hudi.storage.StoragePathInfo;
@@ -106,6 +108,7 @@ import static org.apache.hudi.metadata.HoodieTableMetadata.METADATA_TABLE_NAME_S
 import static org.apache.hudi.metadata.HoodieTableMetadataUtil.PARTITION_NAME_PARTITION_STATS;
 import static org.apache.hudi.metadata.HoodieTableMetadataUtil.convertMetadataToBloomFilterRecords;
 import static org.apache.hudi.metadata.HoodieTableMetadataUtil.convertMetadataToColumnStatsRecords;
+import static org.apache.hudi.metadata.HoodieTableMetadataUtil.convertMetadataToExpressionIndexRecords;
 import static org.apache.hudi.metadata.HoodieTableMetadataUtil.convertMetadataToFilesPartitionRecords;
 import static org.apache.hudi.metadata.HoodieTableMetadataUtil.convertMetadataToPartitionStatsRecords;
 import static org.apache.hudi.metadata.HoodieTableMetadataUtil.convertMetadataToRecordIndexRecords;
@@ -363,6 +366,41 @@ public class HoodieMetadataWriteUtils {
   }
 
   /**
+   * Convert the clean action to metadata records.
+   */
+  public static Map<String, HoodieData<HoodieRecord>> convertMetadataToRecords(HoodieEngineContext engineContext,
+                                                                               HoodieCleanMetadata cleanMetadata,
+                                                                               String instantTime,
+                                                                               HoodieTableMetaClient dataMetaClient,
+                                                                               HoodieMetadataConfig metadataConfig,
+                                                                               Map<MetadataPartitionType, Indexer> enabledIndexBuilderMap,
+                                                                               int bloomIndexParallelism,
+                                                                               Option<HoodieRecord.HoodieRecordType> recordTypeOpt) {
+    final Map<String, HoodieData<HoodieRecord>> partitionToRecordsMap = new HashMap<>();
+    final HoodieData<HoodieRecord> filesPartitionRecordsRDD = engineContext.parallelize(
+        convertMetadataToFilesPartitionRecords(cleanMetadata, instantTime), 1);
+    partitionToRecordsMap.put(MetadataPartitionType.FILES.getPartitionPath(), filesPartitionRecordsRDD);
+    if (enabledIndexBuilderMap.containsKey(MetadataPartitionType.BLOOM_FILTERS)) {
+      final HoodieData<HoodieRecord> metadataBloomFilterRecordsRDD =
+          convertMetadataToBloomFilterRecords(cleanMetadata, engineContext, instantTime, bloomIndexParallelism);
+      partitionToRecordsMap.put(MetadataPartitionType.BLOOM_FILTERS.getPartitionPath(), metadataBloomFilterRecordsRDD);
+    }
+
+    if (enabledIndexBuilderMap.containsKey(MetadataPartitionType.COLUMN_STATS)) {
+      final HoodieData<HoodieRecord> metadataColumnStatsRDD =
+          convertMetadataToColumnStatsRecords(cleanMetadata, engineContext,
+              dataMetaClient, metadataConfig, recordTypeOpt);
+      partitionToRecordsMap.put(MetadataPartitionType.COLUMN_STATS.getPartitionPath(), metadataColumnStatsRDD);
+    }
+    if (enabledIndexBuilderMap.containsKey(MetadataPartitionType.EXPRESSION_INDEX)) {
+      convertMetadataToExpressionIndexRecords(engineContext, cleanMetadata, instantTime, dataMetaClient, metadataConfig, bloomIndexParallelism, partitionToRecordsMap,
+          recordTypeOpt);
+    }
+
+    return partitionToRecordsMap;
+  }
+
+  /**
    * Convert commit action to metadata records for the enabled partition types.
    *
    * @param context                     - Engine context to use
@@ -370,12 +408,14 @@ public class HoodieMetadataWriteUtils {
    * @param commitMetadata              - Commit action metadata
    * @param instantTime                 - Action instant time
    * @param dataMetaClient              - HoodieTableMetaClient for data
-   * @param tableMetadata
+   * @param tableMetadata               - metadata table reader
    * @param metadataConfig              - HoodieMetadataConfig
    * @param enabledPartitionTypes       - Set of enabled MDT partitions to update
    * @param bloomFilterType             - Type of generated bloom filter records
    * @param bloomIndexParallelism       - Parallelism for bloom filter record generation
-   * @param enableOptimizeLogBlocksScan - flag used to enable scanInternalV2 for log blocks in data table
+   * @param writesFileIdEncoding        - file id encoding used while generating record index records
+   * @param engineType                  - execution engine type
+   * @param recordTypeOpt               - record type override for generated metadata records
    * @return Map of partition to metadata records for the commit action
    */
   public static Map<String, HoodieData<HoodieRecord>> convertMetadataToRecords(HoodieEngineContext context, HoodieWriteConfig dataWriteConfig, HoodieCommitMetadata commitMetadata,

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/HoodieMetadataWriteUtils.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/HoodieMetadataWriteUtils.java
@@ -18,7 +18,6 @@
 
 package org.apache.hudi.metadata;
 
-import org.apache.hudi.avro.model.HoodieCleanMetadata;
 import org.apache.hudi.avro.model.HoodieMetadataRecord;
 import org.apache.hudi.client.FailOnFirstErrorWriteStatus;
 import org.apache.hudi.client.transaction.lock.InProcessLockProvider;
@@ -26,28 +25,17 @@ import org.apache.hudi.common.config.HoodieMetadataConfig;
 import org.apache.hudi.common.config.HoodieReaderConfig;
 import org.apache.hudi.common.config.HoodieStorageConfig;
 import org.apache.hudi.common.config.RecordMergeMode;
-import org.apache.hudi.common.data.HoodieData;
-import org.apache.hudi.common.data.HoodieListData;
-import org.apache.hudi.common.data.HoodiePairData;
-import org.apache.hudi.common.engine.EngineType;
-import org.apache.hudi.common.engine.HoodieEngineContext;
 import org.apache.hudi.common.engine.HoodieLocalEngineContext;
 import org.apache.hudi.common.fs.ConsistencyGuardConfig;
 import org.apache.hudi.common.model.HoodieAvroRecordMerger;
 import org.apache.hudi.common.model.HoodieBaseFile;
 import org.apache.hudi.common.model.HoodieCleaningPolicy;
-import org.apache.hudi.common.model.HoodieCommitMetadata;
 import org.apache.hudi.common.model.HoodieFailedWritesCleaningPolicy;
 import org.apache.hudi.common.model.HoodieLogFile;
-import org.apache.hudi.common.model.HoodieRecord;
 import org.apache.hudi.common.model.HoodieRecordMerger;
-import org.apache.hudi.common.model.HoodieReplaceCommitMetadata;
 import org.apache.hudi.common.model.HoodieTableType;
 import org.apache.hudi.common.model.HoodieWriteStat;
 import org.apache.hudi.common.model.WriteConcurrencyMode;
-import org.apache.hudi.common.model.WriteOperationType;
-import org.apache.hudi.common.schema.HoodieSchema;
-import org.apache.hudi.common.schema.HoodieSchemaUtils;
 import org.apache.hudi.common.table.HoodieTableConfig;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.common.table.HoodieTableVersion;
@@ -59,7 +47,6 @@ import org.apache.hudi.common.table.view.SyncableFileSystemView;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.common.util.ValidationUtils;
 import org.apache.hudi.common.util.VisibleForTesting;
-import org.apache.hudi.common.util.collection.Pair;
 import org.apache.hudi.config.HoodieArchivalConfig;
 import org.apache.hudi.config.HoodieCleanConfig;
 import org.apache.hudi.config.HoodieCompactionConfig;
@@ -72,23 +59,17 @@ import org.apache.hudi.config.metrics.HoodieMetricsGraphiteConfig;
 import org.apache.hudi.config.metrics.HoodieMetricsJmxConfig;
 import org.apache.hudi.config.metrics.HoodieMetricsM3Config;
 import org.apache.hudi.config.metrics.HoodieMetricsPrometheusConfig;
-import org.apache.hudi.exception.HoodieException;
 import org.apache.hudi.exception.HoodieMetadataException;
-import org.apache.hudi.metadata.index.Indexer;
 import org.apache.hudi.stats.HoodieColumnRangeMetadata;
 import org.apache.hudi.storage.StoragePath;
 import org.apache.hudi.storage.StoragePathInfo;
 import org.apache.hudi.table.action.compact.CompactionTriggerStrategy;
 import org.apache.hudi.table.action.compact.strategy.UnBoundedCompactionStrategy;
-import org.apache.hudi.util.Lazy;
 
 import lombok.extern.slf4j.Slf4j;
 
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.Collections;
-import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -101,20 +82,8 @@ import static java.util.stream.Collectors.toList;
 import static org.apache.hudi.common.config.HoodieMetadataConfig.DEFAULT_METADATA_ASYNC_CLEAN;
 import static org.apache.hudi.common.config.HoodieMetadataConfig.DEFAULT_METADATA_CLEANER_COMMITS_RETAINED;
 import static org.apache.hudi.common.config.HoodieMetadataConfig.DEFAULT_METADATA_POPULATE_META_FIELDS;
-import static org.apache.hudi.common.util.StringUtils.isNullOrEmpty;
 import static org.apache.hudi.common.util.StringUtils.nonEmpty;
-import static org.apache.hudi.common.util.ValidationUtils.checkState;
 import static org.apache.hudi.metadata.HoodieTableMetadata.METADATA_TABLE_NAME_SUFFIX;
-import static org.apache.hudi.metadata.HoodieTableMetadataUtil.PARTITION_NAME_PARTITION_STATS;
-import static org.apache.hudi.metadata.HoodieTableMetadataUtil.convertMetadataToBloomFilterRecords;
-import static org.apache.hudi.metadata.HoodieTableMetadataUtil.convertMetadataToColumnStatsRecords;
-import static org.apache.hudi.metadata.HoodieTableMetadataUtil.convertMetadataToExpressionIndexRecords;
-import static org.apache.hudi.metadata.HoodieTableMetadataUtil.convertMetadataToFilesPartitionRecords;
-import static org.apache.hudi.metadata.HoodieTableMetadataUtil.convertMetadataToPartitionStatsRecords;
-import static org.apache.hudi.metadata.HoodieTableMetadataUtil.convertMetadataToRecordIndexRecords;
-import static org.apache.hudi.metadata.HoodieTableMetadataUtil.existingIndexVersionOrDefault;
-import static org.apache.hudi.metadata.HoodieTableMetadataUtil.generateColumnStatsKeys;
-import static org.apache.hudi.metadata.HoodieTableMetadataUtil.getColumnsToIndex;
 import static org.apache.hudi.metadata.HoodieTableMetadataUtil.translateWriteStatToFileStats;
 
 /**
@@ -363,196 +332,6 @@ public class HoodieMetadataWriteUtils {
     ValidationUtils.checkArgument(!metadataWriteConfig.isMetadataTableEnabled(), "File listing cannot be used for Metadata Table");
 
     return metadataWriteConfig;
-  }
-
-  /**
-   * Convert the clean action to metadata records.
-   */
-  public static Map<String, HoodieData<HoodieRecord>> convertMetadataToRecords(HoodieEngineContext engineContext,
-                                                                               HoodieCleanMetadata cleanMetadata,
-                                                                               String instantTime,
-                                                                               HoodieTableMetaClient dataMetaClient,
-                                                                               HoodieMetadataConfig metadataConfig,
-                                                                               Map<MetadataPartitionType, Indexer> enabledIndexBuilderMap,
-                                                                               int bloomIndexParallelism,
-                                                                               Option<HoodieRecord.HoodieRecordType> recordTypeOpt) {
-    final Map<String, HoodieData<HoodieRecord>> partitionToRecordsMap = new HashMap<>();
-    final HoodieData<HoodieRecord> filesPartitionRecordsRDD = engineContext.parallelize(
-        convertMetadataToFilesPartitionRecords(cleanMetadata, instantTime), 1);
-    partitionToRecordsMap.put(MetadataPartitionType.FILES.getPartitionPath(), filesPartitionRecordsRDD);
-    if (enabledIndexBuilderMap.containsKey(MetadataPartitionType.BLOOM_FILTERS)) {
-      final HoodieData<HoodieRecord> metadataBloomFilterRecordsRDD =
-          convertMetadataToBloomFilterRecords(cleanMetadata, engineContext, instantTime, bloomIndexParallelism);
-      partitionToRecordsMap.put(MetadataPartitionType.BLOOM_FILTERS.getPartitionPath(), metadataBloomFilterRecordsRDD);
-    }
-
-    if (enabledIndexBuilderMap.containsKey(MetadataPartitionType.COLUMN_STATS)) {
-      final HoodieData<HoodieRecord> metadataColumnStatsRDD =
-          convertMetadataToColumnStatsRecords(cleanMetadata, engineContext,
-              dataMetaClient, metadataConfig, recordTypeOpt);
-      partitionToRecordsMap.put(MetadataPartitionType.COLUMN_STATS.getPartitionPath(), metadataColumnStatsRDD);
-    }
-    if (enabledIndexBuilderMap.containsKey(MetadataPartitionType.EXPRESSION_INDEX)) {
-      convertMetadataToExpressionIndexRecords(engineContext, cleanMetadata, instantTime, dataMetaClient, metadataConfig, bloomIndexParallelism, partitionToRecordsMap,
-          recordTypeOpt);
-    }
-
-    return partitionToRecordsMap;
-  }
-
-  /**
-   * Convert commit action to metadata records for the enabled partition types.
-   *
-   * @param context                     - Engine context to use
-   * @param dataWriteConfig             - Hudi configs
-   * @param commitMetadata              - Commit action metadata
-   * @param instantTime                 - Action instant time
-   * @param dataMetaClient              - HoodieTableMetaClient for data
-   * @param tableMetadata               - metadata table reader
-   * @param metadataConfig              - HoodieMetadataConfig
-   * @param enabledPartitionTypes       - Set of enabled MDT partitions to update
-   * @param bloomFilterType             - Type of generated bloom filter records
-   * @param bloomIndexParallelism       - Parallelism for bloom filter record generation
-   * @param writesFileIdEncoding        - file id encoding used while generating record index records
-   * @param engineType                  - execution engine type
-   * @param recordTypeOpt               - record type override for generated metadata records
-   * @return Map of partition to metadata records for the commit action
-   */
-  public static Map<String, HoodieData<HoodieRecord>> convertMetadataToRecords(HoodieEngineContext context, HoodieWriteConfig dataWriteConfig, HoodieCommitMetadata commitMetadata,
-                                                                               String instantTime, HoodieTableMetaClient dataMetaClient, HoodieTableMetadata tableMetadata,
-                                                                               HoodieMetadataConfig metadataConfig, Set<String> enabledPartitionTypes, String bloomFilterType,
-                                                                               int bloomIndexParallelism, int writesFileIdEncoding, EngineType engineType,
-                                                                               Option<HoodieRecord.HoodieRecordType> recordTypeOpt) {
-    final Map<String, HoodieData<HoodieRecord>> partitionToRecordsMap = new HashMap<>();
-    final HoodieData<HoodieRecord> filesPartitionRecordsRDD = context.parallelize(
-        convertMetadataToFilesPartitionRecords(commitMetadata, instantTime), 1);
-    partitionToRecordsMap.put(MetadataPartitionType.FILES.getPartitionPath(), filesPartitionRecordsRDD);
-
-    if (enabledPartitionTypes.contains(MetadataPartitionType.BLOOM_FILTERS.getPartitionPath())) {
-      final HoodieData<HoodieRecord> metadataBloomFilterRecords = convertMetadataToBloomFilterRecords(
-          context, dataWriteConfig, commitMetadata, instantTime, dataMetaClient, bloomFilterType, bloomIndexParallelism);
-      partitionToRecordsMap.put(MetadataPartitionType.BLOOM_FILTERS.getPartitionPath(), metadataBloomFilterRecords);
-    }
-
-    if (enabledPartitionTypes.contains(MetadataPartitionType.COLUMN_STATS.getPartitionPath())) {
-      final HoodieData<HoodieRecord> metadataColumnStatsRDD = convertMetadataToColumnStatsRecords(commitMetadata, context,
-          dataMetaClient, metadataConfig, recordTypeOpt);
-      partitionToRecordsMap.put(MetadataPartitionType.COLUMN_STATS.getPartitionPath(), metadataColumnStatsRDD);
-    }
-    if (enabledPartitionTypes.contains(MetadataPartitionType.PARTITION_STATS.getPartitionPath())) {
-      checkState(MetadataPartitionType.COLUMN_STATS.isMetadataPartitionAvailable(dataMetaClient),
-          "Column stats partition must be enabled to generate partition stats. Please enable: " + HoodieMetadataConfig.ENABLE_METADATA_INDEX_COLUMN_STATS.key());
-      // Generate Hoodie Pair data of partition name and list of column range metadata for all the files in that partition
-      boolean isDeletePartition = commitMetadata.getOperationType().equals(WriteOperationType.DELETE_PARTITION);
-      final HoodieData<HoodieRecord> partitionStatsRDD = convertMetadataToPartitionStatRecords(
-          commitMetadata, instantTime, context, dataWriteConfig, dataMetaClient, tableMetadata, metadataConfig, recordTypeOpt, isDeletePartition);
-      partitionToRecordsMap.put(MetadataPartitionType.PARTITION_STATS.getPartitionPath(), partitionStatsRDD);
-    }
-    if (enabledPartitionTypes.contains(MetadataPartitionType.RECORD_INDEX.getPartitionPath())) {
-      partitionToRecordsMap.put(MetadataPartitionType.RECORD_INDEX.getPartitionPath(), convertMetadataToRecordIndexRecords(context, commitMetadata, metadataConfig,
-          dataMetaClient, writesFileIdEncoding, instantTime, engineType));
-    }
-    return partitionToRecordsMap;
-  }
-
-  public static HoodieData<HoodieRecord> convertMetadataToPartitionStatRecords(HoodieCommitMetadata commitMetadata, String instantTime,
-                                                                               HoodieEngineContext engineContext, HoodieWriteConfig dataWriteConfig,
-                                                                               HoodieTableMetaClient dataMetaClient,
-                                                                               HoodieTableMetadata tableMetadata, HoodieMetadataConfig metadataConfig,
-                                                                               Option<HoodieRecord.HoodieRecordType> recordTypeOpt, boolean isDeletePartition) {
-    try {
-      Option<HoodieSchema> writerSchema =
-          Option.ofNullable(commitMetadata.getMetadata(HoodieCommitMetadata.SCHEMA_KEY))
-              .flatMap(writerSchemaStr ->
-                  isNullOrEmpty(writerSchemaStr)
-                      ? Option.empty()
-                      : Option.of(HoodieSchema.parse(writerSchemaStr)));
-      HoodieTableConfig tableConfig = dataMetaClient.getTableConfig();
-      Option<HoodieSchema> tableSchema = writerSchema.map(schema -> tableConfig.populateMetaFields() ? HoodieSchemaUtils.addMetadataFields(schema) : schema);
-
-      if (tableSchema.isEmpty()) {
-        return engineContext.emptyHoodieData();
-      }
-      HoodieIndexVersion partitionStatsIndexVersion = existingIndexVersionOrDefault(PARTITION_NAME_PARTITION_STATS, dataMetaClient);
-      Lazy<Option<HoodieSchema>> writerSchemaOpt = Lazy.eagerly(tableSchema);
-      Map<String, HoodieSchema> columnsToIndexSchemaMap = getColumnsToIndex(dataMetaClient.getTableConfig(), metadataConfig, writerSchemaOpt, false, recordTypeOpt, partitionStatsIndexVersion);
-      if (columnsToIndexSchemaMap.isEmpty()) {
-        return engineContext.emptyHoodieData();
-      }
-
-      // if this is DELETE_PARTITION, then create delete metadata payload for all columns for partition_stats
-      if (isDeletePartition) {
-        HoodieReplaceCommitMetadata replaceCommitMetadata = (HoodieReplaceCommitMetadata) commitMetadata;
-        Map<String, List<String>> partitionToReplaceFileIds = replaceCommitMetadata.getPartitionToReplaceFileIds();
-        List<String> partitionsToDelete = new ArrayList<>(partitionToReplaceFileIds.keySet());
-        if (partitionToReplaceFileIds.isEmpty()) {
-          return engineContext.emptyHoodieData();
-        }
-        return engineContext.parallelize(partitionsToDelete, partitionsToDelete.size()).flatMap(partition -> {
-          Stream<HoodieRecord> columnRangeMetadata = columnsToIndexSchemaMap.keySet().stream()
-              .flatMap(column -> HoodieMetadataPayload.createPartitionStatsRecords(
-                  partition,
-                  Collections.singletonList(HoodieColumnRangeMetadata.stub("", column, partitionStatsIndexVersion)),
-                  true, true, Option.empty()));
-          return columnRangeMetadata.iterator();
-        });
-      }
-
-      // In this function we fetch column range metadata for all new files part of commit metadata along with all the other files
-      // of the affected partitions. The column range metadata is grouped by partition name to generate HoodiePairData of partition name
-      // and list of column range metadata for that partition files. This pair data is then used to generate partition stat records.
-      List<HoodieWriteStat> allWriteStats = commitMetadata.getPartitionToWriteStats().values().stream()
-          .flatMap(Collection::stream).collect(Collectors.toList());
-      if (allWriteStats.isEmpty()) {
-        return engineContext.emptyHoodieData();
-      }
-
-      List<String> colsToIndex = new ArrayList<>(columnsToIndexSchemaMap.keySet());
-      log.debug("Indexing following columns for partition stats index: {}", columnsToIndexSchemaMap.keySet());
-      // Group by partitionPath and then gather write stats lists,
-      // where each inner list contains HoodieWriteStat objects that have the same partitionPath.
-      List<List<HoodieWriteStat>> partitionedWriteStats = new ArrayList<>(allWriteStats.stream()
-          .collect(Collectors.groupingBy(HoodieWriteStat::getPartitionPath))
-          .values());
-      Map<String, Set<String>> fileGroupIdsToReplaceMap = (commitMetadata instanceof HoodieReplaceCommitMetadata)
-          ? ((HoodieReplaceCommitMetadata) commitMetadata).getPartitionToReplaceFileIds()
-          .entrySet().stream().collect(Collectors.toMap(Map.Entry::getKey, e -> new HashSet<>(e.getValue())))
-          : Collections.emptyMap();
-
-      int parallelism = Math.max(Math.min(partitionedWriteStats.size(), metadataConfig.getPartitionStatsIndexParallelism()), 1);
-      String maxInstantTime = getMaxInstantTime(dataMetaClient, instantTime);
-      HoodiePairData<String, List<HoodieColumnRangeMetadata<Comparable>>> columnRangeMetadata =
-          engineContext.parallelize(partitionedWriteStats, parallelism).mapToPair(partitionedWriteStat -> {
-            final String partitionName = partitionedWriteStat.get(0).getPartitionPath();
-            checkState(tableMetadata != null, "tableMetadata should not be null when scanning metadata table");
-
-            // Collect column metadata for each file part of the latest merged file slice before the current instant time
-            List<HoodieColumnRangeMetadata<Comparable>> fileColumnMetadata = partitionedWriteStat.stream()
-                .flatMap(writeStat -> translateWriteStatToFileStats(writeStat, dataMetaClient, colsToIndex, partitionStatsIndexVersion).stream()).collect(toList());
-            // Collect column metadata of each file that does not have column stats provided by the write stat in the commit metadata
-            Set<String> filesToFetchColumnStats = getFilesToFetchColumnStats(partitionedWriteStat, dataMetaClient, tableMetadata, dataWriteConfig, partitionName, maxInstantTime,
-                instantTime, fileGroupIdsToReplaceMap, colsToIndex, partitionStatsIndexVersion);
-            // Fetch metadata table COLUMN_STATS partition records for the above files
-            List<HoodieColumnRangeMetadata<Comparable>> partitionColumnMetadata = tableMetadata
-                .getRecordsByKeyPrefixes(
-                    HoodieListData.lazy(generateColumnStatsKeys(colsToIndex, partitionName)),
-                    MetadataPartitionType.COLUMN_STATS.getPartitionPath(), false)
-                // schema and properties are ignored in getInsertValue, so simply pass as null
-                .map(record -> ((HoodieMetadataPayload) record.getData()).getColumnStatMetadata())
-                .filter(Option::isPresent)
-                .map(colStatsOpt -> colStatsOpt.get())
-                .filter(stats -> filesToFetchColumnStats.contains(stats.getFileName()))
-                .map(HoodieColumnRangeMetadata::fromColumnStats).collectAsList();
-            // fileColumnMetadata already contains stats for the files from the current inflight commit.
-            // Here it adds the stats for the committed files part of the latest merged file slices
-            fileColumnMetadata.addAll(partitionColumnMetadata);
-            return Pair.of(partitionName, fileColumnMetadata);
-          });
-
-      return convertMetadataToPartitionStatsRecords(columnRangeMetadata, dataMetaClient, columnsToIndexSchemaMap, partitionStatsIndexVersion);
-    } catch (Exception e) {
-      throw new HoodieException("Failed to generate column stats records for metadata table", e);
-    }
   }
 
   private static StoragePathInfo getBaseFileStoragePathInfo(HoodieBaseFile baseFile) {

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/SecondaryIndexRecordGenerationUtils.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/SecondaryIndexRecordGenerationUtils.java
@@ -27,6 +27,7 @@ import org.apache.hudi.common.engine.HoodieReaderContext;
 import org.apache.hudi.common.engine.ReaderContextFactory;
 import org.apache.hudi.common.fs.FSUtils;
 import org.apache.hudi.common.model.FileSlice;
+import org.apache.hudi.metadata.model.FileSliceAndPartition;
 import org.apache.hudi.common.model.HoodieBaseFile;
 import org.apache.hudi.common.model.HoodieFileFormat;
 import org.apache.hudi.common.model.HoodieIndexDefinition;
@@ -235,7 +236,7 @@ public class SecondaryIndexRecordGenerationUtils {
   }
 
   public static <T> HoodieData<HoodieRecord> readSecondaryKeysFromFileSlices(HoodieEngineContext engineContext,
-                                                                             List<Pair<String, FileSlice>> partitionFileSlicePairs,
+                                                                             List<FileSliceAndPartition> partitionFileSlicePairs,
                                                                              int secondaryIndexMaxParallelism,
                                                                              String activeModule, HoodieTableMetaClient metaClient,
                                                                              HoodieIndexDefinition indexDefinition,
@@ -255,8 +256,8 @@ public class SecondaryIndexRecordGenerationUtils {
     engineContext.setJobStatus(activeModule, "Secondary Index: reading secondary keys from " + partitionFileSlicePairs.size() + " file slices");
     HoodieFileFormat baseFileFormat = metaClient.getTableConfig().getBaseFileFormat();
     return engineContext.parallelize(partitionFileSlicePairs, parallelism).flatMap(partitionAndBaseFile -> {
-      final String partition = partitionAndBaseFile.getKey();
-      final FileSlice fileSlice = partitionAndBaseFile.getValue();
+      final String partition = partitionAndBaseFile.partitionPath();
+      final FileSlice fileSlice = partitionAndBaseFile.fileSlice();
       Option<StoragePath> dataFilePath = Option.ofNullable(fileSlice.getBaseFile().map(baseFile -> FSUtils.getAbsoluteFilePath(basePath, partition, baseFile.getFileName())).orElseGet(null));
       HoodieSchema readerSchema;
       if (dataFilePath.isPresent()) {

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/index/BaseIndexer.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/index/BaseIndexer.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.hudi.metadata.index;
+
+import org.apache.hudi.common.data.HoodieData;
+import org.apache.hudi.common.engine.HoodieEngineContext;
+import org.apache.hudi.common.model.HoodieRecord;
+import org.apache.hudi.common.table.HoodieTableMetaClient;
+import org.apache.hudi.config.HoodieWriteConfig;
+
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Base implementation of {@link Indexer} that handles common metadata-partition bootstrap flow,
+ * including file-group initialization, commit, and partition state update.
+ */
+@Slf4j
+public abstract class BaseIndexer implements Indexer {
+  protected final HoodieEngineContext engineContext;
+  protected final HoodieWriteConfig dataTableWriteConfig;
+  protected final HoodieTableMetaClient dataTableMetaClient;
+
+  protected BaseIndexer(
+      HoodieEngineContext engineContext,
+      HoodieWriteConfig dataTableWriteConfig,
+      HoodieTableMetaClient dataTableMetaClient) {
+    this.engineContext = engineContext;
+    this.dataTableWriteConfig = dataTableWriteConfig;
+    this.dataTableMetaClient = dataTableMetaClient;
+  }
+
+  /**
+   * Hook invoked after the bootstrap bulk commit for an index partition succeeds.
+   * <p>
+   * The default implementation marks the index partition as available in the data table config.
+   * Subclasses can override this to perform index-specific follow-up work (for example, index-definition
+   * registration or post-commit validation).
+   *
+   * @param metadataMetaClient metadata table meta client used during initialization
+   * @param records records committed during index partition initialization
+   * @param fileGroupCount number of file groups created for the index partition
+   * @param relativePartitionPath metadata table relative partition path being initialized
+   */
+  @Override
+  public void postInitialization(HoodieTableMetaClient metadataMetaClient, HoodieData<HoodieRecord> records, int fileGroupCount, String relativePartitionPath) {
+    dataTableMetaClient.getTableConfig().setMetadataPartitionState(dataTableMetaClient, relativePartitionPath, true);
+  }
+}

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/index/BaseIndexer.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/index/BaseIndexer.java
@@ -24,8 +24,14 @@ import org.apache.hudi.common.engine.HoodieEngineContext;
 import org.apache.hudi.common.model.HoodieRecord;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.config.HoodieWriteConfig;
+import org.apache.hudi.metadata.index.model.IndexPartitionAndRecords;
+import org.apache.hudi.metadata.model.FileInfo;
 
 import lombok.extern.slf4j.Slf4j;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
 
 /**
  * Base implementation of {@link Indexer} that handles common metadata-partition bootstrap flow,
@@ -61,5 +67,10 @@ public abstract class BaseIndexer implements Indexer {
   @Override
   public void postInitialization(HoodieTableMetaClient metadataMetaClient, HoodieData<HoodieRecord> records, int fileGroupCount, String relativePartitionPath) {
     dataTableMetaClient.getTableConfig().setMetadataPartitionState(dataTableMetaClient, relativePartitionPath, true);
+  }
+
+  @Override
+  public List<IndexPartitionAndRecords> buildRestore(String instantTime, List<String> deletedPartitions, Map<String, List<FileInfo>> filesAdded, Map<String, List<String>> filesDeleted) {
+    return Collections.emptyList();
   }
 }

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/index/ExpressionIndexRecordGenerator.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/index/ExpressionIndexRecordGenerator.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.hudi.metadata.index;
+
+import org.apache.hudi.common.data.HoodieData;
+import org.apache.hudi.common.engine.EngineType;
+import org.apache.hudi.common.model.HoodieIndexDefinition;
+import org.apache.hudi.common.model.HoodieRecord;
+import org.apache.hudi.common.schema.HoodieSchema;
+import org.apache.hudi.common.table.HoodieTableMetaClient;
+import org.apache.hudi.metadata.model.FileInfoAndPartition;
+import org.apache.hudi.storage.StorageConfiguration;
+
+import java.util.List;
+
+/**
+ * Engine-specific generator for expression index records used during metadata index bootstrap.
+ */
+public interface ExpressionIndexRecordGenerator {
+  EngineType getEngineType();
+
+  /**
+   * Generates expression index records.
+   *
+   * @param filesToIndex    triplet of partition, (file path, file size)
+   * @param indexDefinition definition of the expression index
+   * @param metaClient      {@link HoodieTableMetaClient} instance
+   * @param parallelism     parallelism to use for engine operations
+   * @param tableSchema     table schema
+   * @param readerSchema    reader schema
+   * @param storageConf     storage config
+   * @param instantTime     instant time
+   * @return expression index records
+   */
+  HoodieData<HoodieRecord> generate(
+      List<FileInfoAndPartition> filesToIndex,
+      HoodieIndexDefinition indexDefinition,
+      HoodieTableMetaClient metaClient,
+      int parallelism,
+      HoodieSchema tableSchema,
+      HoodieSchema readerSchema,
+      StorageConfiguration<?> storageConf,
+      String instantTime);
+}

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/index/ExpressionIndexRecordGenerator.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/index/ExpressionIndexRecordGenerator.java
@@ -21,11 +21,13 @@ package org.apache.hudi.metadata.index;
 
 import org.apache.hudi.common.data.HoodieData;
 import org.apache.hudi.common.engine.EngineType;
+import org.apache.hudi.common.model.HoodieCommitMetadata;
 import org.apache.hudi.common.model.HoodieIndexDefinition;
 import org.apache.hudi.common.model.HoodieRecord;
 import org.apache.hudi.common.schema.HoodieSchema;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.metadata.model.FileInfoAndPartition;
+import org.apache.hudi.metadata.HoodieTableMetadata;
 import org.apache.hudi.storage.StorageConfiguration;
 
 import java.util.List;
@@ -49,7 +51,7 @@ public interface ExpressionIndexRecordGenerator {
    * @param instantTime     instant time
    * @return expression index records
    */
-  HoodieData<HoodieRecord> generate(
+  HoodieData<HoodieRecord> buildInitialization(
       List<FileInfoAndPartition> filesToIndex,
       HoodieIndexDefinition indexDefinition,
       HoodieTableMetaClient metaClient,
@@ -57,5 +59,26 @@ public interface ExpressionIndexRecordGenerator {
       HoodieSchema tableSchema,
       HoodieSchema readerSchema,
       StorageConfiguration<?> storageConf,
+      String instantTime);
+
+  /**
+   * Loads the file slices touched by the commit due to given instant time and returns
+   * the records for the expression index. This generates partition stat record updates
+   * along with EI column stat update records. Partition stat record updates are generated
+   * by reloading the affected partitions column range metadata from EI and then merging
+   * it with partition stat record from the updated data.
+   *
+   * @param dataTableMetaClient {@link HoodieTableMetaClient} for the data table
+   * @param tableMetadata       metadata table reader used to load existing index content
+   * @param commitMetadata      commit metadata
+   * @param indexPartition      metadata partition path for the expression index
+   * @param instantTime         completed data-table instant time being indexed
+   * @return expression index records to upsert into metadata table
+   */
+  HoodieData<HoodieRecord> buildUpdate(
+      HoodieTableMetaClient dataTableMetaClient,
+      HoodieTableMetadata tableMetadata,
+      HoodieCommitMetadata commitMetadata,
+      String indexPartition,
       String instantTime);
 }

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/index/Indexer.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/index/Indexer.java
@@ -19,10 +19,15 @@
 
 package org.apache.hudi.metadata.index;
 
+import org.apache.hudi.avro.model.HoodieCleanMetadata;
 import org.apache.hudi.common.data.HoodieData;
+import org.apache.hudi.common.model.HoodieCommitMetadata;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
+import org.apache.hudi.common.table.view.HoodieTableFileSystemView;
+import org.apache.hudi.metadata.HoodieBackedTableMetadata;
 import org.apache.hudi.metadata.index.model.IndexPartitionInitialization;
 import org.apache.hudi.metadata.model.FileInfo;
+import org.apache.hudi.metadata.index.model.IndexPartitionAndRecords;
 import org.apache.hudi.metadata.model.FileSliceAndPartition;
 import org.apache.hudi.common.model.HoodieRecord;
 import org.apache.hudi.util.Lazy;
@@ -56,6 +61,53 @@ public interface Indexer {
       String instantTimeForPartition,
       Map<String, List<FileInfo>> partitionToAllFilesMap,
       Lazy<List<FileSliceAndPartition>> lazyLatestMergedPartitionFileSliceList) throws IOException;
+
+  /**
+   * Generates records for updating the index based on the commit metadata.
+   *
+   * @param instantTime        instant time of the commit being applied to the index
+   * @param tableMetadata      metadata table accessor used by indexers that need table lookups
+   * @param lazyFileSystemView lazily-evaluated file system view used by indexers that require file slices
+   * @param commitMetadata     commit metadata containing write stats for the update
+   * @return zero or more {@link IndexPartitionAndRecords} entries to be committed to metadata partitions.
+   * Returning an empty list means no index updates are required for this commit.
+   */
+  List<IndexPartitionAndRecords> buildUpdate(
+      String instantTime,
+      HoodieBackedTableMetadata tableMetadata,
+      Lazy<HoodieTableFileSystemView> lazyFileSystemView,
+      HoodieCommitMetadata commitMetadata);
+
+  /**
+   * Generates records for cleaning index entries based on the clean metadata.
+   *
+   * @param instantTime   instant time of the clean action being applied to the index
+   * @param cleanMetadata clean metadata describing files removed from the data table
+   * @return zero or more {@link IndexPartitionAndRecords} entries to be committed to metadata partitions.
+   * Returning an empty list means no index cleanup is required for this clean action.
+   */
+  List<IndexPartitionAndRecords> buildClean(
+      String instantTime,
+      HoodieCleanMetadata cleanMetadata);
+
+  /**
+   * Generates records for restoring index entries based on the restore metadata.
+   * <p>
+   * Implementations can emit records for files added back, files deleted, and partition deletions.
+   * The default implementation is a no-op and returns an empty list.
+   *
+   * @param instantTime       instant time of the restore action being applied to the index
+   * @param deletedPartitions data table partitions deleted during restore
+   * @param filesAdded        files that need to be re-added to index state, grouped by partition
+   * @param filesDeleted      files that need to be removed from index state, grouped by partition
+   * @return zero or more {@link IndexPartitionAndRecords} entries to be committed to metadata partitions.
+   * Returning an empty list means no index restore updates are required.
+   */
+  List<IndexPartitionAndRecords> buildRestore(
+      String instantTime,
+      List<String> deletedPartitions,
+      Map<String, List<FileInfo>> filesAdded,
+      Map<String, List<String>> filesDeleted);
 
   /**
    * Hook invoked after the bootstrap bulk commit for an index partition succeeds.

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/index/Indexer.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/index/Indexer.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.hudi.metadata.index;
+
+import org.apache.hudi.common.data.HoodieData;
+import org.apache.hudi.common.table.HoodieTableMetaClient;
+import org.apache.hudi.metadata.index.model.IndexPartitionInitialization;
+import org.apache.hudi.metadata.model.FileInfo;
+import org.apache.hudi.metadata.model.FileSliceAndPartition;
+import org.apache.hudi.common.model.HoodieRecord;
+import org.apache.hudi.util.Lazy;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Interface to building records for initializing and updating a type of metadata or index
+ * in the metadata table.
+ * <p>
+ * When a new type of index is added to MetadataPartitionType, an
+ * implementation of the {@link Indexer} interface is required, and it
+ * must be added to {@link IndexerFactory}.
+ */
+public interface Indexer {
+  /**
+   * Generates records for initializing the index.
+   *
+   * @param dataTableInstantTime                   instant time of the data table that the metadata table is initialized on
+   * @param instantTimeForPartition                instant time used for initializing a specific metadata partition
+   * @param partitionToAllFilesMap                 map of partition to files
+   * @param lazyLatestMergedPartitionFileSliceList lazily-evaluated list of file slices for the indexer that needs it
+   * @return zero or more {@link IndexPartitionInitialization} entries to be initialized.
+   * Returning an empty list means no metadata partition needs initialization in this invocation.
+   * @throws IOException upon IO error
+   */
+  List<IndexPartitionInitialization> buildInitialization(
+      String dataTableInstantTime,
+      String instantTimeForPartition,
+      Map<String, List<FileInfo>> partitionToAllFilesMap,
+      Lazy<List<FileSliceAndPartition>> lazyLatestMergedPartitionFileSliceList) throws IOException;
+
+  /**
+   * Hook invoked after the bootstrap bulk commit for an index partition succeeds.
+   * Implementations can use this to perform index-specific follow-up work.
+   *
+   * @param metadataMetaClient     metadata table meta client used during initialization
+   * @param records                records committed during index partition initialization
+   * @param fileGroupCount         number of file groups created for the index partition
+   * @param relativePartitionPath  metadata table relative partition path being initialized
+   */
+  void postInitialization(
+      HoodieTableMetaClient metadataMetaClient,
+      HoodieData<HoodieRecord> records,
+      int fileGroupCount,
+      String relativePartitionPath);
+}

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/index/IndexerFactory.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/index/IndexerFactory.java
@@ -84,10 +84,22 @@ public class IndexerFactory {
     }
     return Collections.unmodifiableMap(Arrays.stream(MetadataPartitionType.getValidValues(dataTableMetaClient.getTableConfig().getTableVersion()))
         .filter(partitionType ->
-            partitionType.isMetadataPartitionEnabled(dataTableWriteConfig.getMetadataConfig(), dataTableMetaClient.getTableConfig())
+            (partitionType.isMetadataPartitionEnabled(dataTableWriteConfig.getMetadataConfig(), dataTableMetaClient.getTableConfig())
             || partitionType.isMetadataPartitionAvailable(dataTableMetaClient))
+            && !(partitionType == MetadataPartitionType.RECORD_INDEX && shouldDeferRecordIndexInit(dataTableWriteConfig, dataTableMetaClient))
+        )
         .collect(Collectors.toMap(
             Function.identity(),
             type -> IndexerFactory.getIndexer(type, engineContext, dataTableWriteConfig, dataTableMetaClient, expressionIndexRecordGenerator))));
+  }
+
+  /**
+   * Returns whether the initialization of record index should be deferred, true if the table is a fresh table.
+   */
+  private static boolean shouldDeferRecordIndexInit(
+      HoodieWriteConfig dataTableWriteConfig,
+      HoodieTableMetaClient dataTableMetaClient) {
+    return dataTableWriteConfig.getMetadataConfig().shouldDeferRliInitForFreshTable()
+        && dataTableMetaClient.getActiveTimeline().filterCompletedInstants().countInstants() == 0;
   }
 }

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/index/IndexerFactory.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/index/IndexerFactory.java
@@ -1,0 +1,93 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.metadata.index;
+
+import org.apache.hudi.common.engine.HoodieEngineContext;
+import org.apache.hudi.common.table.HoodieTableMetaClient;
+import org.apache.hudi.config.HoodieWriteConfig;
+import org.apache.hudi.exception.HoodieNotSupportedException;
+import org.apache.hudi.metadata.MetadataPartitionType;
+import org.apache.hudi.metadata.index.bloomfilters.BloomFiltersIndexer;
+import org.apache.hudi.metadata.index.columnstats.ColumnStatsIndexer;
+import org.apache.hudi.metadata.index.expression.ExpressionIndexer;
+import org.apache.hudi.metadata.index.files.FilesIndexer;
+import org.apache.hudi.metadata.index.partitionstats.PartitionStatsIndexer;
+import org.apache.hudi.metadata.index.record.PartitionedRecordIndexer;
+import org.apache.hudi.metadata.index.record.RecordIndexer;
+import org.apache.hudi.metadata.index.secondary.SecondaryIndexer;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+/**
+ * Factory for creating {@link Indexer} implementations and resolving enabled indexers
+ * based on table and metadata configuration.
+ */
+public class IndexerFactory {
+  private static Indexer getIndexer(MetadataPartitionType partitionType,
+                                   HoodieEngineContext engineContext,
+                                   HoodieWriteConfig dataTableWriteConfig,
+                                   HoodieTableMetaClient dataTableMetaClient,
+                                   ExpressionIndexRecordGenerator expressionIndexRecordGenerator) {
+    switch (partitionType) {
+      case FILES:
+        return new FilesIndexer(engineContext, dataTableWriteConfig, dataTableMetaClient);
+      case BLOOM_FILTERS:
+        return new BloomFiltersIndexer(engineContext, dataTableWriteConfig, dataTableMetaClient);
+      case COLUMN_STATS:
+        return new ColumnStatsIndexer(engineContext, dataTableWriteConfig, dataTableMetaClient);
+      case RECORD_INDEX:
+        return dataTableWriteConfig.isRecordLevelIndexEnabled()
+            ? new PartitionedRecordIndexer(engineContext, dataTableWriteConfig, dataTableMetaClient)
+            : new RecordIndexer(engineContext, dataTableWriteConfig, dataTableMetaClient);
+      case EXPRESSION_INDEX:
+        return new ExpressionIndexer(engineContext, dataTableWriteConfig, dataTableMetaClient, expressionIndexRecordGenerator);
+      case PARTITION_STATS:
+        return new PartitionStatsIndexer(engineContext, dataTableWriteConfig, dataTableMetaClient);
+      case SECONDARY_INDEX:
+        return new SecondaryIndexer(engineContext, dataTableWriteConfig, dataTableMetaClient);
+      default:
+        throw new HoodieNotSupportedException("Unsupported metadata partition type for indexing: " + partitionType);
+    }
+  }
+
+  /**
+   * Returns the map of metadata partition type to the indexer for the enabled metadata
+   * partition types based on the metadata config and table config.
+   */
+  public static Map<MetadataPartitionType, Indexer> getEnabledIndexerMap(
+      HoodieEngineContext engineContext,
+      HoodieWriteConfig dataTableWriteConfig,
+      HoodieTableMetaClient dataTableMetaClient,
+      ExpressionIndexRecordGenerator expressionIndexRecordGenerator) {
+    if (!dataTableWriteConfig.getMetadataConfig().isEnabled()) {
+      return Collections.emptyMap();
+    }
+    return Collections.unmodifiableMap(Arrays.stream(MetadataPartitionType.getValidValues(dataTableMetaClient.getTableConfig().getTableVersion()))
+        .filter(partitionType ->
+            partitionType.isMetadataPartitionEnabled(dataTableWriteConfig.getMetadataConfig(), dataTableMetaClient.getTableConfig())
+            || partitionType.isMetadataPartitionAvailable(dataTableMetaClient))
+        .collect(Collectors.toMap(
+            Function.identity(),
+            type -> IndexerFactory.getIndexer(type, engineContext, dataTableWriteConfig, dataTableMetaClient, expressionIndexRecordGenerator))));
+  }
+}

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/index/UnsupportedExpressionIndexRecordGenerator.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/index/UnsupportedExpressionIndexRecordGenerator.java
@@ -21,12 +21,14 @@ package org.apache.hudi.metadata.index;
 
 import org.apache.hudi.common.data.HoodieData;
 import org.apache.hudi.common.engine.EngineType;
+import org.apache.hudi.common.model.HoodieCommitMetadata;
 import org.apache.hudi.common.model.HoodieIndexDefinition;
 import org.apache.hudi.common.model.HoodieRecord;
 import org.apache.hudi.common.schema.HoodieSchema;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.common.table.HoodieTableVersion;
 import org.apache.hudi.exception.HoodieNotSupportedException;
+import org.apache.hudi.metadata.HoodieTableMetadata;
 import org.apache.hudi.metadata.model.FileInfoAndPartition;
 import org.apache.hudi.storage.StorageConfiguration;
 
@@ -50,7 +52,7 @@ public class UnsupportedExpressionIndexRecordGenerator implements ExpressionInde
   }
 
   @Override
-  public HoodieData<HoodieRecord> generate(
+  public HoodieData<HoodieRecord> buildInitialization(
       List<FileInfoAndPartition> filesToIndex,
       HoodieIndexDefinition indexDefinition,
       HoodieTableMetaClient metaClient,
@@ -58,6 +60,19 @@ public class UnsupportedExpressionIndexRecordGenerator implements ExpressionInde
       HoodieSchema tableSchema,
       HoodieSchema readerSchema,
       StorageConfiguration<?> storageConf,
+      String instantTime) {
+    if (metaClient.getTableConfig().getTableVersion().lesserThan(HoodieTableVersion.EIGHT)) {
+      throw new HoodieNotSupportedException("Table version 6 and below does not support expression index");
+    }
+    throw new HoodieNotSupportedException(engineType + " engine does not support building expression index yet");
+  }
+
+  @Override
+  public HoodieData<HoodieRecord> buildUpdate(
+      HoodieTableMetaClient metaClient,
+      HoodieTableMetadata tableMetadata,
+      HoodieCommitMetadata commitMetadata,
+      String indexPartition,
       String instantTime) {
     if (metaClient.getTableConfig().getTableVersion().lesserThan(HoodieTableVersion.EIGHT)) {
       throw new HoodieNotSupportedException("Table version 6 and below does not support expression index");

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/index/UnsupportedExpressionIndexRecordGenerator.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/index/UnsupportedExpressionIndexRecordGenerator.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.hudi.metadata.index;
+
+import org.apache.hudi.common.data.HoodieData;
+import org.apache.hudi.common.engine.EngineType;
+import org.apache.hudi.common.model.HoodieIndexDefinition;
+import org.apache.hudi.common.model.HoodieRecord;
+import org.apache.hudi.common.schema.HoodieSchema;
+import org.apache.hudi.common.table.HoodieTableMetaClient;
+import org.apache.hudi.common.table.HoodieTableVersion;
+import org.apache.hudi.exception.HoodieNotSupportedException;
+import org.apache.hudi.metadata.model.FileInfoAndPartition;
+import org.apache.hudi.storage.StorageConfiguration;
+
+import java.util.List;
+
+/**
+ * Fallback {@link ExpressionIndexRecordGenerator} that throws a not-supported exception
+ * when expression index bootstrap is requested for unsupported engines.
+ */
+public class UnsupportedExpressionIndexRecordGenerator implements ExpressionIndexRecordGenerator {
+
+  private final EngineType engineType;
+
+  public UnsupportedExpressionIndexRecordGenerator(EngineType engineType) {
+    this.engineType = engineType;
+  }
+
+  @Override
+  public EngineType getEngineType() {
+    return engineType;
+  }
+
+  @Override
+  public HoodieData<HoodieRecord> generate(
+      List<FileInfoAndPartition> filesToIndex,
+      HoodieIndexDefinition indexDefinition,
+      HoodieTableMetaClient metaClient,
+      int parallelism,
+      HoodieSchema tableSchema,
+      HoodieSchema readerSchema,
+      StorageConfiguration<?> storageConf,
+      String instantTime) {
+    if (metaClient.getTableConfig().getTableVersion().lesserThan(HoodieTableVersion.EIGHT)) {
+      throw new HoodieNotSupportedException("Table version 6 and below does not support expression index");
+    }
+    throw new HoodieNotSupportedException(engineType + " engine does not support building expression index yet");
+  }
+}

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/index/bloomfilters/BloomFiltersIndexer.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/index/bloomfilters/BloomFiltersIndexer.java
@@ -19,8 +19,23 @@
 
 package org.apache.hudi.metadata.index.bloomfilters;
 
+import org.apache.hudi.avro.model.HoodieCleanMetadata;
+import org.apache.hudi.common.bloom.BloomFilter;
+import org.apache.hudi.common.config.HoodieConfig;
 import org.apache.hudi.common.data.HoodieData;
 import org.apache.hudi.common.engine.HoodieEngineContext;
+import org.apache.hudi.common.fs.FSUtils;
+import org.apache.hudi.common.model.HoodieCommitMetadata;
+import org.apache.hudi.common.model.HoodieDeltaWriteStat;
+import org.apache.hudi.common.model.HoodieWriteStat;
+import org.apache.hudi.common.table.view.HoodieTableFileSystemView;
+import org.apache.hudi.common.util.StringUtils;
+import org.apache.hudi.common.util.collection.Pair;
+import org.apache.hudi.io.storage.HoodieFileReader;
+import org.apache.hudi.io.storage.HoodieIOFactory;
+import org.apache.hudi.metadata.HoodieBackedTableMetadata;
+import org.apache.hudi.metadata.HoodieMetadataPayload;
+import org.apache.hudi.metadata.index.model.IndexPartitionAndRecords;
 import org.apache.hudi.metadata.model.FileInfo;
 import org.apache.hudi.metadata.model.FileSliceAndPartition;
 import org.apache.hudi.common.model.HoodieRecord;
@@ -30,14 +45,22 @@ import org.apache.hudi.config.HoodieWriteConfig;
 import org.apache.hudi.metadata.HoodieTableMetadataUtil;
 import org.apache.hudi.metadata.MetadataPartitionType;
 import org.apache.hudi.metadata.index.BaseIndexer;
+import org.apache.hudi.storage.StoragePath;
 import org.apache.hudi.util.Lazy;
 
 import lombok.extern.slf4j.Slf4j;
 
 import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
+
+import static org.apache.hudi.common.util.StringUtils.getUTF8Bytes;
+import static org.apache.hudi.metadata.MetadataPartitionType.BLOOM_FILTERS;
 
 /**
  * Implementation of {@link MetadataPartitionType#BLOOM_FILTERS} index
@@ -61,6 +84,130 @@ public class BloomFiltersIndexer extends BaseIndexer {
         engineContext, Collections.emptyMap(), partitionToAllFilesMap, dataTableInstantTime, dataTableMetaClient,
         dataTableWriteConfig.getBloomIndexParallelism(), dataTableWriteConfig.getBloomFilterType());
     final int fileGroupCount = dataTableWriteConfig.getMetadataConfig().getBloomFilterIndexFileGroupCount();
-    return Collections.singletonList(IndexPartitionInitialization.of(fileGroupCount, MetadataPartitionType.BLOOM_FILTERS.getPartitionPath(), records));
+    return Collections.singletonList(IndexPartitionInitialization.of(fileGroupCount, BLOOM_FILTERS.getPartitionPath(), records));
+  }
+
+  @Override
+  public List<IndexPartitionAndRecords> buildUpdate(
+      String instantTime,
+      HoodieBackedTableMetadata tableMetadata,
+      Lazy<HoodieTableFileSystemView> lazyFileSystemView,
+      HoodieCommitMetadata commitMetadata) {
+    final HoodieData<HoodieRecord> records = convertMetadataToBloomFilterRecords(
+        engineContext, dataTableWriteConfig, commitMetadata, instantTime, dataTableMetaClient,
+        dataTableWriteConfig.getBloomFilterType(), dataTableWriteConfig.getBloomIndexParallelism());
+    return Collections.singletonList(IndexPartitionAndRecords.of(BLOOM_FILTERS.getPartitionPath(), records));
+  }
+
+  @Override
+  public List<IndexPartitionAndRecords> buildClean(String instantTime, HoodieCleanMetadata cleanMetadata) {
+    final HoodieData<HoodieRecord> records =
+        convertMetadataToBloomFilterRecords(cleanMetadata, engineContext, instantTime, dataTableWriteConfig.getBloomIndexParallelism());
+    return Collections.singletonList(IndexPartitionAndRecords.of(BLOOM_FILTERS.getPartitionPath(), records));
+  }
+
+  /**
+   * Convert commit action metadata to bloom filter records.
+   *
+   * @param context                 - Engine context to use
+   * @param hoodieConfig            - Hudi configs
+   * @param commitMetadata          - Commit action metadata
+   * @param instantTime             - Action instant time
+   * @param dataMetaClient          - HoodieTableMetaClient for data
+   * @param bloomFilterType         - Type of generated bloom filter records
+   * @param bloomIndexParallelism   - Parallelism for bloom filter record generation
+   * @return HoodieData of metadata table records
+   */
+  private static HoodieData<HoodieRecord> convertMetadataToBloomFilterRecords(
+      HoodieEngineContext context,
+      HoodieConfig hoodieConfig,
+      HoodieCommitMetadata commitMetadata,
+      String instantTime,
+      HoodieTableMetaClient dataMetaClient,
+      String bloomFilterType,
+      int bloomIndexParallelism) {
+    final List<HoodieWriteStat> allWriteStats = commitMetadata.getPartitionToWriteStats().values().stream()
+        .flatMap(Collection::stream).collect(Collectors.toList());
+    if (allWriteStats.isEmpty()) {
+      return context.emptyHoodieData();
+    }
+
+    final int parallelism = Math.max(Math.min(allWriteStats.size(), bloomIndexParallelism), 1);
+    HoodieData<HoodieWriteStat> allWriteStatsRDD = context.parallelize(allWriteStats, parallelism);
+    return allWriteStatsRDD.flatMap(hoodieWriteStat -> {
+      final String partition = hoodieWriteStat.getPartitionPath();
+
+      // For bloom filter index, delta writes do not change the base file bloom filter entries
+      if (hoodieWriteStat instanceof HoodieDeltaWriteStat) {
+        return Collections.emptyListIterator();
+      }
+
+      String pathWithPartition = hoodieWriteStat.getPath();
+      if (pathWithPartition == null) {
+        // Empty partition
+        log.error("Failed to find path in write stat to update metadata table {}", hoodieWriteStat);
+        return Collections.emptyListIterator();
+      }
+
+      String fileName = FSUtils.getFileName(pathWithPartition, partition);
+      if (!FSUtils.isBaseFile(new StoragePath(fileName))) {
+        return Collections.emptyListIterator();
+      }
+
+      final StoragePath writeFilePath = new StoragePath(dataMetaClient.getBasePath(), pathWithPartition);
+      try (HoodieFileReader fileReader = HoodieIOFactory.getIOFactory(dataMetaClient.getStorage())
+          .getReaderFactory(HoodieRecord.HoodieRecordType.AVRO).getFileReader(hoodieConfig, writeFilePath)) {
+        try {
+          final BloomFilter fileBloomFilter = fileReader.readBloomFilter();
+          if (fileBloomFilter == null) {
+            log.error("Failed to read bloom filter for {}", writeFilePath);
+            return Collections.emptyListIterator();
+          }
+          ByteBuffer bloomByteBuffer = ByteBuffer.wrap(getUTF8Bytes(fileBloomFilter.serializeToString()));
+          HoodieRecord record = HoodieMetadataPayload.createBloomFilterMetadataRecord(
+              partition, fileName, instantTime, bloomFilterType, bloomByteBuffer, false);
+          return Collections.singletonList(record).iterator();
+        } catch (Exception e) {
+          log.error("Failed to read bloom filter for {}", writeFilePath);
+          return Collections.emptyListIterator();
+        }
+      } catch (IOException e) {
+        log.error("Failed to get bloom filter for file: {}, write stat: {}", writeFilePath, hoodieWriteStat);
+      }
+      return Collections.emptyListIterator();
+    });
+  }
+
+  /**
+   * Convert clean metadata to bloom filter index records.
+   *
+   * @param cleanMetadata           - Clean action metadata
+   * @param engineContext           - Engine context
+   * @param instantTime             - Clean action instant time
+   * @param bloomIndexParallelism   - Parallelism for bloom filter record generation
+   * @return List of bloom filter index records for the clean metadata
+   */
+  public static HoodieData<HoodieRecord> convertMetadataToBloomFilterRecords(
+      HoodieCleanMetadata cleanMetadata,
+      HoodieEngineContext engineContext,
+      String instantTime,
+      int bloomIndexParallelism) {
+    List<Pair<String, String>> deleteFileList = new ArrayList<>();
+    cleanMetadata.getPartitionMetadata().forEach((partition, partitionMetadata) -> {
+      // Files deleted from a partition
+      List<String> deletedFiles = partitionMetadata.getDeletePathPatterns();
+      deletedFiles.forEach(entry -> {
+        final StoragePath deletedFilePath = new StoragePath(entry);
+        if (FSUtils.isBaseFile(deletedFilePath)) {
+          deleteFileList.add(Pair.of(partition, deletedFilePath.getName()));
+        }
+      });
+    });
+
+    final int parallelism = Math.max(Math.min(deleteFileList.size(), bloomIndexParallelism), 1);
+    HoodieData<Pair<String, String>> deleteFileListRDD = engineContext.parallelize(deleteFileList, parallelism);
+    return deleteFileListRDD.map(deleteFileInfoPair -> HoodieMetadataPayload.createBloomFilterMetadataRecord(
+        deleteFileInfoPair.getLeft(), deleteFileInfoPair.getRight(), instantTime, StringUtils.EMPTY_STRING,
+        ByteBuffer.allocate(0), true));
   }
 }

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/index/bloomfilters/BloomFiltersIndexer.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/index/bloomfilters/BloomFiltersIndexer.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.hudi.metadata.index.bloomfilters;
+
+import org.apache.hudi.common.data.HoodieData;
+import org.apache.hudi.common.engine.HoodieEngineContext;
+import org.apache.hudi.metadata.model.FileInfo;
+import org.apache.hudi.metadata.model.FileSliceAndPartition;
+import org.apache.hudi.common.model.HoodieRecord;
+import org.apache.hudi.metadata.index.model.IndexPartitionInitialization;
+import org.apache.hudi.common.table.HoodieTableMetaClient;
+import org.apache.hudi.config.HoodieWriteConfig;
+import org.apache.hudi.metadata.HoodieTableMetadataUtil;
+import org.apache.hudi.metadata.MetadataPartitionType;
+import org.apache.hudi.metadata.index.BaseIndexer;
+import org.apache.hudi.util.Lazy;
+
+import lombok.extern.slf4j.Slf4j;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Implementation of {@link MetadataPartitionType#BLOOM_FILTERS} index
+ */
+@Slf4j
+public class BloomFiltersIndexer extends BaseIndexer {
+
+  public BloomFiltersIndexer(HoodieEngineContext engineContext,
+                             HoodieWriteConfig dataTableWriteConfig,
+                             HoodieTableMetaClient dataTableMetaClient) {
+    super(engineContext, dataTableWriteConfig, dataTableMetaClient);
+  }
+
+  @Override
+  public List<IndexPartitionInitialization> buildInitialization(
+      String dataTableInstantTime,
+      String instantTimeForPartition,
+      Map<String, List<FileInfo>> partitionToAllFilesMap,
+      Lazy<List<FileSliceAndPartition>> lazyLatestMergedPartitionFileSliceList) throws IOException {
+    HoodieData<HoodieRecord> records = HoodieTableMetadataUtil.convertFilesToBloomFilterRecords(
+        engineContext, Collections.emptyMap(), partitionToAllFilesMap, dataTableInstantTime, dataTableMetaClient,
+        dataTableWriteConfig.getBloomIndexParallelism(), dataTableWriteConfig.getBloomFilterType());
+    final int fileGroupCount = dataTableWriteConfig.getMetadataConfig().getBloomFilterIndexFileGroupCount();
+    return Collections.singletonList(IndexPartitionInitialization.of(fileGroupCount, MetadataPartitionType.BLOOM_FILTERS.getPartitionPath(), records));
+  }
+}

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/index/columnstats/ColumnStatsIndexer.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/index/columnstats/ColumnStatsIndexer.java
@@ -19,9 +19,21 @@
 
 package org.apache.hudi.metadata.index.columnstats;
 
+import org.apache.hudi.avro.model.HoodieCleanMetadata;
+import org.apache.hudi.common.config.HoodieMetadataConfig;
 import org.apache.hudi.common.data.HoodieData;
 import org.apache.hudi.common.engine.HoodieEngineContext;
 import org.apache.hudi.metadata.model.FileInfo;
+import org.apache.hudi.common.model.HoodieCommitMetadata;
+import org.apache.hudi.common.model.HoodieWriteStat;
+import org.apache.hudi.common.schema.HoodieSchema;
+import org.apache.hudi.common.table.view.HoodieTableFileSystemView;
+import org.apache.hudi.common.util.collection.Pair;
+import org.apache.hudi.exception.HoodieException;
+import org.apache.hudi.metadata.HoodieBackedTableMetadata;
+import org.apache.hudi.metadata.HoodieIndexVersion;
+import org.apache.hudi.metadata.HoodieMetadataPayload;
+import org.apache.hudi.metadata.index.model.IndexPartitionAndRecords;
 import org.apache.hudi.metadata.model.FileSliceAndPartition;
 import org.apache.hudi.common.model.HoodieIndexDefinition;
 import org.apache.hudi.common.model.HoodieRecord;
@@ -32,19 +44,26 @@ import org.apache.hudi.config.HoodieWriteConfig;
 import org.apache.hudi.metadata.HoodieTableMetadataUtil;
 import org.apache.hudi.metadata.MetadataPartitionType;
 import org.apache.hudi.metadata.index.BaseIndexer;
+import org.apache.hudi.stats.HoodieColumnRangeMetadata;
 import org.apache.hudi.util.Lazy;
 
 import lombok.extern.slf4j.Slf4j;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
+import static org.apache.hudi.common.fs.FSUtils.getFileNameFromPath;
 import static org.apache.hudi.index.HoodieIndexUtils.register;
 import static org.apache.hudi.metadata.HoodieTableMetadataUtil.PARTITION_NAME_COLUMN_STATS;
 import static org.apache.hudi.metadata.HoodieTableMetadataUtil.existingIndexVersionOrDefault;
+import static org.apache.hudi.metadata.HoodieTableMetadataUtil.getColumnStatsRecords;
+import static org.apache.hudi.metadata.HoodieTableMetadataUtil.getColumnsToIndex;
 import static org.apache.hudi.metadata.MetadataPartitionType.COLUMN_STATS;
 
 /**
@@ -60,7 +79,7 @@ public class ColumnStatsIndexer extends BaseIndexer {
     super(engineContext, dataTableWriteConfig, dataTableMetaClient);
 
     this.columnsToIndex = Lazy.lazily(() ->
-        new ArrayList<>(HoodieTableMetadataUtil.getColumnsToIndex(
+        new ArrayList<>(getColumnsToIndex(
             dataTableMetaClient.getTableConfig(),
             dataTableWriteConfig.getMetadataConfig(),
             Lazy.lazily(() -> HoodieTableMetadataUtil.tryResolveSchemaForTable(dataTableMetaClient)),
@@ -96,6 +115,52 @@ public class ColumnStatsIndexer extends BaseIndexer {
   }
 
   @Override
+  public List<IndexPartitionAndRecords> buildUpdate(
+      String instantTime,
+      HoodieBackedTableMetadata tableMetadata,
+      Lazy<HoodieTableFileSystemView> lazyFileSystemView,
+      HoodieCommitMetadata commitMetadata) {
+    final HoodieData<HoodieRecord> records = convertMetadataToColumnStatsRecords(commitMetadata, engineContext,
+        dataTableMetaClient, dataTableWriteConfig.getMetadataConfig(), Option.of(dataTableWriteConfig.getRecordMerger().getRecordType()));
+    return Collections.singletonList(IndexPartitionAndRecords.of(COLUMN_STATS.getPartitionPath(), records));
+  }
+
+  @Override
+  public List<IndexPartitionAndRecords> buildClean(String instantTime, HoodieCleanMetadata cleanMetadata) {
+    final HoodieData<HoodieRecord> records =
+        convertMetadataToColumnStatsRecords(cleanMetadata, engineContext, dataTableMetaClient,
+            dataTableWriteConfig.getMetadataConfig(), Option.of(dataTableWriteConfig.getRecordMerger().getRecordType()));
+    return Collections.singletonList(IndexPartitionAndRecords.of(COLUMN_STATS.getPartitionPath(), records));
+  }
+
+  @Override
+  public List<IndexPartitionAndRecords> buildRestore(String instantTime, List<String> deletedPartitions, Map<String, List<FileInfo>> filesAdded, Map<String, List<String>> filesDeleted) {
+    if (filesDeleted.isEmpty() && filesAdded.isEmpty()) {
+      return Collections.emptyList();
+    }
+    Lazy<Option<HoodieSchema>> tableSchema =
+        Lazy.lazily(() -> HoodieTableMetadataUtil.tryResolveSchemaForTable(dataTableMetaClient));
+    final List<String> columnsToIndex = new ArrayList<>(HoodieTableMetadataUtil.getColumnsToIndex(
+        dataTableMetaClient.getTableConfig(),
+        dataTableWriteConfig.getMetadataConfig(),
+        tableSchema,
+        false,
+        Option.of(dataTableWriteConfig.getRecordMerger().getRecordType()),
+        HoodieTableMetadataUtil.existingIndexVersionOrDefault(PARTITION_NAME_COLUMN_STATS, dataTableMetaClient)).keySet());
+    if (columnsToIndex.isEmpty()) {
+      log.info("Since there are no columns to index, stop to generate ColumnStats records.");
+      return Collections.emptyList();
+    }
+    HoodieData<HoodieRecord> records = HoodieTableMetadataUtil.convertFilesToColumnStatsRecords(
+        engineContext, filesDeleted,
+        filesAdded, dataTableMetaClient,
+        dataTableWriteConfig.getMetadataConfig().getColumnStatsIndexParallelism(),
+        dataTableWriteConfig.getMetadataConfig().getMaxReaderBufferSize(),
+        columnsToIndex);
+    return Collections.singletonList(IndexPartitionAndRecords.of(COLUMN_STATS.getPartitionPath(), records));
+  }
+
+  @Override
   public void postInitialization(HoodieTableMetaClient metadataMetaClient, HoodieData<HoodieRecord> records, int fileGroupCount, String relativePartitionPath) {
     HoodieIndexDefinition indexDefinition = HoodieIndexDefinition.newBuilder()
         .withIndexName(PARTITION_NAME_COLUMN_STATS)
@@ -110,5 +175,93 @@ public class ColumnStatsIndexer extends BaseIndexer {
     register(dataTableMetaClient, indexDefinition);
 
     super.postInitialization(metadataMetaClient, records, fileGroupCount, relativePartitionPath);
+  }
+
+  private static HoodieData<HoodieRecord> convertMetadataToColumnStatsRecords(
+      HoodieCommitMetadata commitMetadata,
+      HoodieEngineContext engineContext,
+      HoodieTableMetaClient dataMetaClient,
+      HoodieMetadataConfig metadataConfig,
+      Option<HoodieRecord.HoodieRecordType> recordTypeOpt) {
+    List<HoodieWriteStat> allWriteStats = commitMetadata.getPartitionToWriteStats().values().stream()
+        .flatMap(Collection::stream).collect(Collectors.toList());
+
+    if (allWriteStats.isEmpty()) {
+      return engineContext.emptyHoodieData();
+    }
+
+    try {
+      Map<String, HoodieSchema> columnsToIndexSchemaMap = getColumnsToIndex(commitMetadata, dataMetaClient, metadataConfig, recordTypeOpt);
+      if (columnsToIndexSchemaMap.isEmpty()) {
+        // In case there are no columns to index, bail
+        return engineContext.emptyHoodieData();
+      }
+      List<String> columnsToIndex = new ArrayList<>(columnsToIndexSchemaMap.keySet());
+      int parallelism = Math.max(Math.min(allWriteStats.size(), metadataConfig.getColumnStatsIndexParallelism()), 1);
+      return engineContext.parallelize(allWriteStats, parallelism)
+          .flatMap(writeStat ->
+              translateWriteStatToColumnStats(writeStat, dataMetaClient, columnsToIndex).iterator());
+    } catch (Exception e) {
+      throw new HoodieException("Failed to generate column stats records for metadata table", e);
+    }
+  }
+
+  /**
+   * Convert clean metadata to column stats index records.
+   *
+   * @param cleanMetadata                    - Clean action metadata
+   * @param engineContext                    - Engine context
+   * @param dataMetaClient                   - HoodieTableMetaClient for data
+   * @param metadataConfig                   - HoodieMetadataConfig
+   * @return List of column stats index records for the clean metadata
+   */
+  public static HoodieData<HoodieRecord> convertMetadataToColumnStatsRecords(
+      HoodieCleanMetadata cleanMetadata,
+      HoodieEngineContext engineContext,
+      HoodieTableMetaClient dataMetaClient,
+      HoodieMetadataConfig metadataConfig,
+      Option<HoodieRecord.HoodieRecordType> recordTypeOpt) {
+    List<Pair<String, String>> deleteFileList = new ArrayList<>();
+    cleanMetadata.getPartitionMetadata().forEach((partition, partitionMetadata) -> {
+      // Files deleted from a partition
+      List<String> deletedFiles = partitionMetadata.getDeletePathPatterns();
+      deletedFiles.forEach(entry -> deleteFileList.add(Pair.of(partition, entry)));
+    });
+    if (deleteFileList.isEmpty()) {
+      return engineContext.emptyHoodieData();
+    }
+
+    HoodieIndexVersion indexVersion = existingIndexVersionOrDefault(PARTITION_NAME_COLUMN_STATS, dataMetaClient);
+
+    List<String> columnsToIndex = new ArrayList<>(getColumnsToIndex(dataMetaClient.getTableConfig(), metadataConfig,
+        Lazy.lazily(() -> HoodieTableMetadataUtil.tryResolveSchemaForTable(dataMetaClient)), false, recordTypeOpt, indexVersion).keySet());
+
+    if (columnsToIndex.isEmpty()) {
+      // In case there are no columns to index, bail
+      log.info("No columns to index for column stats index.");
+      return engineContext.emptyHoodieData();
+    }
+
+    int parallelism = Math.max(Math.min(deleteFileList.size(), metadataConfig.getColumnStatsIndexParallelism()), 1);
+    return engineContext.parallelize(deleteFileList, parallelism)
+        .flatMap(deleteFileInfoPair -> {
+          String partitionPath = deleteFileInfoPair.getLeft();
+          String fileName = deleteFileInfoPair.getRight();
+          return getColumnStatsRecords(partitionPath, fileName, dataMetaClient, columnsToIndex, true).iterator();
+        });
+  }
+
+  private static Stream<HoodieRecord> translateWriteStatToColumnStats(
+      HoodieWriteStat writeStat,
+      HoodieTableMetaClient datasetMetaClient,
+      List<String> columnsToIndex) {
+    if (writeStat.getColumnStats().isPresent()) {
+      Map<String, HoodieColumnRangeMetadata<Comparable>> columnRangeMap = writeStat.getColumnStats().get();
+      Collection<HoodieColumnRangeMetadata<Comparable>> columnRangeMetadataList = columnRangeMap.values();
+      return HoodieMetadataPayload.createColumnStatsRecords(writeStat.getPartitionPath(), columnRangeMetadataList, false);
+    }
+
+    String filePath = writeStat.getPath();
+    return getColumnStatsRecords(writeStat.getPartitionPath(), getFileNameFromPath(filePath), datasetMetaClient, columnsToIndex, false);
   }
 }

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/index/columnstats/ColumnStatsIndexer.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/index/columnstats/ColumnStatsIndexer.java
@@ -1,0 +1,114 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.hudi.metadata.index.columnstats;
+
+import org.apache.hudi.common.data.HoodieData;
+import org.apache.hudi.common.engine.HoodieEngineContext;
+import org.apache.hudi.metadata.model.FileInfo;
+import org.apache.hudi.metadata.model.FileSliceAndPartition;
+import org.apache.hudi.common.model.HoodieIndexDefinition;
+import org.apache.hudi.common.model.HoodieRecord;
+import org.apache.hudi.metadata.index.model.IndexPartitionInitialization;
+import org.apache.hudi.common.table.HoodieTableMetaClient;
+import org.apache.hudi.common.util.Option;
+import org.apache.hudi.config.HoodieWriteConfig;
+import org.apache.hudi.metadata.HoodieTableMetadataUtil;
+import org.apache.hudi.metadata.MetadataPartitionType;
+import org.apache.hudi.metadata.index.BaseIndexer;
+import org.apache.hudi.util.Lazy;
+
+import lombok.extern.slf4j.Slf4j;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import static org.apache.hudi.index.HoodieIndexUtils.register;
+import static org.apache.hudi.metadata.HoodieTableMetadataUtil.PARTITION_NAME_COLUMN_STATS;
+import static org.apache.hudi.metadata.HoodieTableMetadataUtil.existingIndexVersionOrDefault;
+import static org.apache.hudi.metadata.MetadataPartitionType.COLUMN_STATS;
+
+/**
+ * Implementation of {@link MetadataPartitionType#COLUMN_STATS} metadata
+ */
+@Slf4j
+public class ColumnStatsIndexer extends BaseIndexer {
+  private Lazy<List<String>> columnsToIndex;
+
+  public ColumnStatsIndexer(HoodieEngineContext engineContext,
+                               HoodieWriteConfig dataTableWriteConfig,
+                               HoodieTableMetaClient dataTableMetaClient) {
+    super(engineContext, dataTableWriteConfig, dataTableMetaClient);
+
+    this.columnsToIndex = Lazy.lazily(() ->
+        new ArrayList<>(HoodieTableMetadataUtil.getColumnsToIndex(
+            dataTableMetaClient.getTableConfig(),
+            dataTableWriteConfig.getMetadataConfig(),
+            Lazy.lazily(() -> HoodieTableMetadataUtil.tryResolveSchemaForTable(dataTableMetaClient)),
+            true,
+            Option.of(dataTableWriteConfig.getRecordMerger().getRecordType()),
+            existingIndexVersionOrDefault(PARTITION_NAME_COLUMN_STATS, dataTableMetaClient)).keySet()));
+  }
+
+  @Override
+  public List<IndexPartitionInitialization> buildInitialization(
+      String dataTableInstantTime,
+      String instantTimeForPartition,
+      Map<String, List<FileInfo>> partitionToAllFilesMap,
+      Lazy<List<FileSliceAndPartition>> lazyLatestMergedPartitionFileSliceList) throws IOException {
+    final int fileGroupCount = dataTableWriteConfig.getMetadataConfig().getColumnStatsIndexFileGroupCount();
+    if (partitionToAllFilesMap.isEmpty()) {
+      this.columnsToIndex = Lazy.lazily(Collections::emptyList);
+      return Collections.singletonList(IndexPartitionInitialization.of(fileGroupCount, COLUMN_STATS.getPartitionPath(), engineContext.emptyHoodieData()));
+    }
+
+    if (columnsToIndex.get().isEmpty()) {
+      return Collections.singletonList(IndexPartitionInitialization.of(fileGroupCount, COLUMN_STATS.getPartitionPath(), engineContext.emptyHoodieData()));
+    }
+
+    log.info("Indexing {} columns for column stats index", columnsToIndex.get().size());
+    // during initialization, we need stats for base and log files.
+    HoodieData<HoodieRecord> records = HoodieTableMetadataUtil.convertFilesToColumnStatsRecords(
+        engineContext, Collections.emptyMap(), partitionToAllFilesMap,
+        dataTableMetaClient, dataTableWriteConfig.getColumnStatsIndexParallelism(),
+        dataTableWriteConfig.getMetadataConfig().getMaxReaderBufferSize(),
+        columnsToIndex.get());
+    return Collections.singletonList(IndexPartitionInitialization.of(fileGroupCount, COLUMN_STATS.getPartitionPath(), records));
+  }
+
+  @Override
+  public void postInitialization(HoodieTableMetaClient metadataMetaClient, HoodieData<HoodieRecord> records, int fileGroupCount, String relativePartitionPath) {
+    HoodieIndexDefinition indexDefinition = HoodieIndexDefinition.newBuilder()
+        .withIndexName(PARTITION_NAME_COLUMN_STATS)
+        .withIndexType(PARTITION_NAME_COLUMN_STATS)
+        .withIndexFunction(PARTITION_NAME_COLUMN_STATS)
+        .withSourceFields(columnsToIndex.get())
+        // Use the existing version if exists, otherwise fall back to the default version.
+        .withVersion(existingIndexVersionOrDefault(PARTITION_NAME_COLUMN_STATS, dataTableMetaClient))
+        .withIndexOptions(Collections.EMPTY_MAP)
+        .build();
+    log.info("Registering or updating index: {} of type: {}", indexDefinition.getIndexName(), indexDefinition.getIndexType());
+    register(dataTableMetaClient, indexDefinition);
+
+    super.postInitialization(metadataMetaClient, records, fileGroupCount, relativePartitionPath);
+  }
+}

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/index/expression/ExpressionIndexer.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/index/expression/ExpressionIndexer.java
@@ -19,12 +19,22 @@
 
 package org.apache.hudi.metadata.index.expression;
 
+import org.apache.hudi.avro.model.HoodieCleanMetadata;
+import org.apache.hudi.common.config.HoodieMetadataConfig;
 import org.apache.hudi.common.data.HoodieData;
 import org.apache.hudi.common.engine.HoodieEngineContext;
+import org.apache.hudi.common.model.HoodieCommitMetadata;
 import org.apache.hudi.common.model.HoodieIndexDefinition;
+import org.apache.hudi.common.model.HoodieIndexMetadata;
 import org.apache.hudi.common.model.HoodieRecord;
+import org.apache.hudi.common.table.view.HoodieTableFileSystemView;
+import org.apache.hudi.common.util.Option;
+import org.apache.hudi.metadata.HoodieBackedTableMetadata;
 import org.apache.hudi.metadata.index.ExpressionIndexRecordGenerator;
 import org.apache.hudi.metadata.model.FileInfo;
+import org.apache.hudi.metadata.index.bloomfilters.BloomFiltersIndexer;
+import org.apache.hudi.metadata.index.columnstats.ColumnStatsIndexer;
+import org.apache.hudi.metadata.index.model.IndexPartitionAndRecords;
 import org.apache.hudi.metadata.model.FileSliceAndPartition;
 import org.apache.hudi.metadata.model.FileInfoAndPartition;
 import org.apache.hudi.metadata.index.model.IndexPartitionInitialization;
@@ -46,10 +56,14 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 
+import static org.apache.hudi.metadata.HoodieTableMetadataUtil.PARTITION_NAME_BLOOM_FILTERS;
+import static org.apache.hudi.metadata.HoodieTableMetadataUtil.PARTITION_NAME_COLUMN_STATS;
 import static org.apache.hudi.metadata.HoodieTableMetadataUtil.getExpressionIndexPartitionsToInit;
 import static org.apache.hudi.metadata.HoodieTableMetadataUtil.getProjectedSchemaForExpressionIndex;
 import static org.apache.hudi.metadata.MetadataPartitionType.EXPRESSION_INDEX;
+import static org.apache.hudi.metadata.MetadataPartitionType.fromPartitionPath;
 
 /**
  * Implementation of {@link MetadataPartitionType#EXPRESSION_INDEX} index
@@ -112,10 +126,69 @@ public class ExpressionIndexer extends BaseIndexer {
     HoodieSchema tableSchema = tableSchemaOpt.get();
     HoodieSchema readerSchema = getProjectedSchemaForExpressionIndex(indexDefinition, dataTableMetaClient, tableSchema);
 
-    HoodieData<HoodieRecord> records = expressionIndexRecordGenerator.generate(
+    HoodieData<HoodieRecord> records = expressionIndexRecordGenerator.buildInitialization(
         filesToIndex, indexDefinition, dataTableMetaClient, parallelism,
         tableSchema, readerSchema, engineContext.getStorageConf(), dataTableInstantTime);
 
     return Collections.singletonList(IndexPartitionInitialization.of(fileGroupCount, indexName, records));
+  }
+
+  @Override
+  public List<IndexPartitionAndRecords> buildUpdate(String instantTime, HoodieBackedTableMetadata tableMetadata, Lazy<HoodieTableFileSystemView> lazyFileSystemView,
+                                                    HoodieCommitMetadata commitMetadata) {
+    if (!MetadataPartitionType.EXPRESSION_INDEX.isMetadataPartitionAvailable(dataTableMetaClient)) {
+      log.info("Don't need to update expression index, since no expression index is available");
+      return Collections.emptyList();
+    }
+    return dataTableMetaClient.getTableConfig().getMetadataPartitions()
+        .stream()
+        .filter(partition -> partition.startsWith(HoodieTableMetadataUtil.PARTITION_NAME_EXPRESSION_INDEX_PREFIX))
+        .map(partition -> {
+          HoodieData<HoodieRecord> expressionIndexRecords;
+          try {
+            expressionIndexRecords = expressionIndexRecordGenerator.buildUpdate(dataTableMetaClient, tableMetadata, commitMetadata, partition, instantTime);
+          } catch (Exception e) {
+            throw new HoodieMetadataException(String.format("Failed to get expression index updates for partition %s", partition), e);
+          }
+          return IndexPartitionAndRecords.of(partition, expressionIndexRecords);
+        }).collect(Collectors.toList());
+  }
+
+  @Override
+  public List<IndexPartitionAndRecords> buildClean(String instantTime, HoodieCleanMetadata cleanMetadata) {
+    Option<HoodieIndexMetadata> indexMetadata = dataTableMetaClient.getIndexMetadata();
+    if (indexMetadata.isEmpty()) {
+      throw new HoodieMetadataException("Expression index metadata not found");
+    }
+    List<IndexPartitionAndRecords> indexRecordsList = new ArrayList<>();
+    HoodieIndexMetadata metadata = indexMetadata.get();
+    Map<String, HoodieIndexDefinition> indexDefinitions = metadata.getIndexDefinitions();
+    if (indexDefinitions.isEmpty()) {
+      throw new HoodieMetadataException("Expression index metadata not found");
+    }
+    // iterate over each index definition and check:
+    // if it is an expression index using column_stats, then follow the same approach as column_stats
+    // if it is an expression index using bloom_filters, then follow the same approach as bloom_filters
+    // else throw an exception
+    for (Map.Entry<String, HoodieIndexDefinition> entry : indexDefinitions.entrySet()) {
+      String indexName = entry.getKey();
+      HoodieIndexDefinition indexDefinition = entry.getValue();
+      if (MetadataPartitionType.EXPRESSION_INDEX.equals(fromPartitionPath(indexDefinition.getIndexName()))) {
+        if (indexDefinition.getIndexType().equalsIgnoreCase(PARTITION_NAME_BLOOM_FILTERS)) {
+          indexRecordsList.add(IndexPartitionAndRecords.of(indexName,
+              BloomFiltersIndexer.convertMetadataToBloomFilterRecords(cleanMetadata, engineContext, instantTime, dataTableWriteConfig.getBloomIndexParallelism())));
+        } else if (indexDefinition.getIndexType().equalsIgnoreCase(PARTITION_NAME_COLUMN_STATS)) {
+          HoodieMetadataConfig modifiedMetadataConfig = HoodieMetadataConfig.newBuilder()
+              .withProperties(dataTableWriteConfig.getMetadataConfig().getProps())
+              .withColumnStatsIndexForColumns(String.join(",", indexDefinition.getSourceFields()))
+              .build();
+          indexRecordsList.add(IndexPartitionAndRecords.of(indexName, ColumnStatsIndexer.convertMetadataToColumnStatsRecords(
+              cleanMetadata, engineContext, dataTableMetaClient, modifiedMetadataConfig, Option.of(dataTableWriteConfig.getRecordMerger().getRecordType()))));
+        } else {
+          throw new HoodieMetadataException("Unsupported expression index type");
+        }
+      }
+    }
+    return indexRecordsList;
   }
 }

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/index/expression/ExpressionIndexer.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/index/expression/ExpressionIndexer.java
@@ -1,0 +1,121 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.hudi.metadata.index.expression;
+
+import org.apache.hudi.common.data.HoodieData;
+import org.apache.hudi.common.engine.HoodieEngineContext;
+import org.apache.hudi.common.model.HoodieIndexDefinition;
+import org.apache.hudi.common.model.HoodieRecord;
+import org.apache.hudi.metadata.index.ExpressionIndexRecordGenerator;
+import org.apache.hudi.metadata.model.FileInfo;
+import org.apache.hudi.metadata.model.FileSliceAndPartition;
+import org.apache.hudi.metadata.model.FileInfoAndPartition;
+import org.apache.hudi.metadata.index.model.IndexPartitionInitialization;
+import org.apache.hudi.common.schema.HoodieSchema;
+import org.apache.hudi.common.table.HoodieTableMetaClient;
+import org.apache.hudi.common.util.ValidationUtils;
+import org.apache.hudi.config.HoodieWriteConfig;
+import org.apache.hudi.exception.HoodieMetadataException;
+import org.apache.hudi.metadata.HoodieTableMetadataUtil;
+import org.apache.hudi.metadata.MetadataPartitionType;
+import org.apache.hudi.metadata.index.BaseIndexer;
+import org.apache.hudi.util.Lazy;
+
+import lombok.extern.slf4j.Slf4j;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.apache.hudi.metadata.HoodieTableMetadataUtil.getExpressionIndexPartitionsToInit;
+import static org.apache.hudi.metadata.HoodieTableMetadataUtil.getProjectedSchemaForExpressionIndex;
+import static org.apache.hudi.metadata.MetadataPartitionType.EXPRESSION_INDEX;
+
+/**
+ * Implementation of {@link MetadataPartitionType#EXPRESSION_INDEX} index
+ */
+@Slf4j
+public class ExpressionIndexer extends BaseIndexer {
+
+  private final ExpressionIndexRecordGenerator expressionIndexRecordGenerator;
+
+  public ExpressionIndexer(
+      HoodieEngineContext engineContext,
+      HoodieWriteConfig dataTableWriteConfig,
+      HoodieTableMetaClient dataTableMetaClient,
+      ExpressionIndexRecordGenerator expressionIndexRecordGenerator) {
+    super(engineContext, dataTableWriteConfig, dataTableMetaClient);
+
+    this.expressionIndexRecordGenerator = expressionIndexRecordGenerator;
+  }
+
+  @Override
+  public List<IndexPartitionInitialization> buildInitialization(
+      String dataTableInstantTime,
+      String instantTimeForPartition,
+      Map<String, List<FileInfo>> partitionToAllFilesMap,
+      Lazy<List<FileSliceAndPartition>> lazyLatestMergedPartitionFileSliceList) throws IOException {
+    Set<String> expressionIndexPartitionsToInit = getExpressionIndexPartitionsToInit(
+        EXPRESSION_INDEX, dataTableWriteConfig.getMetadataConfig(), dataTableMetaClient);
+    if (expressionIndexPartitionsToInit.size() != 1) {
+      if (expressionIndexPartitionsToInit.size() > 1) {
+        log.warn("Skipping expression index initialization as only one expression index "
+            + "bootstrap at a time is supported for now. Provided: {}", expressionIndexPartitionsToInit);
+      }
+      return Collections.emptyList();
+    }
+
+    String indexName = expressionIndexPartitionsToInit.iterator().next();
+    HoodieIndexDefinition indexDefinition = HoodieTableMetadataUtil.getHoodieIndexDefinition(indexName, dataTableMetaClient);
+    ValidationUtils.checkState(indexDefinition != null, "Expression Index definition is not present for index " + indexName);
+
+    List<FileSliceAndPartition> partitionFileSlicePairs = lazyLatestMergedPartitionFileSliceList.get();
+    List<FileInfoAndPartition> filesToIndex = new ArrayList<>();
+    partitionFileSlicePairs.forEach(fsp -> {
+      if (fsp.fileSlice().getBaseFile().isPresent()) {
+        filesToIndex.add(FileInfoAndPartition.of(fsp.partitionPath(), fsp.fileSlice().getBaseFile().get().getPath(), fsp.fileSlice().getBaseFile().get().getFileSize()));
+      }
+      fsp.fileSlice().getLogFiles()
+          .forEach(hoodieLogFile
+              -> filesToIndex.add(FileInfoAndPartition.of(fsp.partitionPath(), hoodieLogFile.getPath().toString(), hoodieLogFile.getFileSize())));
+    });
+
+    int fileGroupCount = dataTableWriteConfig.getMetadataConfig().getExpressionIndexFileGroupCount();
+    if (partitionFileSlicePairs.isEmpty()) {
+      return Collections.singletonList(IndexPartitionInitialization.of(fileGroupCount, indexName, engineContext.emptyHoodieData()));
+    }
+
+    int parallelism = Math.min(filesToIndex.size(), dataTableWriteConfig.getMetadataConfig().getExpressionIndexParallelism());
+    Lazy<HoodieSchema> tableSchemaOpt = Lazy.lazily(() ->
+        HoodieTableMetadataUtil.tryResolveSchemaForTable(dataTableMetaClient)
+            .orElseThrow(() -> new HoodieMetadataException("Table schema is not available for expression index initialization")));
+    HoodieSchema tableSchema = tableSchemaOpt.get();
+    HoodieSchema readerSchema = getProjectedSchemaForExpressionIndex(indexDefinition, dataTableMetaClient, tableSchema);
+
+    HoodieData<HoodieRecord> records = expressionIndexRecordGenerator.generate(
+        filesToIndex, indexDefinition, dataTableMetaClient, parallelism,
+        tableSchema, readerSchema, engineContext.getStorageConf(), dataTableInstantTime);
+
+    return Collections.singletonList(IndexPartitionInitialization.of(fileGroupCount, indexName, records));
+  }
+}

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/index/files/FilesIndexer.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/index/files/FilesIndexer.java
@@ -18,9 +18,20 @@
 
 package org.apache.hudi.metadata.index.files;
 
+import org.apache.hudi.avro.model.HoodieCleanMetadata;
+import org.apache.hudi.common.data.HoodieAccumulator;
+import org.apache.hudi.common.data.HoodieAtomicLongAccumulator;
 import org.apache.hudi.common.data.HoodieData;
 import org.apache.hudi.common.engine.HoodieEngineContext;
 import org.apache.hudi.metadata.model.FileInfo;
+import org.apache.hudi.common.fs.FSUtils;
+import org.apache.hudi.common.model.HoodieCommitMetadata;
+import org.apache.hudi.common.model.HoodieWriteStat;
+import org.apache.hudi.common.table.view.HoodieTableFileSystemView;
+import org.apache.hudi.common.util.CollectionUtils;
+import org.apache.hudi.metadata.HoodieBackedTableMetadata;
+import org.apache.hudi.metadata.HoodieTableMetadataUtil;
+import org.apache.hudi.metadata.index.model.IndexPartitionAndRecords;
 import org.apache.hudi.metadata.model.FileSliceAndPartition;
 import org.apache.hudi.common.model.HoodieRecord;
 import org.apache.hudi.metadata.index.model.IndexPartitionInitialization;
@@ -37,6 +48,8 @@ import lombok.extern.slf4j.Slf4j;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -84,5 +97,166 @@ public class FilesIndexer extends BaseIndexer {
     ValidationUtils.checkState(fileListRecords.count() == partitions.size());
 
     return Collections.singletonList(IndexPartitionInitialization.of(fileGroupCount, FILES.getPartitionPath(), allPartitionsRecord.union(fileListRecords)));
+  }
+
+  @Override
+  public List<IndexPartitionAndRecords> buildUpdate(
+      String instantTime,
+      HoodieBackedTableMetadata tableMetadata,
+      Lazy<HoodieTableFileSystemView> lazyFileSystemView,
+      HoodieCommitMetadata commitMetadata) {
+    final HoodieData<HoodieRecord> records = engineContext.parallelize(
+        convertMetadataToFilesPartitionRecords(commitMetadata, instantTime), 1);
+    return Collections.singletonList(IndexPartitionAndRecords.of(FILES.getPartitionPath(), records));
+  }
+
+  @Override
+  public List<IndexPartitionAndRecords> buildClean(String instantTime, HoodieCleanMetadata cleanMetadata) {
+    final HoodieData<HoodieRecord> records = engineContext.parallelize(
+        convertMetadataToFilesPartitionRecords(cleanMetadata, instantTime), 1);
+    return Collections.singletonList(IndexPartitionAndRecords.of(FILES.getPartitionPath(), records));
+  }
+
+  @Override
+  public List<IndexPartitionAndRecords> buildRestore(String instantTime, List<String> deletedPartitions, Map<String, List<FileInfo>> filesAdded, Map<String, List<String>> filesDeleted) {
+    List<HoodieRecord> records = new LinkedList<>();
+    int[] fileDeleteCount = {0};
+    int[] filesAddedCount = {0};
+
+    filesAdded.forEach((partition, filesToAdd) -> {
+      filesAddedCount[0] += filesToAdd.size();
+      List<String> filesToDelete = filesDeleted.getOrDefault(partition, Collections.emptyList());
+      fileDeleteCount[0] += filesToDelete.size();
+      Map<String, Long> fileNameToSize = filesToAdd.stream().collect(Collectors.toMap(FileInfo::fileName, FileInfo::size));
+      HoodieRecord record = HoodieMetadataPayload.createPartitionFilesRecord(partition, fileNameToSize, filesToDelete);
+      records.add(record);
+    });
+
+    // there could be partitions which only has missing deleted files.
+    filesDeleted.forEach((partition, filesToDelete) -> {
+      if (!filesAdded.containsKey(partition)) {
+        fileDeleteCount[0] += filesToDelete.size();
+        HoodieRecord record = HoodieMetadataPayload.createPartitionFilesRecord(partition, Collections.emptyMap(), filesToDelete);
+        records.add(record);
+      }
+    });
+
+    if (!deletedPartitions.isEmpty()) {
+      // if there are partitions to be deleted, add them to delete list
+      records.add(HoodieMetadataPayload.createPartitionListRecord(deletedPartitions, true));
+    }
+
+    log.info("Re-adding missing records at {} during Restore. #partitions_updated={}, #files_added={}, #files_deleted={}, #partitions_deleted={}",
+        instantTime, records.size(), filesAddedCount[0], fileDeleteCount[0], deletedPartitions.size());
+    return Collections.singletonList(IndexPartitionAndRecords.of(MetadataPartitionType.FILES.getPartitionPath(), engineContext.parallelize(records, 1)));
+  }
+
+  // -------------------------------------------------------------------------
+  //  Utilities
+  // -------------------------------------------------------------------------
+
+  /**
+   * Finds all new files/partitions created as part of commit and creates metadata table records for them.
+   *
+   * @param commitMetadata - Commit action metadata
+   * @param instantTime    - Commit action instant time
+   * @return List of metadata table records
+   */
+  private static List<HoodieRecord> convertMetadataToFilesPartitionRecords(HoodieCommitMetadata commitMetadata,
+                                                                           String instantTime) {
+    List<HoodieRecord> records = new ArrayList<>(commitMetadata.getPartitionToWriteStats().size());
+
+    // Add record bearing added partitions list
+    List<String> partitionsAdded = getPartitionsAdded(commitMetadata);
+
+    records.add(HoodieMetadataPayload.createPartitionListRecord(partitionsAdded));
+
+    // Update files listing records for each individual partition
+    HoodieAccumulator newFileCount = HoodieAtomicLongAccumulator.create();
+    List<HoodieRecord<HoodieMetadataPayload>> updatedPartitionFilesRecords =
+        commitMetadata.getPartitionToWriteStats().entrySet()
+            .stream()
+            .map(entry -> {
+              String partitionStatName = entry.getKey();
+              List<HoodieWriteStat> writeStats = entry.getValue();
+
+              HashMap<String, Long> updatedFilesToSizesMapping =
+                  writeStats.stream().reduce(new HashMap<>(writeStats.size()),
+                      (map, stat) -> {
+                        String pathWithPartition = stat.getPath();
+                        if (pathWithPartition == null) {
+                          // Empty partition
+                          log.warn("Unable to find path in write stat to update metadata table {}", stat);
+                          return map;
+                        }
+
+                        String fileName = FSUtils.getFileName(pathWithPartition, partitionStatName);
+
+                        // Since write-stats are coming in no particular order, if the same
+                        // file have previously been appended to w/in the txn, we simply pick max
+                        // of the sizes as reported after every write, since file-sizes are
+                        // monotonically increasing (ie file-size never goes down, unless deleted)
+                        map.merge(fileName, stat.getFileSizeInBytes(), Math::max);
+
+                        Map<String, Long> cdcPathAndSizes = stat.getCdcStats();
+                        if (cdcPathAndSizes != null && !cdcPathAndSizes.isEmpty()) {
+                          cdcPathAndSizes.forEach((key, value) -> map.put(FSUtils.getFileName(key, partitionStatName), value));
+                        }
+                        return map;
+                      },
+                      CollectionUtils::combine);
+
+              newFileCount.add(updatedFilesToSizesMapping.size());
+              return HoodieMetadataPayload.createPartitionFilesRecord(partitionStatName, updatedFilesToSizesMapping,
+                  Collections.emptyList());
+            })
+            .collect(Collectors.toList());
+
+    records.addAll(updatedPartitionFilesRecords);
+
+    log.info("Updating at {} from Commit/{}. #partitions_updated={}, #files_added={}", instantTime, commitMetadata.getOperationType(),
+        records.size(), newFileCount.value());
+
+    return records;
+  }
+
+  /**
+   * Finds all files that were deleted as part of a clean and creates metadata table records for them.
+   *
+   * @param cleanMetadata
+   * @param instantTime
+   * @return a list of metadata table records
+   */
+  private static List<HoodieRecord> convertMetadataToFilesPartitionRecords(HoodieCleanMetadata cleanMetadata,
+                                                                          String instantTime) {
+    List<HoodieRecord> records = new LinkedList<>();
+    int[] fileDeleteCount = {0};
+    List<String> deletedPartitions = new ArrayList<>();
+    cleanMetadata.getPartitionMetadata().forEach((partitionName, partitionMetadata) -> {
+      boolean isPartitionDeleted = partitionMetadata.getIsPartitionDeleted();
+      // Files deleted from a partition
+      List<String> deletedFiles = partitionMetadata.getDeletePathPatterns();
+      records.add(HoodieMetadataPayload.createPartitionFilesRecord(partitionName, Collections.emptyMap(),
+          deletedFiles, isPartitionDeleted));
+      fileDeleteCount[0] += deletedFiles.size();
+      if (isPartitionDeleted) {
+        deletedPartitions.add(partitionName);
+      }
+    });
+
+    if (!deletedPartitions.isEmpty()) {
+      // if there are partitions to be deleted, add them to delete list
+      records.add(HoodieMetadataPayload.createPartitionListRecord(deletedPartitions, true));
+    }
+    log.info("Updating at {} from Clean. #partitions_updated={}, #files_deleted={}, #partitions_deleted={}",
+        instantTime, records.size(), fileDeleteCount[0], deletedPartitions.size());
+    return records;
+  }
+
+  private static List<String> getPartitionsAdded(HoodieCommitMetadata commitMetadata) {
+    return commitMetadata.getPartitionToWriteStats().keySet().stream()
+        // We need to make sure we properly handle case of non-partitioned tables
+        .map(HoodieTableMetadataUtil::getPartitionIdentifierForFilesPartition)
+        .collect(Collectors.toList());
   }
 }

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/index/files/FilesIndexer.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/index/files/FilesIndexer.java
@@ -1,0 +1,88 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.metadata.index.files;
+
+import org.apache.hudi.common.data.HoodieData;
+import org.apache.hudi.common.engine.HoodieEngineContext;
+import org.apache.hudi.metadata.model.FileInfo;
+import org.apache.hudi.metadata.model.FileSliceAndPartition;
+import org.apache.hudi.common.model.HoodieRecord;
+import org.apache.hudi.metadata.index.model.IndexPartitionInitialization;
+import org.apache.hudi.common.table.HoodieTableMetaClient;
+import org.apache.hudi.common.util.ValidationUtils;
+import org.apache.hudi.config.HoodieWriteConfig;
+import org.apache.hudi.metadata.HoodieMetadataPayload;
+import org.apache.hudi.metadata.MetadataPartitionType;
+import org.apache.hudi.metadata.index.BaseIndexer;
+import org.apache.hudi.util.Lazy;
+
+import lombok.extern.slf4j.Slf4j;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static org.apache.hudi.metadata.MetadataPartitionType.FILES;
+
+/**
+ * Implementation of {@link MetadataPartitionType#FILES} metadata
+ */
+@Slf4j
+public class FilesIndexer extends BaseIndexer {
+  public FilesIndexer(HoodieEngineContext engineContext, HoodieWriteConfig dataTableWriteConfig,
+                         HoodieTableMetaClient dataTableMetaClient) {
+    super(engineContext, dataTableWriteConfig, dataTableMetaClient);
+  }
+
+  @Override
+  public List<IndexPartitionInitialization> buildInitialization(String dataTableInstantTime, String instantTimeForPartition, Map<String, List<FileInfo>> partitionToAllFilesMap,
+                                                                Lazy<List<FileSliceAndPartition>> lazyLatestMergedPartitionFileSliceList) throws IOException {
+    // FILES partition uses a single file group
+    final int fileGroupCount = 1;
+
+    Set<String> partitions = partitionToAllFilesMap.keySet();
+    final int totalDataFilesCount = partitionToAllFilesMap.values().stream().mapToInt(List::size).sum();
+    log.info("Committing total {} partitions and {} files to metadata", partitions.size(), totalDataFilesCount);
+
+    // Record which saves the list of all partitions
+    HoodieRecord record = HoodieMetadataPayload.createPartitionListRecord(partitions);
+    HoodieData<HoodieRecord> allPartitionsRecord = engineContext.parallelize(Collections.singletonList(record), 1);
+    if (partitionToAllFilesMap.isEmpty()) {
+      return Collections.singletonList(IndexPartitionInitialization.of(fileGroupCount, FILES.getPartitionPath(), allPartitionsRecord));
+    }
+
+    // Records which save the file listing of each partition
+    engineContext.setJobStatus(this.getClass().getSimpleName(), "Creating records for metadata FILES partition");
+    HoodieData<HoodieRecord> fileListRecords = engineContext.parallelize(
+            new ArrayList<>(partitionToAllFilesMap.entrySet()), partitionToAllFilesMap.size())
+        .map(partitionInfo -> {
+          Map<String, Long> fileNameToSizeMap = partitionInfo.getValue().stream()
+              .collect(Collectors.toMap(FileInfo::fileName, FileInfo::size));
+          return HoodieMetadataPayload.createPartitionFilesRecord(
+              partitionInfo.getKey(), fileNameToSizeMap, Collections.emptyList());
+        });
+    ValidationUtils.checkState(fileListRecords.count() == partitions.size());
+
+    return Collections.singletonList(IndexPartitionInitialization.of(fileGroupCount, FILES.getPartitionPath(), allPartitionsRecord.union(fileListRecords)));
+  }
+}

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/index/model/DataPartitionAndRecords.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/index/model/DataPartitionAndRecords.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.metadata.index.model;
+
+import org.apache.hudi.common.data.HoodieData;
+import org.apache.hudi.common.model.HoodieRecord;
+import org.apache.hudi.common.util.Option;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.experimental.Accessors;
+
+/**
+ * Holds the initialization records and data partition if the index is a partitioned index, e.g., partitioned record level index.
+ * <p>
+ * For non-partitioned indexes, {@code dataPartition} is empty and the records represent the entire index records.
+ */
+@AllArgsConstructor
+@Getter
+@Accessors(fluent = true)
+public class DataPartitionAndRecords {
+  private final int numFileGroups;
+  private final Option<String> dataPartition;
+  private final HoodieData<HoodieRecord> indexRecords;
+}

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/index/model/IndexPartitionAndRecords.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/index/model/IndexPartitionAndRecords.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.metadata.index.model;
+
+import org.apache.hudi.common.data.HoodieData;
+import org.apache.hudi.common.model.HoodieRecord;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.experimental.Accessors;
+
+@AllArgsConstructor
+@Getter
+@Accessors(fluent = true)
+public class IndexPartitionAndRecords {
+  private final String indexPartitionName;
+  private final HoodieData<HoodieRecord> indexRecords;
+
+  public static IndexPartitionAndRecords of(String indexPartitionName, HoodieData<HoodieRecord> indexRecords) {
+    return new IndexPartitionAndRecords(indexPartitionName, indexRecords);
+  }
+}

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/index/model/IndexPartitionInitialization.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/index/model/IndexPartitionInitialization.java
@@ -1,0 +1,90 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.hudi.metadata.index.model;
+
+import org.apache.hudi.common.data.HoodieData;
+import org.apache.hudi.common.model.HoodieRecord;
+import org.apache.hudi.common.util.Option;
+import org.apache.hudi.metadata.DefaultMetadataTableFileGroupIndexParser;
+import org.apache.hudi.metadata.MetadataTableFileGroupIndexParser;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.experimental.Accessors;
+
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Represents the initialization data for a single metadata index partition,
+ * including file-group count, optional source data partition, destination metadata
+ * partition path, and records to commit.
+ */
+@AllArgsConstructor
+@Getter
+@Accessors(fluent = true)
+public class IndexPartitionInitialization {
+  private final int totalFileGroups;
+  private final String indexPartitionName;
+  private final MetadataTableFileGroupIndexParser indexParser;
+  private final List<DataPartitionAndRecords> dataPartitionAndRecords;
+
+  /**
+   * Creates initialization data for a non-partitioned index from a single {@link DataPartitionAndRecords}
+   * payload and a default file-group parser.
+   *
+   * @param indexPartitionName      metadata index partition path to initialize
+   * @param dataPartitionAndRecords records and metadata for one data partition (or non-partitioned payload)
+   * @return an {@link IndexPartitionInitialization} instance configured with file-group count inferred
+   *         from {@code dataPartitionAndRecords}
+   */
+  public static IndexPartitionInitialization of(String indexPartitionName, DataPartitionAndRecords dataPartitionAndRecords) {
+    return of(dataPartitionAndRecords.numFileGroups(), indexPartitionName, dataPartitionAndRecords.indexRecords());
+  }
+
+  /**
+   * Creates initialization data for a non-partitioned index using a single records payload and the default
+   * {@link MetadataTableFileGroupIndexParser} implementation.
+   *
+   * @param totalFileGroups    total number of file groups to pre-create for this index partition
+   * @param indexPartitionName metadata index partition path/name to initialize
+   * @param indexRecords       records to be written into the target index partition
+   * @return an {@link IndexPartitionInitialization} containing one {@link DataPartitionAndRecords}
+   *         entry without source data-partition binding
+   */
+  public static IndexPartitionInitialization of(int totalFileGroups, String indexPartitionName, HoodieData<HoodieRecord> indexRecords) {
+    return of(totalFileGroups, indexPartitionName, new DefaultMetadataTableFileGroupIndexParser(totalFileGroups),
+        Collections.singletonList(new DataPartitionAndRecords(totalFileGroups, Option.empty(), indexRecords)));
+  }
+
+  /**
+   * Creates initialization data for a partitioned index with a provided file-group parser and
+   * one or more per-data-partition record payloads.
+   *
+   * @param totalFileGroups         total number of file groups to pre-create for this index partition
+   * @param indexPartitionName      metadata index partition path to initialize
+   * @param indexParser             parser used to map records to metadata table file-group indexes
+   * @param dataPartitionAndRecords input record payloads grouped by source data partition
+   * @return an {@link IndexPartitionInitialization} with the provided parser and partitioned payloads
+   */
+  public static IndexPartitionInitialization of(int totalFileGroups, String indexPartitionName, MetadataTableFileGroupIndexParser indexParser, List<DataPartitionAndRecords> dataPartitionAndRecords) {
+    return new IndexPartitionInitialization(totalFileGroups, indexPartitionName, indexParser, dataPartitionAndRecords);
+  }
+}

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/index/partitionstats/PartitionStatsIndexer.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/index/partitionstats/PartitionStatsIndexer.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.hudi.metadata.index.partitionstats;
+
+import org.apache.hudi.common.config.HoodieMetadataConfig;
+import org.apache.hudi.common.data.HoodieData;
+import org.apache.hudi.common.engine.HoodieEngineContext;
+import org.apache.hudi.metadata.model.FileInfo;
+import org.apache.hudi.metadata.model.FileSliceAndPartition;
+import org.apache.hudi.common.model.HoodieRecord;
+import org.apache.hudi.metadata.index.model.IndexPartitionInitialization;
+import org.apache.hudi.common.schema.HoodieSchema;
+import org.apache.hudi.common.table.HoodieTableMetaClient;
+import org.apache.hudi.common.util.Option;
+import org.apache.hudi.config.HoodieWriteConfig;
+import org.apache.hudi.metadata.HoodieTableMetadataUtil;
+import org.apache.hudi.metadata.MetadataPartitionType;
+import org.apache.hudi.metadata.index.BaseIndexer;
+import org.apache.hudi.util.Lazy;
+
+import lombok.extern.slf4j.Slf4j;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import static org.apache.hudi.metadata.MetadataPartitionType.PARTITION_STATS;
+
+/**
+ * Implementation of {@link MetadataPartitionType#PARTITION_STATS} metadata
+ */
+@Slf4j
+public class PartitionStatsIndexer extends BaseIndexer {
+  public PartitionStatsIndexer(HoodieEngineContext engineContext, HoodieWriteConfig dataTableWriteConfig,
+                                  HoodieTableMetaClient dataTableMetaClient) {
+    super(engineContext, dataTableWriteConfig, dataTableMetaClient);
+  }
+
+  @Override
+  public List<IndexPartitionInitialization> buildInitialization(String dataTableInstantTime, String instantTimeForPartition, Map<String, List<FileInfo>> partitionToAllFilesMap,
+                                                                Lazy<List<FileSliceAndPartition>> lazyLatestMergedPartitionFileSliceList) throws IOException {
+    // Partition stats index cannot be enabled for a non-partitioned table
+    if (!dataTableMetaClient.getTableConfig().isTablePartitioned()) {
+      return Collections.emptyList();
+    }
+
+    // For PARTITION_STATS, COLUMN_STATS should also be enabled
+    if (!dataTableWriteConfig.isMetadataColumnStatsIndexEnabled()) {
+      log.debug("Skipping partition stats initialization as column stats index is not enabled. Please enable {}",
+          HoodieMetadataConfig.ENABLE_METADATA_INDEX_COLUMN_STATS.key());
+      return Collections.emptyList();
+    }
+
+    Lazy<Option<HoodieSchema>> tableSchemaOpt = Lazy.lazily(() -> HoodieTableMetadataUtil.tryResolveSchemaForTable(dataTableMetaClient));
+    HoodieData<HoodieRecord> records = HoodieTableMetadataUtil.convertFilesToPartitionStatsRecords(
+        engineContext, lazyLatestMergedPartitionFileSliceList.get(), dataTableWriteConfig.getMetadataConfig(),
+        dataTableMetaClient, tableSchemaOpt, Option.of(dataTableWriteConfig.getRecordMerger().getRecordType()));
+    final int fileGroupCount = dataTableWriteConfig.getMetadataConfig().getPartitionStatsIndexFileGroupCount();
+
+    return Collections.singletonList(IndexPartitionInitialization.of(fileGroupCount, PARTITION_STATS.getPartitionPath(), records));
+  }
+}

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/index/partitionstats/PartitionStatsIndexer.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/index/partitionstats/PartitionStatsIndexer.java
@@ -19,10 +19,28 @@
 
 package org.apache.hudi.metadata.index.partitionstats;
 
+import org.apache.hudi.avro.model.HoodieCleanMetadata;
 import org.apache.hudi.common.config.HoodieMetadataConfig;
 import org.apache.hudi.common.data.HoodieData;
+import org.apache.hudi.common.data.HoodieListData;
+import org.apache.hudi.common.data.HoodiePairData;
 import org.apache.hudi.common.engine.HoodieEngineContext;
 import org.apache.hudi.metadata.model.FileInfo;
+import org.apache.hudi.common.model.HoodieCommitMetadata;
+import org.apache.hudi.common.model.HoodieReplaceCommitMetadata;
+import org.apache.hudi.common.model.HoodieWriteStat;
+import org.apache.hudi.common.model.WriteOperationType;
+import org.apache.hudi.common.schema.HoodieSchemaUtils;
+import org.apache.hudi.common.table.HoodieTableConfig;
+import org.apache.hudi.common.table.view.HoodieTableFileSystemView;
+import org.apache.hudi.common.util.VisibleForTesting;
+import org.apache.hudi.common.util.collection.Pair;
+import org.apache.hudi.exception.HoodieException;
+import org.apache.hudi.metadata.HoodieBackedTableMetadata;
+import org.apache.hudi.metadata.HoodieIndexVersion;
+import org.apache.hudi.metadata.HoodieMetadataPayload;
+import org.apache.hudi.metadata.HoodieTableMetadata;
+import org.apache.hudi.metadata.index.model.IndexPartitionAndRecords;
 import org.apache.hudi.metadata.model.FileSliceAndPartition;
 import org.apache.hudi.common.model.HoodieRecord;
 import org.apache.hudi.metadata.index.model.IndexPartitionInitialization;
@@ -33,15 +51,33 @@ import org.apache.hudi.config.HoodieWriteConfig;
 import org.apache.hudi.metadata.HoodieTableMetadataUtil;
 import org.apache.hudi.metadata.MetadataPartitionType;
 import org.apache.hudi.metadata.index.BaseIndexer;
+import org.apache.hudi.stats.HoodieColumnRangeMetadata;
 import org.apache.hudi.util.Lazy;
 
 import lombok.extern.slf4j.Slf4j;
 
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
+import static java.util.stream.Collectors.toList;
+import static org.apache.hudi.common.util.StringUtils.isNullOrEmpty;
+import static org.apache.hudi.common.util.ValidationUtils.checkState;
+import static org.apache.hudi.metadata.HoodieMetadataWriteUtils.getFilesToFetchColumnStats;
+import static org.apache.hudi.metadata.HoodieMetadataWriteUtils.getMaxInstantTime;
+import static org.apache.hudi.metadata.HoodieTableMetadataUtil.PARTITION_NAME_PARTITION_STATS;
+import static org.apache.hudi.metadata.HoodieTableMetadataUtil.convertMetadataToPartitionStatsRecords;
+import static org.apache.hudi.metadata.HoodieTableMetadataUtil.existingIndexVersionOrDefault;
+import static org.apache.hudi.metadata.HoodieTableMetadataUtil.generateColumnStatsKeys;
+import static org.apache.hudi.metadata.HoodieTableMetadataUtil.getColumnsToIndex;
+import static org.apache.hudi.metadata.HoodieTableMetadataUtil.translateWriteStatToFileStats;
 import static org.apache.hudi.metadata.MetadataPartitionType.PARTITION_STATS;
 
 /**
@@ -76,5 +112,123 @@ public class PartitionStatsIndexer extends BaseIndexer {
     final int fileGroupCount = dataTableWriteConfig.getMetadataConfig().getPartitionStatsIndexFileGroupCount();
 
     return Collections.singletonList(IndexPartitionInitialization.of(fileGroupCount, PARTITION_STATS.getPartitionPath(), records));
+  }
+
+  @Override
+  public List<IndexPartitionAndRecords> buildUpdate(String instantTime, HoodieBackedTableMetadata tableMetadata, Lazy<HoodieTableFileSystemView> lazyFileSystemView,
+                                                    HoodieCommitMetadata commitMetadata) {
+    checkState(MetadataPartitionType.COLUMN_STATS.isMetadataPartitionAvailable(dataTableMetaClient),
+        "Column stats partition must be enabled to generate partition stats. Please enable: " + HoodieMetadataConfig.ENABLE_METADATA_INDEX_COLUMN_STATS.key());
+    // Generate Hoodie Pair data of partition name and list of column range metadata for all the files in that partition
+    boolean isDeletePartition = commitMetadata.getOperationType().equals(WriteOperationType.DELETE_PARTITION);
+    final HoodieData<HoodieRecord> records = convertMetadataToPartitionStatRecords(commitMetadata, instantTime, engineContext, dataTableWriteConfig,
+        dataTableMetaClient, tableMetadata, dataTableWriteConfig.getMetadataConfig(), Option.of(dataTableWriteConfig.getRecordMerger().getRecordType()), isDeletePartition);
+    return Collections.singletonList(IndexPartitionAndRecords.of(PARTITION_STATS.getPartitionPath(), records));
+  }
+
+  @Override
+  public List<IndexPartitionAndRecords> buildClean(String instantTime, HoodieCleanMetadata cleanMetadata) {
+    return Collections.emptyList();
+  }
+
+  @VisibleForTesting
+  public static HoodieData<HoodieRecord> convertMetadataToPartitionStatRecords(HoodieCommitMetadata commitMetadata, String instantTime,
+                                                                               HoodieEngineContext engineContext, HoodieWriteConfig dataWriteConfig,
+                                                                               HoodieTableMetaClient dataMetaClient,
+                                                                               HoodieTableMetadata tableMetadata, HoodieMetadataConfig metadataConfig,
+                                                                               Option<HoodieRecord.HoodieRecordType> recordTypeOpt, boolean isDeletePartition) {
+    try {
+      Option<HoodieSchema> writerSchema =
+          Option.ofNullable(commitMetadata.getMetadata(HoodieCommitMetadata.SCHEMA_KEY))
+              .flatMap(writerSchemaStr ->
+                  isNullOrEmpty(writerSchemaStr)
+                      ? Option.empty()
+                      : Option.of(HoodieSchema.parse(writerSchemaStr)));
+      HoodieTableConfig tableConfig = dataMetaClient.getTableConfig();
+      Option<HoodieSchema> tableSchema = writerSchema.map(schema -> tableConfig.populateMetaFields() ? HoodieSchemaUtils.addMetadataFields(schema) : schema);
+
+      if (tableSchema.isEmpty()) {
+        return engineContext.emptyHoodieData();
+      }
+      HoodieIndexVersion partitionStatsIndexVersion = existingIndexVersionOrDefault(PARTITION_NAME_PARTITION_STATS, dataMetaClient);
+      Lazy<Option<HoodieSchema>> writerSchemaOpt = Lazy.eagerly(tableSchema);
+      Map<String, HoodieSchema> columnsToIndexSchemaMap = getColumnsToIndex(dataMetaClient.getTableConfig(), metadataConfig, writerSchemaOpt, false, recordTypeOpt, partitionStatsIndexVersion);
+      if (columnsToIndexSchemaMap.isEmpty()) {
+        return engineContext.emptyHoodieData();
+      }
+
+      // if this is DELETE_PARTITION, then create delete metadata payload for all columns for partition_stats
+      if (isDeletePartition) {
+        HoodieReplaceCommitMetadata replaceCommitMetadata = (HoodieReplaceCommitMetadata) commitMetadata;
+        Map<String, List<String>> partitionToReplaceFileIds = replaceCommitMetadata.getPartitionToReplaceFileIds();
+        List<String> partitionsToDelete = new ArrayList<>(partitionToReplaceFileIds.keySet());
+        if (partitionToReplaceFileIds.isEmpty()) {
+          return engineContext.emptyHoodieData();
+        }
+        return engineContext.parallelize(partitionsToDelete, partitionsToDelete.size()).flatMap(partition -> {
+          Stream<HoodieRecord> columnRangeMetadata = columnsToIndexSchemaMap.keySet().stream()
+              .flatMap(column -> HoodieMetadataPayload.createPartitionStatsRecords(
+                  partition,
+                  Collections.singletonList(HoodieColumnRangeMetadata.stub("", column, partitionStatsIndexVersion)),
+                  true, true, Option.empty()));
+          return columnRangeMetadata.iterator();
+        });
+      }
+
+      // In this function we fetch column range metadata for all new files part of commit metadata along with all the other files
+      // of the affected partitions. The column range metadata is grouped by partition name to generate HoodiePairData of partition name
+      // and list of column range metadata for that partition files. This pair data is then used to generate partition stat records.
+      List<HoodieWriteStat> allWriteStats = commitMetadata.getPartitionToWriteStats().values().stream()
+          .flatMap(Collection::stream).collect(Collectors.toList());
+      if (allWriteStats.isEmpty()) {
+        return engineContext.emptyHoodieData();
+      }
+
+      List<String> colsToIndex = new ArrayList<>(columnsToIndexSchemaMap.keySet());
+      log.debug("Indexing following columns for partition stats index: {}", columnsToIndexSchemaMap.keySet());
+      // Group by partitionPath and then gather write stats lists,
+      // where each inner list contains HoodieWriteStat objects that have the same partitionPath.
+      List<List<HoodieWriteStat>> partitionedWriteStats = new ArrayList<>(allWriteStats.stream()
+          .collect(Collectors.groupingBy(HoodieWriteStat::getPartitionPath))
+          .values());
+      Map<String, Set<String>> fileGroupIdsToReplaceMap = (commitMetadata instanceof HoodieReplaceCommitMetadata)
+          ? ((HoodieReplaceCommitMetadata) commitMetadata).getPartitionToReplaceFileIds()
+          .entrySet().stream().collect(Collectors.toMap(Map.Entry::getKey, e -> new HashSet<>(e.getValue())))
+          : Collections.emptyMap();
+
+      int parallelism = Math.max(Math.min(partitionedWriteStats.size(), metadataConfig.getPartitionStatsIndexParallelism()), 1);
+      String maxInstantTime = getMaxInstantTime(dataMetaClient, instantTime);
+      HoodiePairData<String, List<HoodieColumnRangeMetadata<Comparable>>> columnRangeMetadata =
+          engineContext.parallelize(partitionedWriteStats, parallelism).mapToPair(partitionedWriteStat -> {
+            final String partitionName = partitionedWriteStat.get(0).getPartitionPath();
+            checkState(tableMetadata != null, "tableMetadata should not be null when scanning metadata table");
+
+            // Collect column metadata for each file part of the latest merged file slice before the current instant time
+            List<HoodieColumnRangeMetadata<Comparable>> fileColumnMetadata = partitionedWriteStat.stream()
+                .flatMap(writeStat -> translateWriteStatToFileStats(writeStat, dataMetaClient, colsToIndex, partitionStatsIndexVersion).stream()).collect(toList());
+            // Collect column metadata of each file that does not have column stats provided by the write stat in the commit metadata
+            Set<String> filesToFetchColumnStats = getFilesToFetchColumnStats(partitionedWriteStat, dataMetaClient, tableMetadata, dataWriteConfig, partitionName, maxInstantTime,
+                instantTime, fileGroupIdsToReplaceMap, colsToIndex, partitionStatsIndexVersion);
+            // Fetch metadata table COLUMN_STATS partition records for the above files
+            List<HoodieColumnRangeMetadata<Comparable>> partitionColumnMetadata = tableMetadata
+                .getRecordsByKeyPrefixes(
+                    HoodieListData.lazy(generateColumnStatsKeys(colsToIndex, partitionName)),
+                    MetadataPartitionType.COLUMN_STATS.getPartitionPath(), false)
+                // schema and properties are ignored in getInsertValue, so simply pass as null
+                .map(record -> ((HoodieMetadataPayload) record.getData()).getColumnStatMetadata())
+                .filter(Option::isPresent)
+                .map(colStatsOpt -> colStatsOpt.get())
+                .filter(stats -> filesToFetchColumnStats.contains(stats.getFileName()))
+                .map(HoodieColumnRangeMetadata::fromColumnStats).collectAsList();
+            // fileColumnMetadata already contains stats for the files from the current inflight commit.
+            // Here it adds the stats for the committed files part of the latest merged file slices
+            fileColumnMetadata.addAll(partitionColumnMetadata);
+            return Pair.of(partitionName, fileColumnMetadata);
+          });
+
+      return convertMetadataToPartitionStatsRecords(columnRangeMetadata, dataMetaClient, columnsToIndexSchemaMap, partitionStatsIndexVersion);
+    } catch (Exception e) {
+      throw new HoodieException("Failed to generate column stats records for metadata table", e);
+    }
   }
 }

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/index/record/BaseRecordIndexer.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/index/record/BaseRecordIndexer.java
@@ -19,19 +19,35 @@
 
 package org.apache.hudi.metadata.index.record;
 
+import org.apache.hudi.avro.model.HoodieCleanMetadata;
 import org.apache.hudi.common.config.HoodieConfig;
+import org.apache.hudi.common.config.HoodieMetadataConfig;
 import org.apache.hudi.common.data.HoodieData;
 import org.apache.hudi.common.engine.HoodieEngineContext;
 import org.apache.hudi.common.engine.HoodieReaderContext;
 import org.apache.hudi.common.engine.ReaderContextFactory;
+import org.apache.hudi.common.fs.FSUtils;
 import org.apache.hudi.common.model.FileSlice;
+import org.apache.hudi.common.model.HoodieBaseFile;
+import org.apache.hudi.common.model.HoodieCommitMetadata;
+import org.apache.hudi.common.model.HoodieDeltaWriteStat;
 import org.apache.hudi.common.model.HoodieFileFormat;
+import org.apache.hudi.common.model.HoodieReplaceCommitMetadata;
+import org.apache.hudi.common.model.HoodieWriteStat;
+import org.apache.hudi.common.model.WriteOperationType;
 import org.apache.hudi.common.table.view.HoodieTableFileSystemView;
+import org.apache.hudi.common.util.CollectionUtils;
 import org.apache.hudi.common.util.ValidationUtils;
+import org.apache.hudi.common.util.VisibleForTesting;
+import org.apache.hudi.common.util.collection.Pair;
+import org.apache.hudi.exception.HoodieException;
 import org.apache.hudi.exception.HoodieIOException;
 import org.apache.hudi.io.storage.HoodieAvroFileReader;
 import org.apache.hudi.io.storage.HoodieIOFactory;
+import org.apache.hudi.metadata.BaseFileRecordParsingUtils;
+import org.apache.hudi.metadata.HoodieBackedTableMetadata;
 import org.apache.hudi.metadata.index.model.DataPartitionAndRecords;
+import org.apache.hudi.metadata.index.model.IndexPartitionAndRecords;
 import org.apache.hudi.metadata.model.FileSliceAndPartition;
 import org.apache.hudi.common.model.HoodieRecord;
 import org.apache.hudi.common.schema.HoodieSchema;
@@ -53,17 +69,25 @@ import org.apache.hudi.storage.HoodieStorage;
 import org.apache.hudi.storage.HoodieStorageUtils;
 import org.apache.hudi.storage.StorageConfiguration;
 import org.apache.hudi.storage.StoragePath;
+import org.apache.hudi.util.Lazy;
 
 import lombok.extern.slf4j.Slf4j;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 import static org.apache.hudi.common.schema.HoodieSchemaUtils.getRecordKeySchema;
+import static org.apache.hudi.common.util.ValidationUtils.checkState;
+import static org.apache.hudi.metadata.HoodieTableMetadataUtil.readRecordKeysFromBaseFiles;
+import static org.apache.hudi.metadata.MetadataPartitionType.RECORD_INDEX;
 
 /**
  * Base implementation for record-index.
@@ -110,6 +134,23 @@ public abstract class BaseRecordIndexer extends BaseIndexer {
       validateRecordIndex(records, fileGroupCount, metadataMetaClient);
     }
     records.unpersist();
+  }
+
+  @Override
+  public List<IndexPartitionAndRecords> buildClean(String instantTime, HoodieCleanMetadata cleanMetadata) {
+    return Collections.emptyList();
+  }
+
+  @Override
+  public List<IndexPartitionAndRecords> buildUpdate(
+      String instantTime,
+      HoodieBackedTableMetadata tableMetadata,
+      Lazy<HoodieTableFileSystemView> lazyFileSystemView,
+      HoodieCommitMetadata commitMetadata) {
+    HoodieData<HoodieRecord> updatesFromWriteStatuses = convertMetadataToRecordIndexRecords(engineContext, commitMetadata,
+        dataTableWriteConfig.getMetadataConfig(), dataTableMetaClient, dataTableWriteConfig.getWritesFileIdEncoding(), instantTime);
+    HoodieData<HoodieRecord> additionalUpdates = getRecordIndexAdditionalUpserts(updatesFromWriteStatuses, commitMetadata, lazyFileSystemView);
+    return Collections.singletonList(IndexPartitionAndRecords.of(RECORD_INDEX.getPartitionPath(), updatesFromWriteStatuses.union(additionalUpdates)));
   }
 
   /**
@@ -278,5 +319,166 @@ public abstract class BaseRecordIndexer extends BaseIndexer {
         dataTableWriteConfig.getRecordIndexGrowthFactor(),
         dataTableWriteConfig.getRecordIndexMaxFileGroupSizeBytes()
     );
+  }
+
+  @VisibleForTesting
+  public static <T> HoodieData<HoodieRecord> convertMetadataToRecordIndexRecords(HoodieEngineContext engineContext,
+                                                                                 HoodieCommitMetadata commitMetadata,
+                                                                                 HoodieMetadataConfig metadataConfig,
+                                                                                 HoodieTableMetaClient dataTableMetaClient,
+                                                                                 int writesFileIdEncoding,
+                                                                                 String instantTime) {
+    List<HoodieWriteStat> allWriteStats = commitMetadata.getPartitionToWriteStats().values().stream()
+        .flatMap(Collection::stream).collect(Collectors.toList());
+    // Return early if there are no write stats, or if the operation is a compaction.
+    if (allWriteStats.isEmpty() || commitMetadata.getOperationType() == WriteOperationType.COMPACT) {
+      return engineContext.emptyHoodieData();
+    }
+    // RLI cannot support logs having inserts with current offering. So, lets validate that.
+    if (allWriteStats.stream().anyMatch(writeStat -> {
+      String fileName = FSUtils.getFileName(writeStat.getPath(), writeStat.getPartitionPath());
+      return FSUtils.isLogFile(fileName) && writeStat.getNumInserts() > 0;
+    })) {
+      throw new HoodieIOException("RLI cannot support logs having inserts with current offering. Would recommend disabling Record Level Index");
+    }
+
+    try {
+      Map<String, List<HoodieWriteStat>> writeStatsByFileId = allWriteStats.stream().collect(Collectors.groupingBy(HoodieWriteStat::getFileId));
+      int parallelism = Math.max(Math.min(writeStatsByFileId.size(), metadataConfig.getRecordIndexMaxParallelism()), 1);
+      String basePath = dataTableMetaClient.getBasePath().toString();
+      HoodieFileFormat baseFileFormat = dataTableMetaClient.getTableConfig().getBaseFileFormat();
+      StorageConfiguration storageConfiguration = dataTableMetaClient.getStorageConf();
+      Option<HoodieSchema> writerSchemaOpt = HoodieTableMetadataUtil.tryResolveSchemaForTable(dataTableMetaClient);
+      Option<HoodieSchema> finalWriterSchemaOpt = writerSchemaOpt;
+      ReaderContextFactory<T> readerContextFactory = engineContext.getReaderContextFactory(dataTableMetaClient);
+      HoodieData<HoodieRecord> recordIndexRecords = engineContext.parallelize(new ArrayList<>(writeStatsByFileId.entrySet()), parallelism)
+          .flatMap(writeStatsByFileIdEntry -> {
+            String fileId = writeStatsByFileIdEntry.getKey();
+            List<HoodieWriteStat> writeStats = writeStatsByFileIdEntry.getValue();
+            // Partition the write stats into base file and log file write stats
+            List<HoodieWriteStat> baseFileWriteStats = writeStats.stream()
+                .filter(writeStat -> writeStat.getPath().endsWith(baseFileFormat.getFileExtension()))
+                .collect(Collectors.toList());
+            List<HoodieWriteStat> logFileWriteStats = writeStats.stream()
+                .filter(writeStat -> FSUtils.isLogFile(new StoragePath(writeStats.get(0).getPath())))
+                .collect(Collectors.toList());
+            // Ensure that only one of base file or log file write stats exists
+            checkState(baseFileWriteStats.isEmpty() || logFileWriteStats.isEmpty(),
+                "A single fileId cannot have both base file and log file write stats in the same commit. FileId: " + fileId);
+            // Process base file write stats
+            if (!baseFileWriteStats.isEmpty()) {
+              return baseFileWriteStats.stream()
+                  .flatMap(writeStat -> {
+                    HoodieStorage storage = HoodieStorageUtils.getStorage(new StoragePath(writeStat.getPath()), storageConfiguration);
+                    return CollectionUtils.toStream(BaseFileRecordParsingUtils
+                        .generateRLIMetadataHoodieRecordsForBaseFile(basePath, writeStat, writesFileIdEncoding, instantTime, storage, metadataConfig.isRecordLevelIndexEnabled()));
+                  })
+                  .iterator();
+            }
+            // Process log file write stats
+            if (!logFileWriteStats.isEmpty()) {
+              String partitionPath = logFileWriteStats.get(0).getPartitionPath();
+              List<String> currentLogFilePaths = logFileWriteStats.stream()
+                  .map(writeStat -> new StoragePath(dataTableMetaClient.getBasePath(), writeStat.getPath()).toString())
+                  .collect(Collectors.toList());
+              List<String> allLogFilePaths = logFileWriteStats.stream()
+                  .flatMap(writeStat -> {
+                    checkState(writeStat instanceof HoodieDeltaWriteStat, "Log file should be associated with a delta write stat");
+                    List<String> currentLogFiles = ((HoodieDeltaWriteStat) writeStat).getLogFiles().stream()
+                        .map(logFile -> new StoragePath(new StoragePath(dataTableMetaClient.getBasePath(), writeStat.getPartitionPath()), logFile).toString())
+                        .collect(Collectors.toList());
+                    return currentLogFiles.stream();
+                  })
+                  .collect(Collectors.toList());
+              // Extract revived and deleted keys
+              Pair<Set<String>, Set<String>> revivedAndDeletedKeys = HoodieTableMetadataUtil.getRevivedAndDeletedKeysFromMergedLogs(dataTableMetaClient,
+                  instantTime, allLogFilePaths, finalWriterSchemaOpt, currentLogFilePaths, partitionPath, readerContextFactory.getContext());
+              Set<String> revivedKeys = revivedAndDeletedKeys.getLeft();
+              Set<String> deletedKeys = revivedAndDeletedKeys.getRight();
+              // Process revived keys to create updates
+              List<HoodieRecord> revivedRecords = revivedKeys.stream()
+                  .map(recordKey -> HoodieMetadataPayload.createRecordIndexUpdate(recordKey, partitionPath, fileId, instantTime, writesFileIdEncoding))
+                  .collect(Collectors.toList());
+              // Process deleted keys to create deletes
+              List<HoodieRecord> deletedRecords = deletedKeys.stream()
+                  .map(key -> HoodieMetadataPayload.createRecordIndexDelete(key, partitionPath, metadataConfig.isRecordLevelIndexEnabled()))
+                  .collect(Collectors.toList());
+              // Combine all records into one list
+              List<HoodieRecord> allRecords = new ArrayList<>();
+              allRecords.addAll(revivedRecords);
+              allRecords.addAll(deletedRecords);
+              return allRecords.iterator();
+            }
+            log.warn("No base file or log file write stats found for fileId: {}", fileId);
+            return Collections.emptyIterator();
+          });
+
+      // there are chances that same record key from data table has 2 entries (1 delete from older partition and 1 insert to newer partition)
+      // lets do reduce by key to ignore the deleted entry.
+      // first deduce parallelism to avoid too few tasks for large number of records.
+      long totalWriteBytesForRLI = allWriteStats.stream().mapToLong(writeStat -> {
+        // if there are no inserts or deletes, we can ignore this write stat for RLI
+        if (writeStat.getNumInserts() == 0 && writeStat.getNumDeletes() == 0) {
+          return 0;
+        }
+        return writeStat.getTotalWriteBytes();
+      }).sum();
+      // approximate task partition size of 100MB
+      // (TODO: make this configurable)
+      long targetPartitionSize = 100 * 1024 * 1024;
+      parallelism = (int) Math.max(1, (totalWriteBytesForRLI + targetPartitionSize - 1) / targetPartitionSize);
+      return HoodieTableMetadataUtil.reduceByKeys(recordIndexRecords, parallelism, metadataConfig.isRecordLevelIndexEnabled());
+    } catch (Exception e) {
+      throw new HoodieException("Failed to generate RLI records for metadata table", e);
+    }
+  }
+
+  private HoodieData<HoodieRecord> getRecordIndexAdditionalUpserts(
+      HoodieData<HoodieRecord> updatesFromWriteStatuses,
+      HoodieCommitMetadata commitMetadata,
+      Lazy<HoodieTableFileSystemView> fsView) {
+    WriteOperationType operationType = commitMetadata.getOperationType();
+    if (operationType == WriteOperationType.INSERT_OVERWRITE) {
+      // load existing records from replaced filegroups and left anti join overwriting records
+      // return partition-level unmatched records (with newLocation being null) to be deleted from RLI
+      return getRecordIndexReplacedRecords((HoodieReplaceCommitMetadata) commitMetadata, fsView)
+          .mapToPair(r -> Pair.of(r.getKey(), r))
+          .leftOuterJoin(updatesFromWriteStatuses.mapToPair(r -> Pair.of(r.getKey(), r)))
+          .values()
+          .filter(p -> !p.getRight().isPresent())
+          .map(Pair::getLeft);
+    } else if (operationType == WriteOperationType.INSERT_OVERWRITE_TABLE) {
+      // load existing records from replaced filegroups and left anti join overwriting records
+      // return globally unmatched records (with newLocation being null) to be deleted from RLI
+      return getRecordIndexReplacedRecords((HoodieReplaceCommitMetadata) commitMetadata, fsView)
+          .mapToPair(r -> Pair.of(r.getRecordKey(), r))
+          .leftOuterJoin(updatesFromWriteStatuses.mapToPair(r -> Pair.of(r.getRecordKey(), r)))
+          .values()
+          .filter(p -> !p.getRight().isPresent())
+          .map(Pair::getLeft);
+    } else if (operationType == WriteOperationType.DELETE_PARTITION) {
+      // all records from the target partition(s) to be deleted from RLI
+      return getRecordIndexReplacedRecords((HoodieReplaceCommitMetadata) commitMetadata, fsView);
+    } else {
+      return engineContext.emptyHoodieData();
+    }
+  }
+
+  private HoodieData<HoodieRecord> getRecordIndexReplacedRecords(HoodieReplaceCommitMetadata replaceCommitMetadata, Lazy<HoodieTableFileSystemView> fsView) {
+    List<Pair<String, HoodieBaseFile>> partitionBaseFilePairs = replaceCommitMetadata
+        .getPartitionToReplaceFileIds()
+        .keySet().stream()
+        .flatMap(partition -> fsView.get().getLatestBaseFiles(partition).map(f -> Pair.of(partition, f)))
+        .collect(Collectors.toList());
+    return readRecordKeysFromBaseFiles(
+        engineContext,
+        dataTableWriteConfig,
+        partitionBaseFilePairs,
+        true,
+        dataTableWriteConfig.getMetadataConfig().getRecordIndexMaxParallelism(),
+        dataTableMetaClient.getBasePath(),
+        dataTableMetaClient.getStorageConf(),
+        this.getClass().getSimpleName(),
+        dataTableWriteConfig.isRecordLevelIndexEnabled());
   }
 }

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/index/record/BaseRecordIndexer.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/index/record/BaseRecordIndexer.java
@@ -1,0 +1,282 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.hudi.metadata.index.record;
+
+import org.apache.hudi.common.config.HoodieConfig;
+import org.apache.hudi.common.data.HoodieData;
+import org.apache.hudi.common.engine.HoodieEngineContext;
+import org.apache.hudi.common.engine.HoodieReaderContext;
+import org.apache.hudi.common.engine.ReaderContextFactory;
+import org.apache.hudi.common.model.FileSlice;
+import org.apache.hudi.common.model.HoodieFileFormat;
+import org.apache.hudi.common.table.view.HoodieTableFileSystemView;
+import org.apache.hudi.common.util.ValidationUtils;
+import org.apache.hudi.exception.HoodieIOException;
+import org.apache.hudi.io.storage.HoodieAvroFileReader;
+import org.apache.hudi.io.storage.HoodieIOFactory;
+import org.apache.hudi.metadata.index.model.DataPartitionAndRecords;
+import org.apache.hudi.metadata.model.FileSliceAndPartition;
+import org.apache.hudi.common.model.HoodieRecord;
+import org.apache.hudi.common.schema.HoodieSchema;
+import org.apache.hudi.common.schema.HoodieSchemaCache;
+import org.apache.hudi.common.schema.HoodieSchemaUtils;
+import org.apache.hudi.common.table.HoodieTableMetaClient;
+import org.apache.hudi.common.table.read.HoodieFileGroupReader;
+import org.apache.hudi.common.table.timeline.HoodieInstant;
+import org.apache.hudi.common.util.Option;
+import org.apache.hudi.common.util.collection.CloseableMappingIterator;
+import org.apache.hudi.config.HoodieWriteConfig;
+import org.apache.hudi.internal.schema.InternalSchema;
+import org.apache.hudi.internal.schema.utils.SerDeHelper;
+import org.apache.hudi.metadata.HoodieMetadataPayload;
+import org.apache.hudi.metadata.HoodieTableMetadataUtil;
+import org.apache.hudi.metadata.MetadataPartitionType;
+import org.apache.hudi.metadata.index.BaseIndexer;
+import org.apache.hudi.storage.HoodieStorage;
+import org.apache.hudi.storage.HoodieStorageUtils;
+import org.apache.hudi.storage.StorageConfiguration;
+import org.apache.hudi.storage.StoragePath;
+
+import lombok.extern.slf4j.Slf4j;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+
+import static org.apache.hudi.common.schema.HoodieSchemaUtils.getRecordKeySchema;
+
+/**
+ * Base implementation for record-index.
+ */
+@Slf4j
+public abstract class BaseRecordIndexer extends BaseIndexer {
+
+  private static final int RECORD_INDEX_AVERAGE_RECORD_SIZE = 48;
+
+  protected BaseRecordIndexer(HoodieEngineContext engineContext, HoodieWriteConfig dataTableWriteConfig, HoodieTableMetaClient dataTableMetaClient) {
+    super(engineContext, dataTableWriteConfig, dataTableMetaClient);
+  }
+
+  protected DataPartitionAndRecords initializeRecordIndexPartition(
+      List<FileSliceAndPartition> latestMergedPartitionFileSliceList,
+      int recordIndexMaxParallelism) {
+    return initializeRecordIndexPartition(null, latestMergedPartitionFileSliceList, recordIndexMaxParallelism);
+  }
+
+  protected DataPartitionAndRecords initializeRecordIndexPartition(
+      String dataPartition,
+      List<FileSliceAndPartition> latestMergedPartitionFileSliceList,
+      int recordIndexMaxParallelism) {
+    log.info("Initializing record index from {} file slices", latestMergedPartitionFileSliceList.size());
+    HoodieData<HoodieRecord> records = readRecordKeysFromFileSliceSnapshot(
+        engineContext,
+        latestMergedPartitionFileSliceList,
+        recordIndexMaxParallelism,
+        this.getClass().getSimpleName(),
+        dataTableMetaClient,
+        dataTableWriteConfig);
+
+    // Initialize the file groups
+    final int fileGroupCount = estimateFileGroupCount(records);
+    log.info("Initializing record index with {} file groups.", fileGroupCount);
+    return new DataPartitionAndRecords(fileGroupCount, Option.ofNullable(dataPartition), records);
+  }
+
+  @Override
+  public void postInitialization(HoodieTableMetaClient metadataMetaClient, HoodieData<HoodieRecord> records, int fileGroupCount, String relativePartitionPath) {
+    super.postInitialization(metadataMetaClient, records, fileGroupCount, relativePartitionPath);
+    // Validate record index after commit if validation is enabled
+    if (dataTableWriteConfig.getMetadataConfig().isRecordIndexInitializationValidationEnabled()) {
+      validateRecordIndex(records, fileGroupCount, metadataMetaClient);
+    }
+    records.unpersist();
+  }
+
+  /**
+   * Validates the record index after bootstrap by comparing the expected record count with the actual
+   * record count stored in the metadata table. The validation is performed in a distributed manner
+   * using the engine context to count records from HFiles in parallel.
+   *
+   * @param recordIndexRecords the HoodieData containing the expected records
+   * @param fileGroupCount the expected number of file groups
+   * @param metadataMetaClient meta client for the metadata table
+   */
+  protected void validateRecordIndex(HoodieData<HoodieRecord> recordIndexRecords, int fileGroupCount, HoodieTableMetaClient metadataMetaClient) {
+    String partitionName = MetadataPartitionType.RECORD_INDEX.getPartitionPath();
+    HoodieTableFileSystemView fsView = HoodieTableMetadataUtil.getFileSystemViewForMetadataTable(metadataMetaClient);
+    try {
+      // Use merged file slices to handle cases with pending compactions
+      List<FileSlice> fileSlices = HoodieTableMetadataUtil.getPartitionLatestMergedFileSlices(metadataMetaClient, fsView, partitionName);
+
+      // Filter to only file slices with base files and extract their storage paths
+      List<StoragePath> baseFilePaths = fileSlices.stream()
+          .filter(fs -> fs.getBaseFile().isPresent())
+          .map(fs -> fs.getBaseFile().get().getStoragePath())
+          .collect(Collectors.toList());
+
+      // Count records in a distributed manner using the engine context
+      long totalRecords = countRecordsInHFiles(baseFilePaths, metadataMetaClient);
+      long expectedRecordCount = recordIndexRecords.count();
+
+      ValidationUtils.checkArgument(totalRecords == expectedRecordCount, "Record Count Validation failed with "
+          + totalRecords + " present in record index vs the expected " + expectedRecordCount);
+      log.info(String.format("Record index initialized on %d shards (expected = %d) with %d records (expected = %d)",
+          fileSlices.size(), fileGroupCount, totalRecords, expectedRecordCount));
+    } finally {
+      fsView.close();
+    }
+  }
+
+  /**
+   * Counts the total number of records in HFiles in a distributed manner.
+   *
+   * @param baseFilePaths list of storage paths to HFiles
+   * @param metadataMetaClient meta client for the metadata table
+   * @return total number of records across all HFiles
+   */
+  private long countRecordsInHFiles(List<StoragePath> baseFilePaths, HoodieTableMetaClient metadataMetaClient) {
+    if (baseFilePaths.isEmpty()) {
+      return 0L;
+    }
+
+    int parallelism = Math.min(baseFilePaths.size(), dataTableWriteConfig.getMetadataConfig().getRecordIndexMaxParallelism());
+    StorageConfiguration<?> storageConfBroadcast = metadataMetaClient.getStorageConf();
+    HoodieFileFormat baseFileFormat = metadataMetaClient.getTableConfig().getBaseFileFormat();
+
+    return engineContext.parallelize(baseFilePaths, parallelism)
+        .mapPartitions(pathIterator -> {
+          long count = 0L;
+          while (pathIterator.hasNext()) {
+            StoragePath path = pathIterator.next();
+            try {
+              HoodieStorage storage = HoodieStorageUtils.getStorage(path, storageConfBroadcast);
+              HoodieConfig readerConfig = new HoodieConfig();
+              HoodieAvroFileReader reader = (HoodieAvroFileReader) HoodieIOFactory.getIOFactory(storage)
+                  .getReaderFactory(HoodieRecord.HoodieRecordType.AVRO)
+                  .getFileReader(readerConfig, path, baseFileFormat, Option.empty());
+              try {
+                count += reader.getTotalRecords();
+              } finally {
+                reader.close();
+              }
+            } catch (IOException e) {
+              throw new HoodieIOException("Error reading total records from file " + path, e);
+            }
+          }
+          return Collections.singletonList(count).iterator();
+        }, true)
+        .collectAsList()
+        .stream()
+        .mapToLong(Long::longValue)
+        .sum();
+  }
+
+  /**
+   * Fetch record locations from FileSlice snapshot.
+   *
+   * @param engineContext             context ot use.
+   * @param partitionFileSlicePairs   list of pairs of partition and file slice.
+   * @param recordIndexMaxParallelism parallelism to use.
+   * @param activeModule              active module of interest.
+   * @param metaClient                metaclient instance to use.
+   * @param dataWriteConfig           write config to use.
+   * @return metadata records for initializing record index entries.
+   */
+  protected <T> HoodieData<HoodieRecord> readRecordKeysFromFileSliceSnapshot(
+      HoodieEngineContext engineContext,
+      List<FileSliceAndPartition> partitionFileSlicePairs,
+      int recordIndexMaxParallelism,
+      String activeModule,
+      HoodieTableMetaClient metaClient,
+      HoodieWriteConfig dataWriteConfig) {
+    if (partitionFileSlicePairs.isEmpty()) {
+      return engineContext.emptyHoodieData();
+    }
+
+    Option<String> instantTime = metaClient.getActiveTimeline().getCommitsTimeline()
+        .filterCompletedInstants()
+        .lastInstant()
+        .map(HoodieInstant::requestedTime);
+    if (!instantTime.isPresent()) {
+      return engineContext.emptyHoodieData();
+    }
+
+    engineContext.setJobStatus(activeModule, "Record Index: reading record keys from " + partitionFileSlicePairs.size() + " file slices");
+    final int parallelism = Math.min(partitionFileSlicePairs.size(), recordIndexMaxParallelism);
+    ReaderContextFactory<T> readerContextFactory = engineContext.getReaderContextFactory(metaClient);
+    return engineContext.parallelize(partitionFileSlicePairs, parallelism).flatMap(partitionAndFileSlice -> {
+      final String partition = partitionAndFileSlice.partitionPath();
+      final FileSlice fileSlice = partitionAndFileSlice.fileSlice();
+      final String fileId = fileSlice.getFileId();
+      HoodieReaderContext<T> readerContext = readerContextFactory.getContext();
+      HoodieSchema dataSchema = HoodieSchemaCache.intern(HoodieSchemaUtils.addMetadataFields(HoodieSchema.parse(dataWriteConfig.getWriteSchema()), dataWriteConfig.allowOperationMetadataField()));
+      HoodieSchema requestedSchema = metaClient.getTableConfig().populateMetaFields() ? getRecordKeySchema()
+          : HoodieSchemaUtils.projectSchema(dataSchema, Arrays.asList(metaClient.getTableConfig().getRecordKeyFields().orElse(new String[0])));
+      Option<InternalSchema> internalSchemaOption = SerDeHelper.fromJson(dataWriteConfig.getInternalSchema());
+      HoodieFileGroupReader<T> fileGroupReader = HoodieFileGroupReader.<T>newBuilder()
+          .withReaderContext(readerContext)
+          .withHoodieTableMetaClient(metaClient)
+          .withFileSlice(fileSlice)
+          .withLatestCommitTime(instantTime.get())
+          .withDataSchema(dataSchema)
+          .withRequestedSchema(requestedSchema)
+          .withInternalSchema(internalSchemaOption)
+          .withShouldUseRecordPosition(false)
+          .withProps(metaClient.getTableConfig().getProps())
+          .build();
+      String baseFileInstantTime = fileSlice.getBaseInstantTime();
+      return new CloseableMappingIterator<>(fileGroupReader.getClosableIterator(), record -> {
+        String recordKey = readerContext.getRecordContext().getRecordKey(record, requestedSchema);
+        return HoodieMetadataPayload.createRecordIndexUpdate(recordKey, partition, fileId,
+            baseFileInstantTime, 0);
+      });
+    });
+  }
+
+  protected int estimateFileGroupCount(HoodieData<HoodieRecord> records) {
+    int minFileGroupCount;
+    int maxFileGroupCount;
+    if (dataTableWriteConfig.isRecordLevelIndexEnabled()) {
+      minFileGroupCount = dataTableWriteConfig.getRecordLevelIndexMinFileGroupCount();
+      maxFileGroupCount = dataTableWriteConfig.getRecordLevelIndexMaxFileGroupCount();
+    } else {
+      minFileGroupCount = dataTableWriteConfig.getGlobalRecordLevelIndexMinFileGroupCount();
+      maxFileGroupCount = dataTableWriteConfig.getGlobalRecordLevelIndexMaxFileGroupCount();
+    }
+    Supplier<Long> recordCountSupplier = () -> {
+      records.persist("MEMORY_AND_DISK_SER");
+      long count = records.count();
+      log.info("Initializing record index with {} mappings", count);
+      return count;
+    };
+    return HoodieTableMetadataUtil.estimateFileGroupCount(
+        MetadataPartitionType.RECORD_INDEX,
+        recordCountSupplier,
+        RECORD_INDEX_AVERAGE_RECORD_SIZE,
+        minFileGroupCount,
+        maxFileGroupCount,
+        dataTableWriteConfig.getRecordIndexGrowthFactor(),
+        dataTableWriteConfig.getRecordIndexMaxFileGroupSizeBytes()
+    );
+  }
+}

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/index/record/PartitionedRecordIndexer.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/index/record/PartitionedRecordIndexer.java
@@ -1,0 +1,91 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.hudi.metadata.index.record;
+
+import org.apache.hudi.common.engine.HoodieEngineContext;
+import org.apache.hudi.metadata.MetadataPartitionType;
+import org.apache.hudi.metadata.index.model.DataPartitionAndRecords;
+import org.apache.hudi.metadata.model.FileInfo;
+import org.apache.hudi.metadata.model.FileSliceAndPartition;
+import org.apache.hudi.metadata.index.model.IndexPartitionInitialization;
+import org.apache.hudi.common.table.HoodieTableMetaClient;
+import org.apache.hudi.common.util.ValidationUtils;
+import org.apache.hudi.config.HoodieWriteConfig;
+import org.apache.hudi.index.record.HoodieRecordIndex;
+import org.apache.hudi.metadata.BucketizedMetadataTableFileGroupIndexParser;
+import org.apache.hudi.util.Lazy;
+
+import lombok.extern.slf4j.Slf4j;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+import java.util.stream.Collectors;
+
+import static org.apache.hudi.metadata.HoodieTableMetadataUtil.createRecordIndexDefinition;
+import static org.apache.hudi.metadata.MetadataPartitionType.RECORD_INDEX;
+
+/**
+ * Implementation of the global {@link MetadataPartitionType#RECORD_INDEX} index
+ */
+@Slf4j
+public class PartitionedRecordIndexer extends BaseRecordIndexer {
+  public PartitionedRecordIndexer(HoodieEngineContext engineContext, HoodieWriteConfig dataTableWriteConfig,
+                                     HoodieTableMetaClient dataTableMetaClient) {
+    super(engineContext, dataTableWriteConfig, dataTableMetaClient);
+  }
+
+  @Override
+  public List<IndexPartitionInitialization> buildInitialization(String dataTableInstantTime, String instantTimeForPartition, Map<String, List<FileInfo>> partitionToAllFilesMap,
+                                                                Lazy<List<FileSliceAndPartition>> lazyLatestMergedPartitionFileSliceList) throws IOException {
+    createRecordIndexDefinition(dataTableMetaClient, Collections.singletonMap(HoodieRecordIndex.IS_PARTITIONED_OPTION, "true"));
+    Map<String, List<FileSliceAndPartition>> partitionFileSlicePairsMap = lazyLatestMergedPartitionFileSliceList.get().stream()
+        .collect(Collectors.groupingBy(FileSliceAndPartition::partitionPath));
+    Map<String, DataPartitionAndRecords> fileGroupCountAndRecordsPairMap = new HashMap<>(partitionFileSlicePairsMap.size());
+    int maxParallelismPerHudiPartition = partitionFileSlicePairsMap.isEmpty()
+        ? 1 : Math.max(1, dataTableWriteConfig.getMetadataConfig().getRecordIndexMaxParallelism() / partitionFileSlicePairsMap.size());
+    int totalFileGroupCount = 0;
+    for (String partition : partitionFileSlicePairsMap.keySet()) {
+      log.info("Initializing partitioned record index from data partition {}", partition);
+      DataPartitionAndRecords dataPartitionAndRecords = initializeRecordIndexPartition(partition, partitionFileSlicePairsMap.get(partition), maxParallelismPerHudiPartition);
+      fileGroupCountAndRecordsPairMap.put(partition, dataPartitionAndRecords);
+      totalFileGroupCount += dataPartitionAndRecords.numFileGroups();
+    }
+    log.info("Initializing partitioned record index with {} mappings", totalFileGroupCount);
+
+    List<DataPartitionAndRecords> initializationList = new ArrayList<>();
+    // Generate the file groups
+    TreeMap<String, Integer> partitionSizes = new TreeMap<>();
+    for (Map.Entry<String, DataPartitionAndRecords> entry: fileGroupCountAndRecordsPairMap.entrySet()) {
+      String dataPartition = entry.getKey();
+      DataPartitionAndRecords dataPartitionAndRecords = entry.getValue();
+      ValidationUtils.checkArgument(dataPartitionAndRecords.numFileGroups() > 0, "FileGroup count for partitioned RLI data partition " + dataPartition + " should be > 0");
+      partitionSizes.put(dataPartition, dataPartitionAndRecords.numFileGroups());
+      initializationList.add(dataPartitionAndRecords);
+    }
+
+    return Collections.singletonList(IndexPartitionInitialization.of(totalFileGroupCount,
+        RECORD_INDEX.getPartitionPath(), new BucketizedMetadataTableFileGroupIndexParser(partitionSizes), initializationList));
+  }
+}

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/index/record/RecordIndexer.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/index/record/RecordIndexer.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.hudi.metadata.index.record;
+
+import org.apache.hudi.common.engine.HoodieEngineContext;
+import org.apache.hudi.metadata.MetadataPartitionType;
+import org.apache.hudi.metadata.index.model.DataPartitionAndRecords;
+import org.apache.hudi.metadata.model.FileInfo;
+import org.apache.hudi.metadata.model.FileSliceAndPartition;
+import org.apache.hudi.metadata.index.model.IndexPartitionInitialization;
+import org.apache.hudi.common.table.HoodieTableMetaClient;
+import org.apache.hudi.config.HoodieWriteConfig;
+import org.apache.hudi.index.record.HoodieRecordIndex;
+import org.apache.hudi.util.Lazy;
+
+import lombok.extern.slf4j.Slf4j;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import static org.apache.hudi.metadata.HoodieTableMetadataUtil.createRecordIndexDefinition;
+import static org.apache.hudi.metadata.MetadataPartitionType.RECORD_INDEX;
+
+/**
+ * Implementation of the global {@link MetadataPartitionType#RECORD_INDEX} index
+ */
+@Slf4j
+public class RecordIndexer extends BaseRecordIndexer {
+
+  public RecordIndexer(HoodieEngineContext engineContext, HoodieWriteConfig dataTableWriteConfig,
+                          HoodieTableMetaClient dataTableMetaClient) {
+    super(engineContext, dataTableWriteConfig, dataTableMetaClient);
+  }
+
+  @Override
+  public List<IndexPartitionInitialization> buildInitialization(String dataTableInstantTime, String instantTimeForPartition, Map<String, List<FileInfo>> partitionToAllFilesMap,
+                                                                Lazy<List<FileSliceAndPartition>> lazyLatestMergedPartitionFileSliceList) throws IOException {
+    createRecordIndexDefinition(dataTableMetaClient, Collections.singletonMap(HoodieRecordIndex.IS_PARTITIONED_OPTION, "false"));
+    DataPartitionAndRecords dataPartitionAndRecords = initializeRecordIndexPartition(
+        lazyLatestMergedPartitionFileSliceList.get(), dataTableWriteConfig.getMetadataConfig().getRecordIndexMaxParallelism());
+    return Collections.singletonList(IndexPartitionInitialization.of(RECORD_INDEX.getPartitionPath(), dataPartitionAndRecords));
+  }
+}

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/index/secondary/SecondaryIndexer.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/index/secondary/SecondaryIndexer.java
@@ -1,0 +1,100 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.hudi.metadata.index.secondary;
+
+import org.apache.hudi.common.data.HoodieData;
+import org.apache.hudi.common.engine.HoodieEngineContext;
+import org.apache.hudi.metadata.model.FileInfo;
+import org.apache.hudi.metadata.model.FileSliceAndPartition;
+import org.apache.hudi.common.model.HoodieIndexDefinition;
+import org.apache.hudi.common.model.HoodieRecord;
+import org.apache.hudi.metadata.index.model.IndexPartitionInitialization;
+import org.apache.hudi.common.table.HoodieTableMetaClient;
+import org.apache.hudi.common.util.ValidationUtils;
+import org.apache.hudi.config.HoodieWriteConfig;
+import org.apache.hudi.metadata.HoodieTableMetadataUtil;
+import org.apache.hudi.metadata.MetadataPartitionType;
+import org.apache.hudi.metadata.index.BaseIndexer;
+import org.apache.hudi.util.Lazy;
+
+import lombok.extern.slf4j.Slf4j;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.apache.hudi.metadata.HoodieTableMetadataUtil.getSecondaryIndexPartitionsToInit;
+import static org.apache.hudi.metadata.MetadataPartitionType.RECORD_INDEX;
+import static org.apache.hudi.metadata.MetadataPartitionType.SECONDARY_INDEX;
+import static org.apache.hudi.metadata.SecondaryIndexRecordGenerationUtils.readSecondaryKeysFromFileSlices;
+
+/**
+ * Implementation of {@link MetadataPartitionType#SECONDARY_INDEX} index
+ */
+@Slf4j
+public class SecondaryIndexer extends BaseIndexer {
+
+  private static final int RECORD_INDEX_AVERAGE_RECORD_SIZE = 48;
+
+  public SecondaryIndexer(
+      HoodieEngineContext engineContext,
+      HoodieWriteConfig dataTableWriteConfig,
+      HoodieTableMetaClient dataTableMetaClient) {
+    super(engineContext, dataTableWriteConfig, dataTableMetaClient);
+  }
+
+  @Override
+  public List<IndexPartitionInitialization> buildInitialization(String dataTableInstantTime, String instantTimeForPartition, Map<String, List<FileInfo>> partitionToAllFilesMap,
+                                                                Lazy<List<FileSliceAndPartition>> lazyLatestMergedPartitionFileSliceList) throws IOException {
+    Set<String> secondaryIndexPartitionsToInit = getSecondaryIndexPartitionsToInit(SECONDARY_INDEX, dataTableWriteConfig.getMetadataConfig(), dataTableMetaClient);
+    if (secondaryIndexPartitionsToInit.size() != 1) {
+      if (secondaryIndexPartitionsToInit.size() > 1) {
+        log.warn("Skipping secondary index initialization as only one secondary index bootstrap at a time is supported for now. Provided: {}", secondaryIndexPartitionsToInit);
+      }
+      return Collections.emptyList();
+    }
+
+    String indexName = secondaryIndexPartitionsToInit.iterator().next();
+    HoodieIndexDefinition indexDefinition = HoodieTableMetadataUtil.getHoodieIndexDefinition(indexName, dataTableMetaClient);
+    ValidationUtils.checkState(indexDefinition != null, "Secondary Index definition is not present for index " + indexName);
+
+    List<FileSliceAndPartition> partitionFileSlicePairs = lazyLatestMergedPartitionFileSliceList.get();
+
+    int parallelism = Math.min(partitionFileSlicePairs.size(), dataTableWriteConfig.getMetadataConfig().getSecondaryIndexParallelism());
+    HoodieData<HoodieRecord> records = readSecondaryKeysFromFileSlices(
+        engineContext,
+        partitionFileSlicePairs,
+        parallelism,
+        this.getClass().getSimpleName(),
+        dataTableMetaClient,
+        indexDefinition,
+        dataTableWriteConfig.getProps());
+
+    // Initialize the file groups - using the same estimation logic as that of record index
+    final int fileGroupCount = HoodieTableMetadataUtil.estimateFileGroupCount(RECORD_INDEX, records::count,
+        RECORD_INDEX_AVERAGE_RECORD_SIZE, dataTableWriteConfig.getGlobalRecordLevelIndexMinFileGroupCount(),
+        dataTableWriteConfig.getGlobalRecordLevelIndexMaxFileGroupCount(), dataTableWriteConfig.getRecordIndexGrowthFactor(),
+        dataTableWriteConfig.getRecordIndexMaxFileGroupSizeBytes());
+
+    return Collections.singletonList(IndexPartitionInitialization.of(fileGroupCount, indexName, records));
+  }
+}

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/index/secondary/SecondaryIndexer.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/index/secondary/SecondaryIndexer.java
@@ -19,9 +19,18 @@
 
 package org.apache.hudi.metadata.index.secondary;
 
+import org.apache.hudi.avro.model.HoodieCleanMetadata;
 import org.apache.hudi.common.data.HoodieData;
 import org.apache.hudi.common.engine.HoodieEngineContext;
 import org.apache.hudi.metadata.model.FileInfo;
+import org.apache.hudi.common.model.HoodieCommitMetadata;
+import org.apache.hudi.common.model.HoodieWriteStat;
+import org.apache.hudi.common.model.WriteOperationType;
+import org.apache.hudi.common.table.view.HoodieTableFileSystemView;
+import org.apache.hudi.exception.HoodieIndexException;
+import org.apache.hudi.exception.HoodieMetadataException;
+import org.apache.hudi.metadata.HoodieBackedTableMetadata;
+import org.apache.hudi.metadata.index.model.IndexPartitionAndRecords;
 import org.apache.hudi.metadata.model.FileSliceAndPartition;
 import org.apache.hudi.common.model.HoodieIndexDefinition;
 import org.apache.hudi.common.model.HoodieRecord;
@@ -37,14 +46,18 @@ import org.apache.hudi.util.Lazy;
 import lombok.extern.slf4j.Slf4j;
 
 import java.io.IOException;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 
+import static org.apache.hudi.metadata.HoodieTableMetadataUtil.PARTITION_NAME_SECONDARY_INDEX_PREFIX;
 import static org.apache.hudi.metadata.HoodieTableMetadataUtil.getSecondaryIndexPartitionsToInit;
 import static org.apache.hudi.metadata.MetadataPartitionType.RECORD_INDEX;
 import static org.apache.hudi.metadata.MetadataPartitionType.SECONDARY_INDEX;
+import static org.apache.hudi.metadata.SecondaryIndexRecordGenerationUtils.convertWriteStatsToSecondaryIndexRecords;
 import static org.apache.hudi.metadata.SecondaryIndexRecordGenerationUtils.readSecondaryKeysFromFileSlices;
 
 /**
@@ -96,5 +109,54 @@ public class SecondaryIndexer extends BaseIndexer {
         dataTableWriteConfig.getRecordIndexMaxFileGroupSizeBytes());
 
     return Collections.singletonList(IndexPartitionInitialization.of(fileGroupCount, indexName, records));
+  }
+
+  @Override
+  public List<IndexPartitionAndRecords> buildUpdate(
+      String instantTime,
+      HoodieBackedTableMetadata tableMetadata,
+      Lazy<HoodieTableFileSystemView> lazyFileSystemView,
+      HoodieCommitMetadata commitMetadata) {
+    if (!SECONDARY_INDEX.isMetadataPartitionAvailable(dataTableMetaClient)) {
+      return Collections.emptyList();
+    }
+    // If write operation type based on commit metadata is COMPACT or CLUSTER then no need to update,
+    // because these operations do not change the secondary key - record key mapping.
+    WriteOperationType operationType = commitMetadata.getOperationType();
+    if (operationType.isInsertOverwriteOrDeletePartition()) {
+      throw new HoodieIndexException(String.format("Can not perform operation %s on secondary index", operationType));
+    } else if (operationType == WriteOperationType.COMPACT || operationType == WriteOperationType.CLUSTER) {
+      return Collections.emptyList();
+    }
+
+    return dataTableMetaClient.getTableConfig().getMetadataPartitions()
+        .stream()
+        .filter(partition -> partition.startsWith(PARTITION_NAME_SECONDARY_INDEX_PREFIX))
+        .map(partition -> {
+          HoodieData<HoodieRecord> secondaryIndexRecords;
+          try {
+            secondaryIndexRecords = getSecondaryIndexUpdates(commitMetadata, partition, instantTime);
+          } catch (Exception e) {
+            throw new HoodieMetadataException("Failed to get secondary index updates for partition " + partition, e);
+          }
+          return IndexPartitionAndRecords.of(partition, secondaryIndexRecords);
+        }).collect(Collectors.toList());
+  }
+
+  @Override
+  public List<IndexPartitionAndRecords> buildClean(String instantTime, HoodieCleanMetadata cleanMetadata) {
+    return Collections.emptyList();
+  }
+
+  private HoodieData<HoodieRecord> getSecondaryIndexUpdates(HoodieCommitMetadata commitMetadata, String indexPartition, String instantTime) {
+    List<HoodieWriteStat> allWriteStats = commitMetadata.getPartitionToWriteStats().values().stream()
+        .flatMap(Collection::stream).collect(Collectors.toList());
+    // Return early if there are no write stats.
+    if (allWriteStats.isEmpty() || WriteOperationType.isCompactionOrClustering(commitMetadata.getOperationType())) {
+      return engineContext.emptyHoodieData();
+    }
+    HoodieIndexDefinition indexDefinition = HoodieTableMetadataUtil.getHoodieIndexDefinition(indexPartition, dataTableMetaClient);
+    return convertWriteStatsToSecondaryIndexRecords(allWriteStats, instantTime, indexDefinition,
+        dataTableWriteConfig.getMetadataConfig(), dataTableMetaClient, engineContext, dataTableWriteConfig);
   }
 }

--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/metadata/TestHoodieBackedTableMetadataWriter.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/metadata/TestHoodieBackedTableMetadataWriter.java
@@ -20,10 +20,7 @@ package org.apache.hudi.metadata;
 
 import org.apache.hudi.client.BaseHoodieWriteClient;
 import org.apache.hudi.common.config.HoodieMetadataConfig;
-import org.apache.hudi.common.data.HoodieData;
-import org.apache.hudi.common.engine.HoodieEngineContext;
 import org.apache.hudi.common.model.HoodieFailedWritesCleaningPolicy;
-import org.apache.hudi.common.model.HoodieRecord;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.common.table.timeline.HoodieActiveTimeline;
 import org.apache.hudi.common.table.timeline.HoodieInstant;
@@ -33,10 +30,7 @@ import org.apache.hudi.common.util.Option;
 import org.apache.hudi.config.HoodieCleanConfig;
 import org.apache.hudi.config.HoodieWriteConfig;
 import org.apache.hudi.exception.HoodieException;
-import org.apache.hudi.metadata.model.FileInfo;
-import org.apache.hudi.storage.StorageConfiguration;
 
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -45,20 +39,14 @@ import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.MockedStatic;
 
 import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.stream.Stream;
 
 import static org.apache.hudi.common.testutils.HoodieTestUtils.INSTANT_GENERATOR;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
 import static org.mockito.Mockito.doCallRealMethod;
@@ -70,21 +58,6 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 class TestHoodieBackedTableMetadataWriter {
-  private HoodieEngineContext engineContext;
-  private HoodieTableMetaClient dataMetaClient;
-  private HoodieMetadataConfig metadataConfig;
-  private StorageConfiguration<?> storageConf;
-
-  @BeforeEach
-  void setUp() {
-    engineContext = mock(HoodieEngineContext.class);
-    dataMetaClient = mock(HoodieTableMetaClient.class);
-    metadataConfig = mock(HoodieMetadataConfig.class);
-    storageConf = mock(StorageConfiguration.class);
-
-    when(metadataConfig.getMaxReaderBufferSize()).thenReturn(1024);
-  }
-
   @ParameterizedTest
   @CsvSource(value = {
       "true,true,false,true",
@@ -154,133 +127,6 @@ class TestHoodieBackedTableMetadataWriter {
         .withCleanConfig(HoodieCleanConfig.newBuilder().withFailedWritesCleaningPolicy(HoodieFailedWritesCleaningPolicy.EAGER).build())
         .build();
     assertSame(mockMetaClient, HoodieBackedTableMetadataWriter.rollbackFailedWrites(lazyWriteConfig, mockWriteClient, mockMetaClient));
-  }
-
-  @Test
-  void testConvertToColumnStatsRecordWithEmptyInputs() {
-    Map<String, List<FileInfo>> partitionFilesToAdd = new HashMap<>();
-    Map<String, List<String>> partitionFilesToDelete = new HashMap<>();
-
-    Map<String, HoodieData<HoodieRecord>> result =
-        HoodieBackedTableMetadataWriter.convertToColumnStatsRecord(
-            partitionFilesToAdd, partitionFilesToDelete, engineContext, dataMetaClient, metadataConfig, Option.empty(), 4);
-    assertTrue(result.isEmpty());
-  }
-
-  @Test
-  void testConvertToColumnStatsRecordWithEmptyColumnsToIndex() {
-    // Mock HoodieTableMetadataUtil.getColumnsToIndex to return empty list
-    try (MockedStatic<HoodieTableMetadataUtil> mockedUtil = mockStatic(HoodieTableMetadataUtil.class)) {
-      Map<String, Object> emptyColumnsMap = new HashMap<>();
-      mockedUtil.when(() -> HoodieTableMetadataUtil.getColumnsToIndex(
-              any(), any(), any(), eq(false), any()))
-          .thenReturn(emptyColumnsMap);
-
-      Map<String, List<FileInfo>> partitionFilesToAdd = new HashMap<>();
-      List<FileInfo> filesToAdd = new ArrayList<>();
-      filesToAdd.add(FileInfo.of("file1.parquet", 1024L));
-      partitionFilesToAdd.put("partition1", filesToAdd);
-      Map<String, List<String>> partitionFilesToDelete = new HashMap<>();
-
-      Map<String, HoodieData<HoodieRecord>> result = HoodieBackedTableMetadataWriter.convertToColumnStatsRecord(
-          partitionFilesToAdd, partitionFilesToDelete, engineContext, dataMetaClient, metadataConfig,
-          Option.empty(), 4);
-      assertTrue(result.isEmpty());
-    }
-  }
-
-  @Test
-  void testConvertToColumnStatsRecordWithValidColumns() {
-    // Mock HoodieTableMetadataUtil.getColumnsToIndex to return valid columns
-    try (MockedStatic<HoodieTableMetadataUtil> mockedUtil = mockStatic(HoodieTableMetadataUtil.class)) {
-      Map<String, Object> columnsMap = new HashMap<>();
-      columnsMap.put("col1", null);
-      columnsMap.put("col2", null);
-      mockedUtil.when(() -> HoodieTableMetadataUtil.getColumnsToIndex(
-              any(), any(), any(), eq(false), any(), any()))
-          .thenReturn(columnsMap);
-
-      // Mock convertFilesToColumnStatsRecords to return empty HoodieData
-      HoodieData<HoodieRecord> mockHoodieData = mock(HoodieData.class);
-      mockedUtil.when(() -> HoodieTableMetadataUtil.convertFilesToColumnStatsRecords(
-              any(), any(), any(), any(), anyInt(), anyInt(), any()))
-          .thenReturn(mockHoodieData);
-
-      Map<String, List<FileInfo>> partitionFilesToAdd = new HashMap<>();
-      partitionFilesToAdd.put("partition1", Collections.emptyList());
-      Map<String, List<String>> partitionFilesToDelete = new HashMap<>();
-
-      Map<String, HoodieData<HoodieRecord>> result = HoodieBackedTableMetadataWriter.convertToColumnStatsRecord(
-          partitionFilesToAdd, partitionFilesToDelete, engineContext, dataMetaClient, metadataConfig,
-          Option.empty(), 4);
-
-      // Verify result contains COLUMN_STATS partition
-      assertEquals(1, result.size());
-      assertTrue(result.containsKey(MetadataPartitionType.COLUMN_STATS.getPartitionPath()));
-      assertEquals(mockHoodieData, result.get(MetadataPartitionType.COLUMN_STATS.getPartitionPath()));
-
-      // Verify the method was called with correct parameters
-      mockedUtil.verify(() -> HoodieTableMetadataUtil.convertFilesToColumnStatsRecords(
-          eq(engineContext),
-          eq(partitionFilesToDelete),
-          eq(partitionFilesToAdd),
-          eq(dataMetaClient),
-          eq(4),
-          eq(1024),
-          any()
-      ));
-    }
-  }
-
-  @Test
-  void testConvertToColumnStatsRecordWithMixedInputs() {
-    // Mock HoodieTableMetadataUtil.getColumnsToIndex to return valid columns
-    try (MockedStatic<HoodieTableMetadataUtil> mockedUtil = mockStatic(HoodieTableMetadataUtil.class)) {
-      Map<String, Object> columnsMap = new HashMap<>();
-      columnsMap.put("col1", null);
-      columnsMap.put("col2", null);
-      columnsMap.put("col3", null);
-      mockedUtil.when(() -> HoodieTableMetadataUtil.getColumnsToIndex(
-              any(), any(), any(), eq(false), any(), any()))
-          .thenReturn(columnsMap);
-
-      // Mock convertFilesToColumnStatsRecords to return empty HoodieData
-      HoodieData<HoodieRecord> mockHoodieData = mock(HoodieData.class);
-      mockedUtil.when(() -> HoodieTableMetadataUtil.convertFilesToColumnStatsRecords(
-              any(), any(), any(), any(), anyInt(), anyInt(), any()))
-          .thenReturn(mockHoodieData);
-
-      Map<String, List<FileInfo>> partitionFilesToAdd = new HashMap<>();
-      List<FileInfo> filesToAdd = new ArrayList<>();
-      filesToAdd.add(FileInfo.of("file1.parquet", 1024L));
-      filesToAdd.add(FileInfo.of("file2.parquet", 2048L));
-      partitionFilesToAdd.put("partition1", filesToAdd);
-
-      Map<String, List<String>> partitionFilesToDelete = new HashMap<>();
-      List<String> filesToDelete = new ArrayList<>();
-      filesToDelete.add("old_file1.parquet");
-      filesToDelete.add("old_file2.parquet");
-      partitionFilesToDelete.put("partition1", filesToDelete);
-
-      Map<String, HoodieData<HoodieRecord>> result = HoodieBackedTableMetadataWriter.convertToColumnStatsRecord(
-          partitionFilesToAdd, partitionFilesToDelete, engineContext, dataMetaClient, metadataConfig,
-          Option.empty(), 4);
-
-      // Verify result contains COLUMN_STATS partition.
-      assertEquals(1, result.size());
-      assertTrue(result.containsKey(MetadataPartitionType.COLUMN_STATS.getPartitionPath()));
-
-      // Verify the method was called with correct parameters.
-      mockedUtil.verify(() -> HoodieTableMetadataUtil.convertFilesToColumnStatsRecords(
-          eq(engineContext),
-          eq(partitionFilesToDelete),
-          eq(partitionFilesToAdd),
-          eq(dataMetaClient),
-          eq(4),
-          eq(1024),
-          any()
-      ));
-    }
   }
 
   @Test

--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/metadata/TestHoodieBackedTableMetadataWriter.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/metadata/TestHoodieBackedTableMetadataWriter.java
@@ -33,6 +33,7 @@ import org.apache.hudi.common.util.Option;
 import org.apache.hudi.config.HoodieCleanConfig;
 import org.apache.hudi.config.HoodieWriteConfig;
 import org.apache.hudi.exception.HoodieException;
+import org.apache.hudi.metadata.model.FileInfo;
 import org.apache.hudi.storage.StorageConfiguration;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -44,6 +45,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.MockedStatic;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -156,7 +158,7 @@ class TestHoodieBackedTableMetadataWriter {
 
   @Test
   void testConvertToColumnStatsRecordWithEmptyInputs() {
-    Map<String, Map<String, Long>> partitionFilesToAdd = new HashMap<>();
+    Map<String, List<FileInfo>> partitionFilesToAdd = new HashMap<>();
     Map<String, List<String>> partitionFilesToDelete = new HashMap<>();
 
     Map<String, HoodieData<HoodieRecord>> result =
@@ -174,9 +176,9 @@ class TestHoodieBackedTableMetadataWriter {
               any(), any(), any(), eq(false), any()))
           .thenReturn(emptyColumnsMap);
 
-      Map<String, Map<String, Long>> partitionFilesToAdd = new HashMap<>();
-      Map<String, Long> filesToAdd = new HashMap<>();
-      filesToAdd.put("file1.parquet", 1024L);
+      Map<String, List<FileInfo>> partitionFilesToAdd = new HashMap<>();
+      List<FileInfo> filesToAdd = new ArrayList<>();
+      filesToAdd.add(FileInfo.of("file1.parquet", 1024L));
       partitionFilesToAdd.put("partition1", filesToAdd);
       Map<String, List<String>> partitionFilesToDelete = new HashMap<>();
 
@@ -201,11 +203,11 @@ class TestHoodieBackedTableMetadataWriter {
       // Mock convertFilesToColumnStatsRecords to return empty HoodieData
       HoodieData<HoodieRecord> mockHoodieData = mock(HoodieData.class);
       mockedUtil.when(() -> HoodieTableMetadataUtil.convertFilesToColumnStatsRecords(
-              any(), any(), any(), any(), any(), anyInt(), anyInt(), any()))
+              any(), any(), any(), any(), anyInt(), anyInt(), any()))
           .thenReturn(mockHoodieData);
 
-      Map<String, Map<String, Long>> partitionFilesToAdd = new HashMap<>();
-      partitionFilesToAdd.put("partition1", new HashMap<>());
+      Map<String, List<FileInfo>> partitionFilesToAdd = new HashMap<>();
+      partitionFilesToAdd.put("partition1", Collections.emptyList());
       Map<String, List<String>> partitionFilesToDelete = new HashMap<>();
 
       Map<String, HoodieData<HoodieRecord>> result = HoodieBackedTableMetadataWriter.convertToColumnStatsRecord(
@@ -223,7 +225,6 @@ class TestHoodieBackedTableMetadataWriter {
           eq(partitionFilesToDelete),
           eq(partitionFilesToAdd),
           eq(dataMetaClient),
-          eq(metadataConfig),
           eq(4),
           eq(1024),
           any()
@@ -246,13 +247,13 @@ class TestHoodieBackedTableMetadataWriter {
       // Mock convertFilesToColumnStatsRecords to return empty HoodieData
       HoodieData<HoodieRecord> mockHoodieData = mock(HoodieData.class);
       mockedUtil.when(() -> HoodieTableMetadataUtil.convertFilesToColumnStatsRecords(
-              any(), any(), any(), any(), any(), anyInt(), anyInt(), any()))
+              any(), any(), any(), any(), anyInt(), anyInt(), any()))
           .thenReturn(mockHoodieData);
 
-      Map<String, Map<String, Long>> partitionFilesToAdd = new HashMap<>();
-      Map<String, Long> filesToAdd = new HashMap<>();
-      filesToAdd.put("file1.parquet", 1024L);
-      filesToAdd.put("file2.parquet", 2048L);
+      Map<String, List<FileInfo>> partitionFilesToAdd = new HashMap<>();
+      List<FileInfo> filesToAdd = new ArrayList<>();
+      filesToAdd.add(FileInfo.of("file1.parquet", 1024L));
+      filesToAdd.add(FileInfo.of("file2.parquet", 2048L));
       partitionFilesToAdd.put("partition1", filesToAdd);
 
       Map<String, List<String>> partitionFilesToDelete = new HashMap<>();
@@ -275,7 +276,6 @@ class TestHoodieBackedTableMetadataWriter {
           eq(partitionFilesToDelete),
           eq(partitionFilesToAdd),
           eq(dataMetaClient),
-          eq(metadataConfig),
           eq(4),
           eq(1024),
           any()

--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/metadata/index/TestIndexerFactory.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/metadata/index/TestIndexerFactory.java
@@ -1,0 +1,104 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.
+ */
+
+package org.apache.hudi.metadata.index;
+
+import org.apache.hudi.common.config.HoodieMetadataConfig;
+import org.apache.hudi.common.engine.HoodieEngineContext;
+import org.apache.hudi.common.model.HoodieRecordMerger;
+import org.apache.hudi.common.table.HoodieTableConfig;
+import org.apache.hudi.common.table.HoodieTableMetaClient;
+import org.apache.hudi.common.table.HoodieTableVersion;
+import org.apache.hudi.common.util.Option;
+import org.apache.hudi.config.HoodieWriteConfig;
+import org.apache.hudi.metadata.MetadataPartitionType;
+import org.apache.hudi.metadata.index.record.PartitionedRecordIndexer;
+import org.apache.hudi.metadata.index.record.RecordIndexer;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class TestIndexerFactory {
+
+  @Test
+  void testMetadataDisabledReturnsEmptyMap() {
+    HoodieEngineContext engineContext = mock(HoodieEngineContext.class);
+    HoodieWriteConfig writeConfig = mock(HoodieWriteConfig.class);
+    HoodieMetadataConfig metadataConfig = mock(HoodieMetadataConfig.class);
+
+    when(writeConfig.getMetadataConfig()).thenReturn(metadataConfig);
+    when(metadataConfig.isEnabled()).thenReturn(false);
+
+    Map<MetadataPartitionType, Indexer> enabled =
+        IndexerFactory.getEnabledIndexerMap(engineContext, writeConfig, mock(HoodieTableMetaClient.class), mock(ExpressionIndexRecordGenerator.class));
+    assertTrue(enabled.isEmpty());
+  }
+
+  @Test
+  void testRecordIndexerSelectionByConfig() {
+    HoodieEngineContext engineContext = mock(HoodieEngineContext.class);
+    HoodieWriteConfig writeConfig = mock(HoodieWriteConfig.class);
+    HoodieMetadataConfig metadataConfig = mock(HoodieMetadataConfig.class);
+    HoodieTableMetaClient metaClient = mock(HoodieTableMetaClient.class);
+    HoodieTableConfig tableConfig = mock(HoodieTableConfig.class);
+
+    when(writeConfig.getMetadataConfig()).thenReturn(metadataConfig);
+    when(metadataConfig.isEnabled()).thenReturn(true);
+    when(writeConfig.getRecordMerger()).thenReturn(mock(HoodieRecordMerger.class));
+
+    when(metaClient.getTableConfig()).thenReturn(tableConfig);
+    when(metaClient.getIndexMetadata()).thenReturn(Option.empty());
+    when(tableConfig.getTableVersion()).thenReturn(HoodieTableVersion.EIGHT);
+    when(tableConfig.isTablePartitioned()).thenReturn(true);
+    when(tableConfig.isMetadataPartitionAvailable(any(MetadataPartitionType.class))).thenReturn(false);
+    when(tableConfig.isMetadataPartitionAvailable(MetadataPartitionType.RECORD_INDEX)).thenReturn(true);
+
+    when(writeConfig.isRecordLevelIndexEnabled()).thenReturn(false);
+    Map<MetadataPartitionType, Indexer> globalIndexers =
+        IndexerFactory.getEnabledIndexerMap(engineContext, writeConfig, metaClient, mock(ExpressionIndexRecordGenerator.class));
+    assertInstanceOf(RecordIndexer.class, globalIndexers.get(MetadataPartitionType.RECORD_INDEX));
+
+    when(writeConfig.isRecordLevelIndexEnabled()).thenReturn(true);
+    Map<MetadataPartitionType, Indexer> partitionedIndexers =
+        IndexerFactory.getEnabledIndexerMap(engineContext, writeConfig, metaClient, mock(ExpressionIndexRecordGenerator.class));
+    assertInstanceOf(PartitionedRecordIndexer.class, partitionedIndexers.get(MetadataPartitionType.RECORD_INDEX));
+  }
+
+  @Test
+  void testTableVersionSixGatesExpressionAndSecondary() {
+    HoodieEngineContext engineContext = mock(HoodieEngineContext.class);
+    HoodieWriteConfig writeConfig = HoodieWriteConfig.newBuilder()
+        .withPath("file:///tmp")
+        .withMetadataConfig(HoodieMetadataConfig.newBuilder()
+            .enable(true)
+            .withExpressionIndexEnabled(true)
+            .withSecondaryIndexEnabled(true)
+            .withSecondaryIndexForColumn("col1")
+            .build())
+        .build();
+
+    HoodieTableMetaClient metaClient = mock(HoodieTableMetaClient.class);
+    HoodieTableConfig tableConfig = mock(HoodieTableConfig.class);
+    when(metaClient.getTableConfig()).thenReturn(tableConfig);
+    when(metaClient.getIndexMetadata()).thenReturn(Option.empty());
+    when(tableConfig.getTableVersion()).thenReturn(HoodieTableVersion.SIX);
+    when(tableConfig.isTablePartitioned()).thenReturn(true);
+    when(tableConfig.isMetadataPartitionAvailable(any(MetadataPartitionType.class))).thenReturn(false);
+
+    Map<MetadataPartitionType, Indexer> enabled =
+        IndexerFactory.getEnabledIndexerMap(engineContext, writeConfig, metaClient, mock(ExpressionIndexRecordGenerator.class));
+
+    assertFalse(enabled.containsKey(MetadataPartitionType.EXPRESSION_INDEX));
+    assertFalse(enabled.containsKey(MetadataPartitionType.SECONDARY_INDEX));
+  }
+}

--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/metadata/index/bloomfilters/TestBloomFiltersIndexer.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/metadata/index/bloomfilters/TestBloomFiltersIndexer.java
@@ -12,16 +12,23 @@
 
 package org.apache.hudi.metadata.index.bloomfilters;
 
+import org.apache.hudi.avro.model.HoodieCleanMetadata;
 import org.apache.hudi.common.config.HoodieMetadataConfig;
 import org.apache.hudi.common.data.HoodieData;
 import org.apache.hudi.common.engine.HoodieEngineContext;
 import org.apache.hudi.common.engine.HoodieLocalEngineContext;
+import org.apache.hudi.common.fs.FSUtils;
+import org.apache.hudi.common.model.HoodieCommitMetadata;
 import org.apache.hudi.common.model.HoodieRecord;
+import org.apache.hudi.common.model.HoodieWriteStat;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
+import org.apache.hudi.common.table.view.HoodieTableFileSystemView;
 import org.apache.hudi.config.HoodieWriteConfig;
+import org.apache.hudi.metadata.HoodieBackedTableMetadata;
 import org.apache.hudi.metadata.HoodieMetadataPayload;
 import org.apache.hudi.metadata.HoodieTableMetadataUtil;
 import org.apache.hudi.metadata.MetadataPartitionType;
+import org.apache.hudi.metadata.index.model.IndexPartitionAndRecords;
 import org.apache.hudi.metadata.index.model.IndexPartitionInitialization;
 import org.apache.hudi.metadata.model.FileInfo;
 import org.apache.hudi.metadata.model.FileSliceAndPartition;
@@ -31,12 +38,16 @@ import org.junit.jupiter.api.Test;
 import org.mockito.MockedStatic;
 
 import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
 import static org.apache.hudi.common.testutils.HoodieTestUtils.getDefaultStorageConf;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.mock;
@@ -77,6 +88,75 @@ class TestBloomFiltersIndexer {
       assertEquals(1, collected.size());
       assertEquals("p_bloom", collected.get(0).getRecordKey());
     }
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void testBuildUpdateWithNonEmptyCommitMetadataAndWriteStat() throws Exception {
+    HoodieEngineContext engineContext = mock(HoodieEngineContext.class);
+    HoodieEngineContext realEngineContext = new HoodieLocalEngineContext(getDefaultStorageConf());
+    HoodieWriteConfig writeConfig = mock(HoodieWriteConfig.class);
+    HoodieTableMetaClient metaClient = mock(HoodieTableMetaClient.class);
+    HoodieMetadataConfig metadataConfig = mock(HoodieMetadataConfig.class);
+    when(writeConfig.getMetadataConfig()).thenReturn(metadataConfig);
+    when(writeConfig.getBloomIndexParallelism()).thenReturn(4);
+    when(writeConfig.getBloomFilterType()).thenReturn("DYNAMIC_V0");
+
+    HoodieCommitMetadata commitMetadata = new HoodieCommitMetadata();
+    HoodieWriteStat writeStat = new HoodieWriteStat();
+    writeStat.setPartitionPath("p1");
+    writeStat.setPath("p1/f1.parquet");
+    commitMetadata.addWriteStat("p1", writeStat);
+
+    HoodieData<HoodieWriteStat> writeStatsData = (HoodieData<HoodieWriteStat>) mock(HoodieData.class);
+    String baseFileName = FSUtils.makeBaseFileName("004", "1-0-1", "fileid-1", ".parquet");
+    HoodieData<HoodieRecord> bloomIndexData = (HoodieData<HoodieRecord>) (HoodieData<?>) realEngineContext.parallelize(
+        Collections.singletonList(HoodieMetadataPayload.createBloomFilterMetadataRecord(
+            "p1", baseFileName, "004", "DYNAMIC_V0",
+            ByteBuffer.wrap("bf".getBytes(StandardCharsets.UTF_8)), false)),
+        1);
+    when(engineContext.parallelize(any(List.class), anyInt())).thenReturn((HoodieData) writeStatsData);
+    when(writeStatsData.flatMap(any())).thenReturn((HoodieData) bloomIndexData);
+
+    ExposedBloomFiltersIndexer indexer = new ExposedBloomFiltersIndexer(engineContext, writeConfig, metaClient);
+    List<IndexPartitionAndRecords> result = indexer.buildUpdate(
+        "004",
+        mock(HoodieBackedTableMetadata.class),
+        Lazy.lazily(() -> mock(HoodieTableFileSystemView.class)),
+        commitMetadata);
+
+    assertEquals(1, result.size());
+    assertEquals(MetadataPartitionType.BLOOM_FILTERS.getPartitionPath(), result.get(0).indexPartitionName());
+    List<HoodieRecord> indexRecords = result.get(0).indexRecords().collectAsList();
+    assertEquals(1, indexRecords.size());
+    HoodieMetadataPayload payload = (HoodieMetadataPayload) indexRecords.get(0).getData();
+    assertTrue(payload.getBloomFilterMetadata().isPresent());
+    assertEquals("DYNAMIC_V0", payload.getBloomFilterMetadata().get().getType());
+    assertEquals("004", payload.getBloomFilterMetadata().get().getTimestamp());
+    assertFalse(payload.getBloomFilterMetadata().get().getIsDeleted());
+    assertEquals("bf", new String(payload.getBloomFilterMetadata().get().getBloomFilter().array(), StandardCharsets.UTF_8));
+  }
+
+  @Test
+  void testBuildCleanProducesDeleteRecordsForBaseFilesOnly() {
+    HoodieEngineContext engineContext = new HoodieLocalEngineContext(getDefaultStorageConf());
+    HoodieWriteConfig writeConfig = mock(HoodieWriteConfig.class);
+    HoodieTableMetaClient metaClient = mock(HoodieTableMetaClient.class);
+    HoodieMetadataConfig metadataConfig = mock(HoodieMetadataConfig.class);
+    when(writeConfig.getMetadataConfig()).thenReturn(metadataConfig);
+    when(writeConfig.getBloomIndexParallelism()).thenReturn(4);
+
+    HoodieCleanMetadata cleanMetadata = mock(HoodieCleanMetadata.class);
+    org.apache.hudi.avro.model.HoodieCleanPartitionMetadata partitionMetadata = mock(org.apache.hudi.avro.model.HoodieCleanPartitionMetadata.class);
+    when(cleanMetadata.getPartitionMetadata()).thenReturn(Collections.singletonMap("p1", partitionMetadata));
+    when(partitionMetadata.getDeletePathPatterns()).thenReturn(Collections.singletonList("f1_1-0-1_000.parquet"));
+
+    ExposedBloomFiltersIndexer indexer = new ExposedBloomFiltersIndexer(engineContext, writeConfig, metaClient);
+    List<IndexPartitionAndRecords> result = indexer.buildClean("005", cleanMetadata);
+
+    assertEquals(1, result.size());
+    assertEquals(MetadataPartitionType.BLOOM_FILTERS.getPartitionPath(), result.get(0).indexPartitionName());
+    assertEquals(1, result.get(0).indexRecords().collectAsList().size());
   }
 
   private static class ExposedBloomFiltersIndexer extends BloomFiltersIndexer {

--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/metadata/index/bloomfilters/TestBloomFiltersIndexer.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/metadata/index/bloomfilters/TestBloomFiltersIndexer.java
@@ -1,0 +1,93 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package org.apache.hudi.metadata.index.bloomfilters;
+
+import org.apache.hudi.common.config.HoodieMetadataConfig;
+import org.apache.hudi.common.data.HoodieData;
+import org.apache.hudi.common.engine.HoodieEngineContext;
+import org.apache.hudi.common.engine.HoodieLocalEngineContext;
+import org.apache.hudi.common.model.HoodieRecord;
+import org.apache.hudi.common.table.HoodieTableMetaClient;
+import org.apache.hudi.config.HoodieWriteConfig;
+import org.apache.hudi.metadata.HoodieMetadataPayload;
+import org.apache.hudi.metadata.HoodieTableMetadataUtil;
+import org.apache.hudi.metadata.MetadataPartitionType;
+import org.apache.hudi.metadata.index.model.IndexPartitionInitialization;
+import org.apache.hudi.metadata.model.FileInfo;
+import org.apache.hudi.metadata.model.FileSliceAndPartition;
+import org.apache.hudi.util.Lazy;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import static org.apache.hudi.common.testutils.HoodieTestUtils.getDefaultStorageConf;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
+
+class TestBloomFiltersIndexer {
+
+  @SuppressWarnings("unchecked")
+  @Test
+  void testInitializeDataWithRealEngineContextAndIndexDataContent() throws IOException {
+    HoodieEngineContext engineContext = new HoodieLocalEngineContext(getDefaultStorageConf());
+    HoodieWriteConfig writeConfig = mock(HoodieWriteConfig.class);
+    HoodieMetadataConfig metadataConfig = mock(HoodieMetadataConfig.class);
+    HoodieTableMetaClient metaClient = mock(HoodieTableMetaClient.class);
+
+    when(writeConfig.getMetadataConfig()).thenReturn(metadataConfig);
+    when(writeConfig.getBloomIndexParallelism()).thenReturn(8);
+    when(writeConfig.getBloomFilterType()).thenReturn("DYNAMIC_V0");
+    when(metadataConfig.getBloomFilterIndexFileGroupCount()).thenReturn(3);
+
+    HoodieData<HoodieRecord> records = (HoodieData<HoodieRecord>) (HoodieData<?>) engineContext.parallelize(
+        Collections.singletonList(HoodieMetadataPayload.createPartitionFilesRecord("p_bloom",
+            Collections.singletonMap("f1.parquet", 11L), Collections.emptyList())),
+        1);
+
+    try (MockedStatic<HoodieTableMetadataUtil> mockedUtil = mockStatic(HoodieTableMetadataUtil.class)) {
+      mockedUtil.when(() -> HoodieTableMetadataUtil.convertFilesToBloomFilterRecords(any(), any(), any(), any(), any(), anyInt(), any()))
+          .thenReturn(records);
+
+      ExposedBloomFiltersIndexer indexer = new ExposedBloomFiltersIndexer(engineContext, writeConfig, metaClient);
+      List<IndexPartitionInitialization> initializationList = indexer.callGetData("001", "002", Collections.emptyMap(), Lazy.lazily(Collections::emptyList));
+      assertEquals(1, initializationList.size());
+
+      assertEquals(MetadataPartitionType.BLOOM_FILTERS.getPartitionPath(), initializationList.get(0).indexPartitionName());
+      assertEquals(3, initializationList.get(0).totalFileGroups());
+      List<HoodieRecord> collected = initializationList.get(0).dataPartitionAndRecords().get(0).indexRecords().collectAsList();
+      assertEquals(1, collected.size());
+      assertEquals("p_bloom", collected.get(0).getRecordKey());
+    }
+  }
+
+  private static class ExposedBloomFiltersIndexer extends BloomFiltersIndexer {
+    ExposedBloomFiltersIndexer(HoodieEngineContext engineContext, HoodieWriteConfig dataTableWriteConfig, HoodieTableMetaClient dataTableMetaClient) {
+      super(engineContext, dataTableWriteConfig, dataTableMetaClient);
+    }
+
+    List<IndexPartitionInitialization> callGetData(String dataTableInstantTime, String instantTimeForPartition,
+                                                   Map<String, List<FileInfo>> partitionIdToAllFilesMap,
+                                                   Lazy<List<FileSliceAndPartition>> lazyLatestMergedPartitionFileSliceList) throws IOException {
+      return buildInitialization(dataTableInstantTime, instantTimeForPartition, partitionIdToAllFilesMap, lazyLatestMergedPartitionFileSliceList);
+    }
+  }
+}

--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/metadata/index/columnstats/TestColumnStatsIndexer.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/metadata/index/columnstats/TestColumnStatsIndexer.java
@@ -5,28 +5,41 @@
 
 package org.apache.hudi.metadata.index.columnstats;
 
+import org.apache.hudi.avro.model.HoodieCleanMetadata;
+import org.apache.hudi.avro.model.HoodieCleanPartitionMetadata;
 import org.apache.hudi.common.config.HoodieMetadataConfig;
 import org.apache.hudi.common.data.HoodieData;
 import org.apache.hudi.common.engine.HoodieEngineContext;
 import org.apache.hudi.common.engine.HoodieLocalEngineContext;
+import org.apache.hudi.common.model.HoodieCommitMetadata;
 import org.apache.hudi.common.model.HoodieRecord;
 import org.apache.hudi.common.model.HoodieRecordMerger;
+import org.apache.hudi.common.model.HoodieWriteStat;
+import org.apache.hudi.common.schema.HoodieSchema;
+import org.apache.hudi.common.model.WriteOperationType;
 import org.apache.hudi.common.table.HoodieTableConfig;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
+import org.apache.hudi.common.table.view.HoodieTableFileSystemView;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.config.HoodieWriteConfig;
+import org.apache.hudi.metadata.HoodieBackedTableMetadata;
+import org.apache.hudi.metadata.HoodieIndexVersion;
 import org.apache.hudi.metadata.HoodieMetadataPayload;
 import org.apache.hudi.metadata.HoodieTableMetadataUtil;
 import org.apache.hudi.metadata.MetadataPartitionType;
+import org.apache.hudi.metadata.index.model.IndexPartitionAndRecords;
 import org.apache.hudi.metadata.index.model.IndexPartitionInitialization;
 import org.apache.hudi.metadata.model.FileInfo;
 import org.apache.hudi.metadata.model.FileSliceAndPartition;
+import org.apache.hudi.stats.HoodieColumnRangeMetadata;
 import org.apache.hudi.util.Lazy;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.MockedStatic;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -34,7 +47,9 @@ import java.util.Map;
 
 import static org.apache.hudi.common.testutils.HoodieTestUtils.getDefaultStorageConf;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.eq;
@@ -43,6 +58,135 @@ import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.when;
 
 class TestColumnStatsIndexer {
+  private static final int PARALLELISM = 4;
+  private static final int MAX_READER_BUFFER_SIZE = 1024;
+
+  private HoodieEngineContext engineContext;
+  private HoodieWriteConfig writeConfig;
+  private HoodieMetadataConfig metadataConfig;
+  private HoodieTableMetaClient metaClient;
+  private HoodieTableConfig tableConfig;
+  private HoodieRecordMerger recordMerger;
+
+  @BeforeEach
+  void setUp() {
+    engineContext = mock(HoodieEngineContext.class);
+    writeConfig = mock(HoodieWriteConfig.class);
+    metadataConfig = mock(HoodieMetadataConfig.class);
+    metaClient = mock(HoodieTableMetaClient.class);
+    tableConfig = mock(HoodieTableConfig.class);
+    recordMerger = mock(HoodieRecordMerger.class);
+
+    when(writeConfig.getMetadataConfig()).thenReturn(metadataConfig);
+    when(writeConfig.getColumnStatsIndexParallelism()).thenReturn(PARALLELISM);
+    when(writeConfig.getRecordMerger()).thenReturn(recordMerger);
+    when(recordMerger.getRecordType()).thenReturn(HoodieRecord.HoodieRecordType.AVRO);
+    when(metadataConfig.getColumnStatsIndexParallelism()).thenReturn(PARALLELISM);
+    when(metadataConfig.getMaxReaderBufferSize()).thenReturn(MAX_READER_BUFFER_SIZE);
+    when(metaClient.getTableConfig()).thenReturn(tableConfig);
+  }
+
+  @Test
+  void testBuildRestoreWithEmptyInputs() {
+    ExposedColumnStatsIndexer indexer = new ExposedColumnStatsIndexer(engineContext, writeConfig, metaClient);
+    List<IndexPartitionAndRecords> result =
+        indexer.buildRestore("001", Collections.emptyList(), Collections.emptyMap(), Collections.emptyMap());
+    assertTrue(result.isEmpty());
+  }
+
+  @Test
+  void testBuildRestoreWithEmptyColumnsToIndex() {
+    try (MockedStatic<HoodieTableMetadataUtil> mockedUtil = mockStatic(HoodieTableMetadataUtil.class)) {
+      Map<String, Object> emptyColumnsMap = new HashMap<>();
+      mockedUtil.when(() -> HoodieTableMetadataUtil.getColumnsToIndex(
+          any(), any(), any(), eq(false), any(), any())).thenReturn(emptyColumnsMap);
+
+      Map<String, List<FileInfo>> filesAdded = new HashMap<>();
+      filesAdded.put("partition1", Collections.singletonList(FileInfo.of("file1.parquet", 1024L)));
+
+      ExposedColumnStatsIndexer indexer = new ExposedColumnStatsIndexer(engineContext, writeConfig, metaClient);
+      List<IndexPartitionAndRecords> result =
+          indexer.buildRestore("001", Collections.emptyList(), filesAdded, Collections.emptyMap());
+      assertTrue(result.isEmpty());
+    }
+  }
+
+  @Test
+  void testBuildRestoreWithValidColumns() {
+    try (MockedStatic<HoodieTableMetadataUtil> mockedUtil = mockStatic(HoodieTableMetadataUtil.class)) {
+      Map<String, Object> columnsMap = new HashMap<>();
+      columnsMap.put("col1", null);
+      columnsMap.put("col2", null);
+      mockedUtil.when(() -> HoodieTableMetadataUtil.getColumnsToIndex(
+          any(), any(), any(), eq(false), any(), any())).thenReturn(columnsMap);
+
+      HoodieData<HoodieRecord> mockHoodieData = mock(HoodieData.class);
+      mockedUtil.when(() -> HoodieTableMetadataUtil.convertFilesToColumnStatsRecords(
+          any(), any(), any(), any(), anyInt(), anyInt(), any())).thenReturn(mockHoodieData);
+
+      Map<String, List<FileInfo>> filesAdded = new HashMap<>();
+      filesAdded.put("partition1", new ArrayList<>());
+
+      ExposedColumnStatsIndexer indexer = new ExposedColumnStatsIndexer(engineContext, writeConfig, metaClient);
+      List<IndexPartitionAndRecords> result =
+          indexer.buildRestore("001", Collections.emptyList(), filesAdded, Collections.emptyMap());
+
+      assertEquals(1, result.size());
+      assertEquals(MetadataPartitionType.COLUMN_STATS.getPartitionPath(), result.get(0).indexPartitionName());
+      assertSame(mockHoodieData, result.get(0).indexRecords());
+
+      mockedUtil.verify(() -> HoodieTableMetadataUtil.convertFilesToColumnStatsRecords(
+          eq(engineContext),
+          eq(Collections.emptyMap()),
+          eq(filesAdded),
+          eq(metaClient),
+          eq(PARALLELISM),
+          eq(MAX_READER_BUFFER_SIZE),
+          any()));
+    }
+  }
+
+  @Test
+  void testBuildRestoreWithMixedInputs() {
+    try (MockedStatic<HoodieTableMetadataUtil> mockedUtil = mockStatic(HoodieTableMetadataUtil.class)) {
+      Map<String, Object> columnsMap = new HashMap<>();
+      columnsMap.put("col1", null);
+      columnsMap.put("col2", null);
+      columnsMap.put("col3", null);
+      mockedUtil.when(() -> HoodieTableMetadataUtil.getColumnsToIndex(
+          any(), any(), any(), eq(false), any(), any())).thenReturn(columnsMap);
+
+      HoodieData<HoodieRecord> mockHoodieData = mock(HoodieData.class);
+      mockedUtil.when(() -> HoodieTableMetadataUtil.convertFilesToColumnStatsRecords(
+          any(), any(), any(), any(), anyInt(), anyInt(), any())).thenReturn(mockHoodieData);
+
+      Map<String, List<FileInfo>> filesAdded = new HashMap<>();
+      List<FileInfo> filesToAdd = new ArrayList<>();
+      filesToAdd.add(FileInfo.of("file1.parquet", 1024L));
+      filesToAdd.add(FileInfo.of("file2.parquet", 2048L));
+      filesAdded.put("partition1", filesToAdd);
+
+      Map<String, List<String>> filesDeleted = new HashMap<>();
+      filesDeleted.put("partition1", List.of("old_file1.parquet", "old_file2.parquet"));
+
+      ExposedColumnStatsIndexer indexer = new ExposedColumnStatsIndexer(engineContext, writeConfig, metaClient);
+      List<IndexPartitionAndRecords> result =
+          indexer.buildRestore("001", Collections.emptyList(), filesAdded, filesDeleted);
+
+      assertEquals(1, result.size());
+      assertEquals(MetadataPartitionType.COLUMN_STATS.getPartitionPath(), result.get(0).indexPartitionName());
+      assertSame(mockHoodieData, result.get(0).indexRecords());
+
+      mockedUtil.verify(() -> HoodieTableMetadataUtil.convertFilesToColumnStatsRecords(
+          eq(engineContext),
+          eq(filesDeleted),
+          eq(filesAdded),
+          eq(metaClient),
+          eq(PARALLELISM),
+          eq(MAX_READER_BUFFER_SIZE),
+          any()));
+    }
+  }
 
   @Test
   void testInitializeDataWithEmptyInputUsesEmptyHoodieData() throws IOException {
@@ -107,6 +251,74 @@ class TestColumnStatsIndexer {
       assertEquals(1, collected.size());
       assertEquals("p_col", collected.get(0).getRecordKey());
     }
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void testBuildUpdateWithNonEmptyCommitMetadataProducesPartitionEntry() {
+    HoodieEngineContext mockedEngineContext = mock(HoodieEngineContext.class);
+    HoodieEngineContext realEngineContext = new HoodieLocalEngineContext(getDefaultStorageConf());
+    ExposedColumnStatsIndexer indexer = new ExposedColumnStatsIndexer(mockedEngineContext, writeConfig, metaClient);
+
+    HoodieCommitMetadata commitMetadata = new HoodieCommitMetadata();
+    commitMetadata.setOperationType(WriteOperationType.UPSERT);
+    String filePath = "p1/fileid-1_1-0-1_014.parquet";
+    HoodieWriteStat writeStat = new HoodieWriteStat();
+    writeStat.setPartitionPath("p1");
+    writeStat.setPath(filePath);
+    writeStat.setRecordsStats(Collections.singletonMap("c1",
+        HoodieColumnRangeMetadata.stub(filePath, "c1", HoodieIndexVersion.V1)));
+    commitMetadata.getPartitionToWriteStats().put("p1", Collections.singletonList(writeStat));
+
+    HoodieData<HoodieWriteStat> writeStatsData = (HoodieData<HoodieWriteStat>) mock(HoodieData.class);
+    HoodieData<HoodieRecord> columnStatsData = (HoodieData<HoodieRecord>) (HoodieData<?>) realEngineContext.parallelize(
+        HoodieMetadataPayload.createColumnStatsRecords("p1",
+            Collections.singletonList(HoodieColumnRangeMetadata.stub(filePath, "c1", HoodieIndexVersion.V1)),
+            false).collect(java.util.stream.Collectors.toList()),
+        1);
+    when(mockedEngineContext.parallelize(any(List.class), anyInt())).thenReturn((HoodieData) writeStatsData);
+    when(writeStatsData.flatMap(any())).thenReturn((HoodieData) columnStatsData);
+
+    List<IndexPartitionAndRecords> result;
+    try (MockedStatic<HoodieTableMetadataUtil> mockedUtil = mockStatic(HoodieTableMetadataUtil.class)) {
+      Map<String, HoodieSchema> columnsToIndex = new HashMap<>();
+      columnsToIndex.put("c1", mock(HoodieSchema.class));
+      mockedUtil.when(() -> HoodieTableMetadataUtil.getColumnsToIndex(any(HoodieCommitMetadata.class), any(HoodieTableMetaClient.class), any(HoodieMetadataConfig.class), any()))
+          .thenReturn(columnsToIndex);
+
+      result = indexer.buildUpdate(
+          "014",
+          mock(HoodieBackedTableMetadata.class),
+          Lazy.lazily(() -> mock(HoodieTableFileSystemView.class)),
+          commitMetadata);
+    }
+
+    assertEquals(1, result.size());
+    assertEquals(MetadataPartitionType.COLUMN_STATS.getPartitionPath(), result.get(0).indexPartitionName());
+    List<HoodieRecord> indexRecords = result.get(0).indexRecords().collectAsList();
+    assertEquals(1, indexRecords.size());
+    HoodieMetadataPayload payload = (HoodieMetadataPayload) indexRecords.get(0).getData();
+    assertTrue(payload.getColumnStatMetadata().isPresent());
+    assertEquals("c1", payload.getColumnStatMetadata().get().getColumnName());
+    assertFalse(payload.getColumnStatMetadata().get().getIsDeleted());
+  }
+
+  @Test
+  void testBuildCleanWithNoDeletedFilesProducesEmptyRecords() {
+    Map<String, HoodieCleanPartitionMetadata> partitionMetadata = new HashMap<>();
+    partitionMetadata.put("p1", new HoodieCleanPartitionMetadata(
+        "p1", "KEEP_LATEST_COMMITS", Collections.emptyList(),
+        Collections.emptyList(), Collections.emptyList(), false));
+    HoodieCleanMetadata cleanMetadata = new HoodieCleanMetadata(
+        "014", 100L, 0, "013", "013", partitionMetadata, 2, Collections.emptyMap(), Collections.emptyMap());
+
+    HoodieEngineContext localEngineContext = new HoodieLocalEngineContext(getDefaultStorageConf());
+    ExposedColumnStatsIndexer indexer = new ExposedColumnStatsIndexer(localEngineContext, writeConfig, metaClient);
+    List<IndexPartitionAndRecords> result = indexer.buildClean("015", cleanMetadata);
+
+    assertEquals(1, result.size());
+    assertEquals(MetadataPartitionType.COLUMN_STATS.getPartitionPath(), result.get(0).indexPartitionName());
+    assertEquals(0, result.get(0).indexRecords().collectAsList().size());
   }
 
   private static class ExposedColumnStatsIndexer extends ColumnStatsIndexer {

--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/metadata/index/columnstats/TestColumnStatsIndexer.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/metadata/index/columnstats/TestColumnStatsIndexer.java
@@ -1,0 +1,123 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.
+ */
+
+package org.apache.hudi.metadata.index.columnstats;
+
+import org.apache.hudi.common.config.HoodieMetadataConfig;
+import org.apache.hudi.common.data.HoodieData;
+import org.apache.hudi.common.engine.HoodieEngineContext;
+import org.apache.hudi.common.engine.HoodieLocalEngineContext;
+import org.apache.hudi.common.model.HoodieRecord;
+import org.apache.hudi.common.model.HoodieRecordMerger;
+import org.apache.hudi.common.table.HoodieTableConfig;
+import org.apache.hudi.common.table.HoodieTableMetaClient;
+import org.apache.hudi.common.util.Option;
+import org.apache.hudi.config.HoodieWriteConfig;
+import org.apache.hudi.metadata.HoodieMetadataPayload;
+import org.apache.hudi.metadata.HoodieTableMetadataUtil;
+import org.apache.hudi.metadata.MetadataPartitionType;
+import org.apache.hudi.metadata.index.model.IndexPartitionInitialization;
+import org.apache.hudi.metadata.model.FileInfo;
+import org.apache.hudi.metadata.model.FileSliceAndPartition;
+import org.apache.hudi.util.Lazy;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.apache.hudi.common.testutils.HoodieTestUtils.getDefaultStorageConf;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
+
+class TestColumnStatsIndexer {
+
+  @Test
+  void testInitializeDataWithEmptyInputUsesEmptyHoodieData() throws IOException {
+    HoodieEngineContext engineContext = mock(HoodieEngineContext.class);
+    HoodieWriteConfig writeConfig = mock(HoodieWriteConfig.class);
+    HoodieMetadataConfig metadataConfig = mock(HoodieMetadataConfig.class);
+    HoodieTableMetaClient metaClient = mock(HoodieTableMetaClient.class);
+    HoodieData<HoodieRecord> emptyData = mock(HoodieData.class);
+
+    when(writeConfig.getMetadataConfig()).thenReturn(metadataConfig);
+    when(metadataConfig.getColumnStatsIndexFileGroupCount()).thenReturn(2);
+    when(engineContext.emptyHoodieData()).thenReturn((HoodieData) emptyData);
+
+    ExposedColumnStatsIndexer indexer = new ExposedColumnStatsIndexer(engineContext, writeConfig, metaClient);
+    List<IndexPartitionInitialization> initializationList = indexer.callGetData("001", "002", Collections.emptyMap(), Lazy.lazily(Collections::emptyList));
+    assertEquals(1, initializationList.size());
+
+    assertEquals(MetadataPartitionType.COLUMN_STATS.getPartitionPath(), initializationList.get(0).indexPartitionName());
+    assertSame(emptyData, initializationList.get(0).dataPartitionAndRecords().get(0).indexRecords());
+  }
+
+  @SuppressWarnings("unchecked")
+  @Test
+  void testInitializeDataWithRealEngineContextAndIndexDataContent() throws IOException {
+    HoodieEngineContext engineContext = new HoodieLocalEngineContext(getDefaultStorageConf());
+    HoodieWriteConfig writeConfig = mock(HoodieWriteConfig.class);
+    HoodieMetadataConfig metadataConfig = mock(HoodieMetadataConfig.class);
+    HoodieTableMetaClient metaClient = mock(HoodieTableMetaClient.class);
+    HoodieTableConfig tableConfig = mock(HoodieTableConfig.class);
+    HoodieRecordMerger recordMerger = mock(HoodieRecordMerger.class);
+
+    when(writeConfig.getMetadataConfig()).thenReturn(metadataConfig);
+    when(writeConfig.getColumnStatsIndexParallelism()).thenReturn(4);
+    when(writeConfig.getRecordMerger()).thenReturn(recordMerger);
+    when(recordMerger.getRecordType()).thenReturn(HoodieRecord.HoodieRecordType.AVRO);
+    when(metadataConfig.getColumnStatsIndexFileGroupCount()).thenReturn(5);
+    when(metadataConfig.getMaxReaderBufferSize()).thenReturn(4096);
+    when(metaClient.getTableConfig()).thenReturn(tableConfig);
+
+    Map<String, List<FileInfo>> files = new HashMap<>();
+    files.put("p1", Collections.singletonList(FileInfo.of("f1.parquet", 1L)));
+
+    HoodieData<HoodieRecord> records = (HoodieData<HoodieRecord>) (HoodieData<?>) engineContext.parallelize(
+        Collections.singletonList(HoodieMetadataPayload.createPartitionFilesRecord("p_col",
+            Collections.singletonMap("f_col.parquet", 22L), Collections.emptyList())),
+        1);
+
+    try (MockedStatic<HoodieTableMetadataUtil> mockedUtil = mockStatic(HoodieTableMetadataUtil.class)) {
+      Map<String, Object> columns = new HashMap<>();
+      columns.put("c1", new Object());
+      mockedUtil.when(() -> HoodieTableMetadataUtil.getColumnsToIndex(any(), any(), any(), eq(true), eq(Option.of(HoodieRecord.HoodieRecordType.AVRO)), any()))
+          .thenReturn(columns);
+      mockedUtil.when(() -> HoodieTableMetadataUtil.convertFilesToColumnStatsRecords(any(), any(), any(), any(), anyInt(), anyInt(), any()))
+          .thenReturn(records);
+
+      ExposedColumnStatsIndexer indexer = new ExposedColumnStatsIndexer(engineContext, writeConfig, metaClient);
+      List<IndexPartitionInitialization> initializationList = indexer.callGetData("001", "002", files, Lazy.lazily(Collections::emptyList));
+      assertEquals(1, initializationList.size());
+
+      assertEquals(5, initializationList.get(0).totalFileGroups());
+      List<HoodieRecord> collected = initializationList.get(0).dataPartitionAndRecords().get(0).indexRecords().collectAsList();
+      assertEquals(1, collected.size());
+      assertEquals("p_col", collected.get(0).getRecordKey());
+    }
+  }
+
+  private static class ExposedColumnStatsIndexer extends ColumnStatsIndexer {
+    ExposedColumnStatsIndexer(HoodieEngineContext engineContext, HoodieWriteConfig dataTableWriteConfig, HoodieTableMetaClient dataTableMetaClient) {
+      super(engineContext, dataTableWriteConfig, dataTableMetaClient);
+    }
+
+    List<IndexPartitionInitialization> callGetData(String dataTableInstantTime, String instantTimeForPartition,
+                                                   Map<String, List<FileInfo>> partitionIdToAllFilesMap,
+                                                   Lazy<List<FileSliceAndPartition>> lazyLatestMergedPartitionFileSliceList) throws IOException {
+      return buildInitialization(dataTableInstantTime, instantTimeForPartition, partitionIdToAllFilesMap, lazyLatestMergedPartitionFileSliceList);
+    }
+  }
+}

--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/metadata/index/expression/TestExpressionIndexer.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/metadata/index/expression/TestExpressionIndexer.java
@@ -1,0 +1,124 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.
+ */
+
+package org.apache.hudi.metadata.index.expression;
+
+import org.apache.hudi.common.config.HoodieMetadataConfig;
+import org.apache.hudi.common.data.HoodieData;
+import org.apache.hudi.common.engine.HoodieEngineContext;
+import org.apache.hudi.common.engine.HoodieLocalEngineContext;
+import org.apache.hudi.common.model.FileSlice;
+import org.apache.hudi.common.model.HoodieBaseFile;
+import org.apache.hudi.common.model.HoodieIndexDefinition;
+import org.apache.hudi.common.model.HoodieRecord;
+import org.apache.hudi.common.schema.HoodieSchema;
+import org.apache.hudi.common.table.HoodieTableMetaClient;
+import org.apache.hudi.common.util.Option;
+import org.apache.hudi.config.HoodieWriteConfig;
+import org.apache.hudi.metadata.HoodieMetadataPayload;
+import org.apache.hudi.metadata.HoodieTableMetadataUtil;
+import org.apache.hudi.metadata.index.ExpressionIndexRecordGenerator;
+import org.apache.hudi.metadata.index.model.IndexPartitionInitialization;
+import org.apache.hudi.metadata.model.FileInfo;
+import org.apache.hudi.metadata.model.FileSliceAndPartition;
+import org.apache.hudi.util.Lazy;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.apache.hudi.common.testutils.HoodieTestUtils.getDefaultStorageConf;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
+
+class TestExpressionIndexer {
+
+  @Test
+  void testSkipWhenMultipleExpressionPartitions() throws IOException {
+    HoodieEngineContext engineContext = mock(HoodieEngineContext.class);
+    HoodieWriteConfig writeConfig = mock(HoodieWriteConfig.class);
+    HoodieMetadataConfig metadataConfig = mock(HoodieMetadataConfig.class);
+    HoodieTableMetaClient metaClient = mock(HoodieTableMetaClient.class);
+
+    when(writeConfig.getMetadataConfig()).thenReturn(metadataConfig);
+
+    try (MockedStatic<HoodieTableMetadataUtil> mockedUtil = mockStatic(HoodieTableMetadataUtil.class)) {
+      mockedUtil.when(() -> HoodieTableMetadataUtil.getExpressionIndexPartitionsToInit(any(), any(), any()))
+          .thenReturn(Set.of("expr1", "expr2"));
+
+      ExposedExpressionIndexer indexer = new ExposedExpressionIndexer(engineContext, writeConfig, metaClient, mock(ExpressionIndexRecordGenerator.class));
+      List<IndexPartitionInitialization> result = indexer.callGetData("001", "002", Collections.emptyMap(), Lazy.lazily(Collections::emptyList));
+      assertTrue(result.isEmpty());
+    }
+  }
+
+  @SuppressWarnings("unchecked")
+  @Test
+  void testInitializeWithRealEngineContextAndIndexDataContent() throws IOException {
+    HoodieEngineContext engineContext = new HoodieLocalEngineContext(getDefaultStorageConf());
+    HoodieWriteConfig writeConfig = mock(HoodieWriteConfig.class);
+    HoodieMetadataConfig metadataConfig = mock(HoodieMetadataConfig.class);
+    HoodieTableMetaClient metaClient = mock(HoodieTableMetaClient.class);
+    ExpressionIndexRecordGenerator generator = mock(ExpressionIndexRecordGenerator.class);
+    HoodieIndexDefinition definition = mock(HoodieIndexDefinition.class);
+    HoodieSchema tableSchema = mock(HoodieSchema.class);
+    HoodieSchema projectedSchema = mock(HoodieSchema.class);
+
+    when(writeConfig.getMetadataConfig()).thenReturn(metadataConfig);
+    when(metadataConfig.getExpressionIndexFileGroupCount()).thenReturn(6);
+    when(metadataConfig.getExpressionIndexParallelism()).thenReturn(10);
+
+    HoodieData<HoodieRecord> records = (HoodieData<HoodieRecord>) (HoodieData<?>) engineContext.parallelize(
+        Collections.singletonList(HoodieMetadataPayload.createPartitionFilesRecord("p_expr",
+            Collections.singletonMap("f_expr.parquet", 55L), Collections.emptyList())),
+        1);
+    when(generator.generate(any(), any(), any(), anyInt(), any(), any(), any(), any())).thenReturn(records);
+
+    FileSlice fileSlice = new FileSlice("p1", "001", "f1");
+    fileSlice.setBaseFile(new HoodieBaseFile("file:///tmp/p1/f1.parquet"));
+    List<FileSliceAndPartition> fileSlices = Collections.singletonList(FileSliceAndPartition.of("p1", fileSlice));
+
+    try (MockedStatic<HoodieTableMetadataUtil> mockedUtil = mockStatic(HoodieTableMetadataUtil.class)) {
+      mockedUtil.when(() -> HoodieTableMetadataUtil.getExpressionIndexPartitionsToInit(any(), any(), any()))
+          .thenReturn(Collections.singleton("expr_idx"));
+      mockedUtil.when(() -> HoodieTableMetadataUtil.getHoodieIndexDefinition("expr_idx", metaClient)).thenReturn(definition);
+      mockedUtil.when(() -> HoodieTableMetadataUtil.tryResolveSchemaForTable(metaClient)).thenReturn(Option.of(tableSchema));
+      mockedUtil.when(() -> HoodieTableMetadataUtil.getProjectedSchemaForExpressionIndex(definition, metaClient, tableSchema)).thenReturn(projectedSchema);
+
+      ExposedExpressionIndexer indexer = new ExposedExpressionIndexer(engineContext, writeConfig, metaClient, generator);
+      List<IndexPartitionInitialization> initializationList = indexer.callGetData("001", "002", new HashMap<>(), Lazy.lazily(() -> fileSlices));
+      assertEquals(1, initializationList.size());
+
+      assertEquals("expr_idx", initializationList.get(0).indexPartitionName());
+      List<HoodieRecord> collected = initializationList.get(0).dataPartitionAndRecords().get(0).indexRecords().collectAsList();
+      assertEquals(1, collected.size());
+      assertEquals("p_expr", collected.get(0).getRecordKey());
+    }
+  }
+
+  private static class ExposedExpressionIndexer extends ExpressionIndexer {
+    ExposedExpressionIndexer(HoodieEngineContext engineContext, HoodieWriteConfig dataTableWriteConfig,
+                             HoodieTableMetaClient dataTableMetaClient, ExpressionIndexRecordGenerator expressionIndexRecordGenerator) {
+      super(engineContext, dataTableWriteConfig, dataTableMetaClient, expressionIndexRecordGenerator);
+    }
+
+    List<IndexPartitionInitialization> callGetData(String dataTableInstantTime, String instantTimeForPartition,
+                                                   Map<String, List<FileInfo>> partitionIdToAllFilesMap,
+                                                   Lazy<List<FileSliceAndPartition>> lazyLatestMergedPartitionFileSliceList) throws IOException {
+      return buildInitialization(dataTableInstantTime, instantTimeForPartition, partitionIdToAllFilesMap, lazyLatestMergedPartitionFileSliceList);
+    }
+  }
+}

--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/metadata/index/expression/TestExpressionIndexer.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/metadata/index/expression/TestExpressionIndexer.java
@@ -6,20 +6,29 @@
 package org.apache.hudi.metadata.index.expression;
 
 import org.apache.hudi.common.config.HoodieMetadataConfig;
+import org.apache.hudi.common.config.TypedProperties;
 import org.apache.hudi.common.data.HoodieData;
 import org.apache.hudi.common.engine.HoodieEngineContext;
 import org.apache.hudi.common.engine.HoodieLocalEngineContext;
 import org.apache.hudi.common.model.FileSlice;
 import org.apache.hudi.common.model.HoodieBaseFile;
+import org.apache.hudi.common.model.HoodieCommitMetadata;
 import org.apache.hudi.common.model.HoodieIndexDefinition;
+import org.apache.hudi.common.model.HoodieIndexMetadata;
 import org.apache.hudi.common.model.HoodieRecord;
+import org.apache.hudi.common.model.HoodieRecordMerger;
 import org.apache.hudi.common.schema.HoodieSchema;
+import org.apache.hudi.common.table.HoodieTableConfig;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.common.util.Option;
+import org.apache.hudi.metadata.HoodieBackedTableMetadata;
 import org.apache.hudi.config.HoodieWriteConfig;
 import org.apache.hudi.metadata.HoodieMetadataPayload;
 import org.apache.hudi.metadata.HoodieTableMetadataUtil;
 import org.apache.hudi.metadata.index.ExpressionIndexRecordGenerator;
+import org.apache.hudi.metadata.index.bloomfilters.BloomFiltersIndexer;
+import org.apache.hudi.metadata.index.columnstats.ColumnStatsIndexer;
+import org.apache.hudi.metadata.index.model.IndexPartitionAndRecords;
 import org.apache.hudi.metadata.index.model.IndexPartitionInitialization;
 import org.apache.hudi.metadata.model.FileInfo;
 import org.apache.hudi.metadata.model.FileSliceAndPartition;
@@ -36,7 +45,11 @@ import java.util.Map;
 import java.util.Set;
 
 import static org.apache.hudi.common.testutils.HoodieTestUtils.getDefaultStorageConf;
+import static org.apache.hudi.metadata.HoodieTableMetadataUtil.PARTITION_NAME_BLOOM_FILTERS;
+import static org.apache.hudi.metadata.HoodieTableMetadataUtil.PARTITION_NAME_COLUMN_STATS;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
@@ -85,7 +98,7 @@ class TestExpressionIndexer {
         Collections.singletonList(HoodieMetadataPayload.createPartitionFilesRecord("p_expr",
             Collections.singletonMap("f_expr.parquet", 55L), Collections.emptyList())),
         1);
-    when(generator.generate(any(), any(), any(), anyInt(), any(), any(), any(), any())).thenReturn(records);
+    when(generator.buildInitialization(any(), any(), any(), anyInt(), any(), any(), any(), any())).thenReturn(records);
 
     FileSlice fileSlice = new FileSlice("p1", "001", "f1");
     fileSlice.setBaseFile(new HoodieBaseFile("file:///tmp/p1/f1.parquet"));
@@ -106,6 +119,129 @@ class TestExpressionIndexer {
       List<HoodieRecord> collected = initializationList.get(0).dataPartitionAndRecords().get(0).indexRecords().collectAsList();
       assertEquals(1, collected.size());
       assertEquals("p_expr", collected.get(0).getRecordKey());
+    }
+  }
+
+  @SuppressWarnings("unchecked")
+  @Test
+  void testBuildUpdateForAvailableExpressionPartitions() {
+    HoodieEngineContext engineContext = mock(HoodieEngineContext.class);
+    HoodieWriteConfig writeConfig = mock(HoodieWriteConfig.class);
+    HoodieTableMetaClient metaClient = mock(HoodieTableMetaClient.class);
+    HoodieTableConfig tableConfig = mock(HoodieTableConfig.class);
+    ExpressionIndexRecordGenerator generator = mock(ExpressionIndexRecordGenerator.class);
+    HoodieIndexMetadata indexMetadata = mock(HoodieIndexMetadata.class);
+    HoodieIndexDefinition indexDefinition = mock(HoodieIndexDefinition.class);
+    HoodieData<HoodieRecord> records = mock(HoodieData.class);
+
+    when(metaClient.getTableConfig()).thenReturn(tableConfig);
+    when(tableConfig.getMetadataPartitions()).thenReturn(Set.of("expr_index_idx"));
+    when(metaClient.getIndexMetadata()).thenReturn(Option.of(indexMetadata));
+    when(indexMetadata.getIndexDefinitions()).thenReturn(Collections.singletonMap("expr_index_idx", indexDefinition));
+    when(indexDefinition.getIndexName()).thenReturn("expr_index_idx");
+    when(generator.buildUpdate(any(), any(), any(), any(), any())).thenReturn(records);
+
+    ExposedExpressionIndexer indexer = new ExposedExpressionIndexer(engineContext, writeConfig, metaClient, generator);
+    List<IndexPartitionAndRecords> result = indexer.buildUpdate(
+        "007",
+        mock(HoodieBackedTableMetadata.class),
+        Lazy.lazily(() -> null),
+        new HoodieCommitMetadata());
+
+    assertEquals(1, result.size());
+    assertEquals("expr_index_idx", result.get(0).indexPartitionName());
+    assertSame(records, result.get(0).indexRecords());
+  }
+
+  @Test
+  void testBuildCleanThrowsWhenIndexMetadataMissing() {
+    HoodieEngineContext engineContext = mock(HoodieEngineContext.class);
+    HoodieWriteConfig writeConfig = mock(HoodieWriteConfig.class);
+    HoodieTableMetaClient metaClient = mock(HoodieTableMetaClient.class);
+    when(metaClient.getIndexMetadata()).thenReturn(Option.empty());
+
+    ExposedExpressionIndexer indexer = new ExposedExpressionIndexer(engineContext, writeConfig, metaClient, mock(ExpressionIndexRecordGenerator.class));
+    assertThrows(RuntimeException.class, () -> indexer.buildClean("008", org.apache.hudi.avro.model.HoodieCleanMetadata.newBuilder().setPartitionMetadata(Collections.emptyMap()).build()));
+  }
+
+  @Test
+  void testBuildCleanThrowsWhenIndexDefinitionsEmpty() {
+    HoodieEngineContext engineContext = mock(HoodieEngineContext.class);
+    HoodieWriteConfig writeConfig = mock(HoodieWriteConfig.class);
+    HoodieTableMetaClient metaClient = mock(HoodieTableMetaClient.class);
+    HoodieIndexMetadata indexMetadata = mock(HoodieIndexMetadata.class);
+    when(metaClient.getIndexMetadata()).thenReturn(Option.of(indexMetadata));
+    when(indexMetadata.getIndexDefinitions()).thenReturn(Collections.emptyMap());
+
+    ExposedExpressionIndexer indexer = new ExposedExpressionIndexer(engineContext, writeConfig, metaClient, mock(ExpressionIndexRecordGenerator.class));
+    assertThrows(RuntimeException.class, () -> indexer.buildClean("009", org.apache.hudi.avro.model.HoodieCleanMetadata.newBuilder().setPartitionMetadata(Collections.emptyMap()).build()));
+  }
+
+  @SuppressWarnings("unchecked")
+  @Test
+  void testBuildCleanForBloomExpressionIndex() {
+    HoodieEngineContext engineContext = mock(HoodieEngineContext.class);
+    HoodieWriteConfig writeConfig = mock(HoodieWriteConfig.class);
+    HoodieMetadataConfig metadataConfig = mock(HoodieMetadataConfig.class);
+    HoodieTableMetaClient metaClient = mock(HoodieTableMetaClient.class);
+    HoodieIndexMetadata indexMetadata = mock(HoodieIndexMetadata.class);
+    HoodieIndexDefinition indexDefinition = mock(HoodieIndexDefinition.class);
+    org.apache.hudi.avro.model.HoodieCleanMetadata cleanMetadata = mock(org.apache.hudi.avro.model.HoodieCleanMetadata.class);
+    HoodieData<HoodieRecord> records = mock(HoodieData.class);
+
+    when(writeConfig.getMetadataConfig()).thenReturn(metadataConfig);
+    when(writeConfig.getBloomIndexParallelism()).thenReturn(3);
+    when(metaClient.getIndexMetadata()).thenReturn(Option.of(indexMetadata));
+    when(indexMetadata.getIndexDefinitions()).thenReturn(Collections.singletonMap("expr_index_bloom", indexDefinition));
+    when(indexDefinition.getIndexName()).thenReturn("expr_index_bloom");
+    when(indexDefinition.getIndexType()).thenReturn(PARTITION_NAME_BLOOM_FILTERS);
+
+    try (MockedStatic<BloomFiltersIndexer> mockedBloom = mockStatic(BloomFiltersIndexer.class)) {
+      mockedBloom.when(() -> BloomFiltersIndexer.convertMetadataToBloomFilterRecords(cleanMetadata, engineContext, "010", 3))
+          .thenReturn(records);
+
+      ExposedExpressionIndexer indexer = new ExposedExpressionIndexer(engineContext, writeConfig, metaClient, mock(ExpressionIndexRecordGenerator.class));
+      List<IndexPartitionAndRecords> result = indexer.buildClean("010", cleanMetadata);
+
+      assertEquals(1, result.size());
+      assertEquals("expr_index_bloom", result.get(0).indexPartitionName());
+      assertSame(records, result.get(0).indexRecords());
+    }
+  }
+
+  @SuppressWarnings("unchecked")
+  @Test
+  void testBuildCleanForColumnStatsExpressionIndex() {
+    HoodieEngineContext engineContext = mock(HoodieEngineContext.class);
+    HoodieWriteConfig writeConfig = mock(HoodieWriteConfig.class);
+    HoodieMetadataConfig metadataConfig = mock(HoodieMetadataConfig.class);
+    HoodieRecordMerger recordMerger = mock(HoodieRecordMerger.class);
+    HoodieTableMetaClient metaClient = mock(HoodieTableMetaClient.class);
+    HoodieIndexMetadata indexMetadata = mock(HoodieIndexMetadata.class);
+    HoodieIndexDefinition indexDefinition = mock(HoodieIndexDefinition.class);
+    org.apache.hudi.avro.model.HoodieCleanMetadata cleanMetadata = mock(org.apache.hudi.avro.model.HoodieCleanMetadata.class);
+    HoodieData<HoodieRecord> records = mock(HoodieData.class);
+
+    when(writeConfig.getMetadataConfig()).thenReturn(metadataConfig);
+    when(metadataConfig.getProps()).thenReturn(new TypedProperties());
+    when(writeConfig.getRecordMerger()).thenReturn(recordMerger);
+    when(recordMerger.getRecordType()).thenReturn(HoodieRecord.HoodieRecordType.AVRO);
+    when(metaClient.getIndexMetadata()).thenReturn(Option.of(indexMetadata));
+    when(indexMetadata.getIndexDefinitions()).thenReturn(Collections.singletonMap("expr_index_col_stats", indexDefinition));
+    when(indexDefinition.getIndexName()).thenReturn("expr_index_col_stats");
+    when(indexDefinition.getIndexType()).thenReturn(PARTITION_NAME_COLUMN_STATS);
+    when(indexDefinition.getSourceFields()).thenReturn(Collections.singletonList("c1"));
+
+    try (MockedStatic<ColumnStatsIndexer> mockedColumnStats = mockStatic(ColumnStatsIndexer.class)) {
+      mockedColumnStats.when(() -> ColumnStatsIndexer.convertMetadataToColumnStatsRecords(any(), any(), any(), any(), any()))
+          .thenReturn(records);
+
+      ExposedExpressionIndexer indexer = new ExposedExpressionIndexer(engineContext, writeConfig, metaClient, mock(ExpressionIndexRecordGenerator.class));
+      List<IndexPartitionAndRecords> result = indexer.buildClean("011", cleanMetadata);
+
+      assertEquals(1, result.size());
+      assertEquals("expr_index_col_stats", result.get(0).indexPartitionName());
+      assertSame(records, result.get(0).indexRecords());
     }
   }
 

--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/metadata/index/files/TestFilesIndexer.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/metadata/index/files/TestFilesIndexer.java
@@ -1,0 +1,115 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package org.apache.hudi.metadata.index.files;
+
+import org.apache.hudi.common.data.HoodieData;
+import org.apache.hudi.common.engine.HoodieEngineContext;
+import org.apache.hudi.common.engine.HoodieLocalEngineContext;
+import org.apache.hudi.common.model.HoodieRecord;
+import org.apache.hudi.common.table.HoodieTableMetaClient;
+import org.apache.hudi.config.HoodieWriteConfig;
+import org.apache.hudi.metadata.HoodieMetadataPayload;
+import org.apache.hudi.metadata.HoodieTableMetadata;
+import org.apache.hudi.metadata.MetadataPartitionType;
+import org.apache.hudi.metadata.index.model.IndexPartitionInitialization;
+import org.apache.hudi.metadata.model.FileInfo;
+import org.apache.hudi.metadata.model.FileSliceAndPartition;
+import org.apache.hudi.util.Lazy;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.apache.hudi.common.testutils.HoodieTestUtils.getDefaultStorageConf;
+
+class TestFilesIndexer {
+
+  @SuppressWarnings("unchecked")
+  @Test
+  void testInitializeDataEmptyInput() throws IOException {
+    HoodieEngineContext engineContext = mock(HoodieEngineContext.class);
+    HoodieWriteConfig writeConfig = mock(HoodieWriteConfig.class);
+    HoodieTableMetaClient metaClient = mock(HoodieTableMetaClient.class);
+    HoodieData<HoodieRecord> allPartitions = mock(HoodieData.class);
+
+    when(engineContext.parallelize(any(List.class), org.mockito.ArgumentMatchers.eq(1))).thenReturn(allPartitions);
+
+    ExposedFilesIndexer indexer = new ExposedFilesIndexer(engineContext, writeConfig, metaClient);
+    List<IndexPartitionInitialization> initializationList = indexer.callGetData("001", "002", Collections.emptyMap(), Lazy.lazily(Collections::emptyList));
+    assertEquals(1, initializationList.size());
+
+    assertEquals(MetadataPartitionType.FILES.getPartitionPath(), initializationList.get(0).indexPartitionName());
+    assertSame(allPartitions, initializationList.get(0).dataPartitionAndRecords().get(0).indexRecords());
+  }
+
+  @Test
+  void testInitializeDataWithRealEngineContext() throws IOException {
+    HoodieEngineContext engineContext = new HoodieLocalEngineContext(getDefaultStorageConf());
+    HoodieWriteConfig writeConfig = mock(HoodieWriteConfig.class);
+    HoodieTableMetaClient metaClient = mock(HoodieTableMetaClient.class);
+
+    Map<String, List<FileInfo>> files = new HashMap<>();
+    files.put("p1", Collections.singletonList(FileInfo.of("f1.parquet", 100L)));
+    files.put("p2", Collections.singletonList(FileInfo.of("f2.parquet", 200L)));
+
+    ExposedFilesIndexer indexer = new ExposedFilesIndexer(engineContext, writeConfig, metaClient);
+    List<IndexPartitionInitialization> initializationList = indexer.callGetData("001", "002", files, Lazy.lazily(Collections::emptyList));
+    assertEquals(1, initializationList.size());
+
+    assertEquals(MetadataPartitionType.FILES.getPartitionPath(), initializationList.get(0).indexPartitionName());
+    // 1 partition-list record + 2 partition-file records
+    HoodieData<HoodieRecord> indexRecords = initializationList.get(0).dataPartitionAndRecords().get(0).indexRecords();
+    assertEquals(3L, indexRecords.count());
+
+    List<HoodieRecord> records = indexRecords.collectAsList();
+    Set<String> keys = records.stream().map(HoodieRecord::getRecordKey).collect(Collectors.toSet());
+    assertEquals(new HashSet<>(Arrays.asList(HoodieTableMetadata.RECORDKEY_PARTITION_LIST, "p1", "p2")), keys);
+
+    HoodieMetadataPayload partitionListPayload = (HoodieMetadataPayload) records.stream()
+        .filter(r -> HoodieTableMetadata.RECORDKEY_PARTITION_LIST.equals(r.getRecordKey()))
+        .findFirst().orElseThrow(() -> new AssertionError("partition-list record not found"))
+        .getData();
+    assertEquals(new HashSet<>(Arrays.asList("p1", "p2")), new HashSet<>(partitionListPayload.getFilenames()));
+
+    Map<String, HoodieMetadataPayload> filesPayloadByPartition = records.stream()
+        .filter(r -> !HoodieTableMetadata.RECORDKEY_PARTITION_LIST.equals(r.getRecordKey()))
+        .collect(Collectors.toMap(HoodieRecord::getRecordKey, r -> (HoodieMetadataPayload) r.getData()));
+    assertEquals(Collections.singletonList("f1.parquet"), filesPayloadByPartition.get("p1").getFilenames());
+    assertEquals(Collections.singletonList("f2.parquet"), filesPayloadByPartition.get("p2").getFilenames());
+  }
+
+  private static class ExposedFilesIndexer extends FilesIndexer {
+    ExposedFilesIndexer(HoodieEngineContext engineContext, HoodieWriteConfig dataTableWriteConfig, HoodieTableMetaClient dataTableMetaClient) {
+      super(engineContext, dataTableWriteConfig, dataTableMetaClient);
+    }
+
+    List<IndexPartitionInitialization> callGetData(String dataTableInstantTime, String instantTimeForPartition,
+                                                   Map<String, List<FileInfo>> partitionIdToAllFilesMap,
+                                                   Lazy<List<FileSliceAndPartition>> lazyLatestMergedPartitionFileSliceList) throws IOException {
+      return buildInitialization(dataTableInstantTime, instantTimeForPartition, partitionIdToAllFilesMap, lazyLatestMergedPartitionFileSliceList);
+    }
+  }
+}

--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/metadata/index/files/TestFilesIndexer.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/metadata/index/files/TestFilesIndexer.java
@@ -12,15 +12,23 @@
 
 package org.apache.hudi.metadata.index.files;
 
+import org.apache.hudi.avro.model.HoodieCleanMetadata;
+import org.apache.hudi.avro.model.HoodieCleanPartitionMetadata;
 import org.apache.hudi.common.data.HoodieData;
 import org.apache.hudi.common.engine.HoodieEngineContext;
 import org.apache.hudi.common.engine.HoodieLocalEngineContext;
+import org.apache.hudi.common.model.HoodieCommitMetadata;
 import org.apache.hudi.common.model.HoodieRecord;
+import org.apache.hudi.common.model.HoodieWriteStat;
+import org.apache.hudi.common.model.WriteOperationType;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
+import org.apache.hudi.common.table.view.HoodieTableFileSystemView;
 import org.apache.hudi.config.HoodieWriteConfig;
+import org.apache.hudi.metadata.HoodieBackedTableMetadata;
 import org.apache.hudi.metadata.HoodieMetadataPayload;
 import org.apache.hudi.metadata.HoodieTableMetadata;
 import org.apache.hudi.metadata.MetadataPartitionType;
+import org.apache.hudi.metadata.index.model.IndexPartitionAndRecords;
 import org.apache.hudi.metadata.index.model.IndexPartitionInitialization;
 import org.apache.hudi.metadata.model.FileInfo;
 import org.apache.hudi.metadata.model.FileSliceAndPartition;
@@ -40,6 +48,7 @@ import java.util.stream.Collectors;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -99,6 +108,118 @@ class TestFilesIndexer {
         .collect(Collectors.toMap(HoodieRecord::getRecordKey, r -> (HoodieMetadataPayload) r.getData()));
     assertEquals(Collections.singletonList("f1.parquet"), filesPayloadByPartition.get("p1").getFilenames());
     assertEquals(Collections.singletonList("f2.parquet"), filesPayloadByPartition.get("p2").getFilenames());
+  }
+
+  @Test
+  void testBuildUpdateGeneratesPartitionListAndFileRecords() {
+    HoodieEngineContext engineContext = new HoodieLocalEngineContext(getDefaultStorageConf());
+    HoodieWriteConfig writeConfig = mock(HoodieWriteConfig.class);
+    HoodieTableMetaClient metaClient = mock(HoodieTableMetaClient.class);
+
+    HoodieCommitMetadata commitMetadata = new HoodieCommitMetadata();
+    commitMetadata.setOperationType(WriteOperationType.INSERT);
+    HoodieWriteStat writeStat = new HoodieWriteStat();
+    writeStat.setPartitionPath("p1");
+    writeStat.setPath("p1/f1.parquet");
+    writeStat.setFileSizeInBytes(123L);
+    commitMetadata.addWriteStat("p1", writeStat);
+
+    ExposedFilesIndexer indexer = new ExposedFilesIndexer(engineContext, writeConfig, metaClient);
+    List<IndexPartitionAndRecords> result = indexer.buildUpdate(
+        "003",
+        mock(HoodieBackedTableMetadata.class),
+        Lazy.lazily(() -> mock(HoodieTableFileSystemView.class)),
+        commitMetadata);
+
+    assertEquals(1, result.size());
+    assertEquals(MetadataPartitionType.FILES.getPartitionPath(), result.get(0).indexPartitionName());
+
+    List<HoodieRecord> records = result.get(0).indexRecords().collectAsList();
+    assertEquals(2, records.size());
+    Set<String> keys = records.stream().map(HoodieRecord::getRecordKey).collect(Collectors.toSet());
+    assertEquals(new HashSet<>(Arrays.asList(HoodieTableMetadata.RECORDKEY_PARTITION_LIST, "p1")), keys);
+
+    Map<String, HoodieMetadataPayload> payloadByKey = records.stream()
+        .collect(Collectors.toMap(HoodieRecord::getRecordKey, r -> (HoodieMetadataPayload) r.getData()));
+    assertEquals(Collections.singletonList("p1"), payloadByKey.get(HoodieTableMetadata.RECORDKEY_PARTITION_LIST).getFilenames());
+    assertEquals(Collections.singletonList("f1.parquet"), payloadByKey.get("p1").getFilenames());
+  }
+
+  @Test
+  void testBuildCleanGeneratesDeleteRecordsForFilesAndPartitions() {
+    HoodieEngineContext engineContext = new HoodieLocalEngineContext(getDefaultStorageConf());
+    HoodieWriteConfig writeConfig = mock(HoodieWriteConfig.class);
+    HoodieTableMetaClient metaClient = mock(HoodieTableMetaClient.class);
+
+    Map<String, HoodieCleanPartitionMetadata> partitionMetadata = new HashMap<>();
+    partitionMetadata.put("p1", new HoodieCleanPartitionMetadata(
+        "p1",
+        "KEEP_LATEST_COMMITS",
+        Collections.singletonList("f1.parquet"),
+        Collections.emptyList(),
+        Collections.emptyList(),
+        false));
+    partitionMetadata.put("p2", new HoodieCleanPartitionMetadata(
+        "p2",
+        "KEEP_LATEST_COMMITS",
+        Collections.emptyList(),
+        Collections.emptyList(),
+        Collections.emptyList(),
+        true));
+    HoodieCleanMetadata cleanMetadata = new HoodieCleanMetadata(
+        "004",
+        100L,
+        1,
+        "003",
+        "003",
+        partitionMetadata,
+        2,
+        Collections.emptyMap(),
+        Collections.emptyMap());
+
+    ExposedFilesIndexer indexer = new ExposedFilesIndexer(engineContext, writeConfig, metaClient);
+    List<IndexPartitionAndRecords> result = indexer.buildClean("005", cleanMetadata);
+
+    assertEquals(1, result.size());
+    assertEquals(MetadataPartitionType.FILES.getPartitionPath(), result.get(0).indexPartitionName());
+
+    List<HoodieRecord> records = result.get(0).indexRecords().collectAsList();
+    assertEquals(3, records.size());
+    Map<String, HoodieMetadataPayload> payloadByKey = records.stream()
+        .collect(Collectors.toMap(HoodieRecord::getRecordKey, r -> (HoodieMetadataPayload) r.getData()));
+    assertTrue(payloadByKey.containsKey("p1"));
+    assertTrue(payloadByKey.containsKey("p2"));
+    assertTrue(payloadByKey.containsKey(HoodieTableMetadata.RECORDKEY_PARTITION_LIST));
+    assertEquals(Collections.singletonList("f1.parquet"), payloadByKey.get("p1").getDeletions());
+    assertEquals(Collections.singletonList("p2"), payloadByKey.get(HoodieTableMetadata.RECORDKEY_PARTITION_LIST).getDeletions());
+  }
+
+  @Test
+  void testBuildRestoreGeneratesRecordsForAddedDeletedFilesAndDeletedPartitions() {
+    HoodieEngineContext engineContext = new HoodieLocalEngineContext(getDefaultStorageConf());
+    HoodieWriteConfig writeConfig = mock(HoodieWriteConfig.class);
+    HoodieTableMetaClient metaClient = mock(HoodieTableMetaClient.class);
+
+    Map<String, List<FileInfo>> filesAdded = new HashMap<>();
+    filesAdded.put("p1", Collections.singletonList(FileInfo.of("f2.parquet", 456L)));
+
+    Map<String, List<String>> filesDeleted = new HashMap<>();
+    filesDeleted.put("p2", Collections.singletonList("f3.parquet"));
+
+    ExposedFilesIndexer indexer = new ExposedFilesIndexer(engineContext, writeConfig, metaClient);
+    List<IndexPartitionAndRecords> result =
+        indexer.buildRestore("006", Collections.singletonList("p3"), filesAdded, filesDeleted);
+
+    assertEquals(1, result.size());
+    assertEquals(MetadataPartitionType.FILES.getPartitionPath(), result.get(0).indexPartitionName());
+
+    List<HoodieRecord> records = result.get(0).indexRecords().collectAsList();
+    assertEquals(3, records.size());
+    Map<String, HoodieMetadataPayload> payloadByKey = records.stream()
+        .collect(Collectors.toMap(HoodieRecord::getRecordKey, r -> (HoodieMetadataPayload) r.getData()));
+    assertEquals(Collections.singletonList("f2.parquet"), payloadByKey.get("p1").getFilenames());
+    assertEquals(Collections.singletonList("f3.parquet"), payloadByKey.get("p2").getDeletions());
+    assertEquals(Collections.singletonList("p3"), payloadByKey.get(HoodieTableMetadata.RECORDKEY_PARTITION_LIST).getDeletions());
   }
 
   private static class ExposedFilesIndexer extends FilesIndexer {

--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/metadata/index/partitionstats/TestPartitionStatsIndexer.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/metadata/index/partitionstats/TestPartitionStatsIndexer.java
@@ -5,20 +5,31 @@
 
 package org.apache.hudi.metadata.index.partitionstats;
 
+import org.apache.hudi.avro.model.HoodieCleanMetadata;
 import org.apache.hudi.common.config.HoodieMetadataConfig;
 import org.apache.hudi.common.data.HoodieData;
 import org.apache.hudi.common.engine.HoodieEngineContext;
 import org.apache.hudi.common.engine.HoodieLocalEngineContext;
+import org.apache.hudi.common.model.HoodieCommitMetadata;
 import org.apache.hudi.common.model.HoodieRecord;
 import org.apache.hudi.common.model.HoodieRecordMerger;
+import org.apache.hudi.common.model.HoodieWriteStat;
+import org.apache.hudi.common.model.WriteOperationType;
 import org.apache.hudi.common.table.HoodieTableConfig;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
+import org.apache.hudi.common.table.view.HoodieTableFileSystemView;
+import org.apache.hudi.common.util.Option;
 import org.apache.hudi.config.HoodieWriteConfig;
+import org.apache.hudi.metadata.HoodieBackedTableMetadata;
+import org.apache.hudi.metadata.HoodieIndexVersion;
 import org.apache.hudi.metadata.HoodieMetadataPayload;
 import org.apache.hudi.metadata.HoodieTableMetadataUtil;
+import org.apache.hudi.metadata.MetadataPartitionType;
+import org.apache.hudi.metadata.index.model.IndexPartitionAndRecords;
 import org.apache.hudi.metadata.index.model.IndexPartitionInitialization;
 import org.apache.hudi.metadata.model.FileInfo;
 import org.apache.hudi.metadata.model.FileSliceAndPartition;
+import org.apache.hudi.stats.HoodieColumnRangeMetadata;
 import org.apache.hudi.util.Lazy;
 
 import org.junit.jupiter.api.Test;
@@ -31,8 +42,11 @@ import java.util.Map;
 
 import static org.apache.hudi.common.testutils.HoodieTestUtils.getDefaultStorageConf;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.when;
@@ -106,6 +120,93 @@ class TestPartitionStatsIndexer {
       assertEquals(1, collected.size());
       assertEquals("p_part", collected.get(0).getRecordKey());
     }
+  }
+
+  @Test
+  void testBuildUpdateThrowsWhenColumnStatsPartitionNotAvailable() {
+    HoodieEngineContext engineContext = mock(HoodieEngineContext.class);
+    HoodieWriteConfig writeConfig = mock(HoodieWriteConfig.class);
+    HoodieMetadataConfig metadataConfig = mock(HoodieMetadataConfig.class);
+    HoodieRecordMerger recordMerger = mock(HoodieRecordMerger.class);
+    HoodieTableMetaClient metaClient = mock(HoodieTableMetaClient.class);
+    HoodieTableConfig tableConfig = mock(HoodieTableConfig.class);
+
+    when(metaClient.getTableConfig()).thenReturn(tableConfig);
+    when(tableConfig.isMetadataPartitionAvailable(any(MetadataPartitionType.class))).thenReturn(false);
+    when(writeConfig.getMetadataConfig()).thenReturn(metadataConfig);
+    when(writeConfig.getRecordMerger()).thenReturn(recordMerger);
+    when(recordMerger.getRecordType()).thenReturn(HoodieRecord.HoodieRecordType.AVRO);
+
+    ExposedPartitionStatsIndexer indexer = new ExposedPartitionStatsIndexer(engineContext, writeConfig, metaClient);
+    assertThrows(IllegalStateException.class, () -> indexer.buildUpdate(
+        "010",
+        mock(HoodieBackedTableMetadata.class),
+        Lazy.lazily(() -> mock(HoodieTableFileSystemView.class)),
+        new HoodieCommitMetadata()));
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void testBuildUpdateWithNonEmptyCommitMetadataProducesPartitionEntry() {
+    HoodieEngineContext engineContext = new HoodieLocalEngineContext(getDefaultStorageConf());
+    HoodieEngineContext realEngineContext = new HoodieLocalEngineContext(getDefaultStorageConf());
+    HoodieWriteConfig writeConfig = mock(HoodieWriteConfig.class);
+    HoodieMetadataConfig metadataConfig = mock(HoodieMetadataConfig.class);
+    HoodieRecordMerger recordMerger = mock(HoodieRecordMerger.class);
+    HoodieTableMetaClient metaClient = mock(HoodieTableMetaClient.class);
+    HoodieTableConfig tableConfig = mock(HoodieTableConfig.class);
+
+    when(metaClient.getTableConfig()).thenReturn(tableConfig);
+    when(tableConfig.isMetadataPartitionAvailable(any(MetadataPartitionType.class))).thenReturn(true);
+    when(writeConfig.getMetadataConfig()).thenReturn(metadataConfig);
+    when(writeConfig.getRecordMerger()).thenReturn(recordMerger);
+    when(recordMerger.getRecordType()).thenReturn(HoodieRecord.HoodieRecordType.AVRO);
+
+    HoodieCommitMetadata commitMetadata = new HoodieCommitMetadata();
+    commitMetadata.setOperationType(WriteOperationType.UPSERT);
+    HoodieWriteStat writeStat = new HoodieWriteStat();
+    writeStat.setPartitionPath("p1");
+    writeStat.setPath("p1/fileid-1_1-0-1_012.parquet");
+    commitMetadata.getPartitionToWriteStats().put("p1", Collections.singletonList(writeStat));
+
+    HoodieData<HoodieRecord> partitionStatsData = (HoodieData<HoodieRecord>) (HoodieData<?>) realEngineContext.parallelize(
+        HoodieMetadataPayload.createPartitionStatsRecords(
+            "p1",
+            Collections.singletonList(HoodieColumnRangeMetadata.stub("p1/fileid-1_1-0-1_012.parquet", "c1", HoodieIndexVersion.V1)),
+            false,
+            true,
+            Option.empty()).collect(java.util.stream.Collectors.toList()),
+        1);
+
+    ExposedPartitionStatsIndexer indexer = new ExposedPartitionStatsIndexer(engineContext, writeConfig, metaClient);
+    List<IndexPartitionAndRecords> result;
+    try (MockedStatic<PartitionStatsIndexer> mockedPartitionStatsIndexer = mockStatic(PartitionStatsIndexer.class)) {
+      mockedPartitionStatsIndexer.when(() -> PartitionStatsIndexer.convertMetadataToPartitionStatRecords(
+              any(), any(), any(), any(), any(), any(), any(), any(), anyBoolean()))
+          .thenReturn(partitionStatsData);
+
+      result = indexer.buildUpdate(
+          "012",
+          mock(HoodieBackedTableMetadata.class),
+          Lazy.lazily(() -> mock(HoodieTableFileSystemView.class)),
+          commitMetadata);
+    }
+
+    assertEquals(1, result.size());
+    assertEquals(MetadataPartitionType.PARTITION_STATS.getPartitionPath(), result.get(0).indexPartitionName());
+    List<HoodieRecord> indexRecords = result.get(0).indexRecords().collectAsList();
+    assertEquals(1, indexRecords.size());
+    HoodieMetadataPayload payload = (HoodieMetadataPayload) indexRecords.get(0).getData();
+    assertTrue(payload.getColumnStatMetadata().isPresent());
+    assertEquals("c1", payload.getColumnStatMetadata().get().getColumnName());
+    assertFalse(payload.getColumnStatMetadata().get().getIsDeleted());
+  }
+
+  @Test
+  void testBuildCleanReturnsEmptyList() {
+    ExposedPartitionStatsIndexer indexer = new ExposedPartitionStatsIndexer(
+        mock(HoodieEngineContext.class), mock(HoodieWriteConfig.class), mock(HoodieTableMetaClient.class));
+    assertTrue(indexer.buildClean("012", mock(HoodieCleanMetadata.class)).isEmpty());
   }
 
   private static class ExposedPartitionStatsIndexer extends PartitionStatsIndexer {

--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/metadata/index/partitionstats/TestPartitionStatsIndexer.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/metadata/index/partitionstats/TestPartitionStatsIndexer.java
@@ -1,0 +1,122 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.
+ */
+
+package org.apache.hudi.metadata.index.partitionstats;
+
+import org.apache.hudi.common.config.HoodieMetadataConfig;
+import org.apache.hudi.common.data.HoodieData;
+import org.apache.hudi.common.engine.HoodieEngineContext;
+import org.apache.hudi.common.engine.HoodieLocalEngineContext;
+import org.apache.hudi.common.model.HoodieRecord;
+import org.apache.hudi.common.model.HoodieRecordMerger;
+import org.apache.hudi.common.table.HoodieTableConfig;
+import org.apache.hudi.common.table.HoodieTableMetaClient;
+import org.apache.hudi.config.HoodieWriteConfig;
+import org.apache.hudi.metadata.HoodieMetadataPayload;
+import org.apache.hudi.metadata.HoodieTableMetadataUtil;
+import org.apache.hudi.metadata.index.model.IndexPartitionInitialization;
+import org.apache.hudi.metadata.model.FileInfo;
+import org.apache.hudi.metadata.model.FileSliceAndPartition;
+import org.apache.hudi.util.Lazy;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import static org.apache.hudi.common.testutils.HoodieTestUtils.getDefaultStorageConf;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
+
+class TestPartitionStatsIndexer {
+
+  @Test
+  void testSkipForNonPartitionedTable() throws IOException {
+    HoodieEngineContext engineContext = mock(HoodieEngineContext.class);
+    HoodieWriteConfig writeConfig = mock(HoodieWriteConfig.class);
+    HoodieTableMetaClient metaClient = mock(HoodieTableMetaClient.class);
+    HoodieTableConfig tableConfig = mock(HoodieTableConfig.class);
+
+    when(metaClient.getTableConfig()).thenReturn(tableConfig);
+    when(tableConfig.isTablePartitioned()).thenReturn(false);
+
+    ExposedPartitionStatsIndexer indexer = new ExposedPartitionStatsIndexer(engineContext, writeConfig, metaClient);
+    List<IndexPartitionInitialization> result = indexer.callGetData("001", "002", Collections.emptyMap(), Lazy.lazily(Collections::emptyList));
+    assertTrue(result.isEmpty());
+  }
+
+  @Test
+  void testSkipWhenColumnStatsDisabled() throws IOException {
+    HoodieEngineContext engineContext = mock(HoodieEngineContext.class);
+    HoodieWriteConfig writeConfig = mock(HoodieWriteConfig.class);
+    HoodieTableMetaClient metaClient = mock(HoodieTableMetaClient.class);
+    HoodieTableConfig tableConfig = mock(HoodieTableConfig.class);
+
+    when(metaClient.getTableConfig()).thenReturn(tableConfig);
+    when(tableConfig.isTablePartitioned()).thenReturn(true);
+    when(writeConfig.isMetadataColumnStatsIndexEnabled()).thenReturn(false);
+
+    ExposedPartitionStatsIndexer indexer = new ExposedPartitionStatsIndexer(engineContext, writeConfig, metaClient);
+    List<IndexPartitionInitialization> result = indexer.callGetData("001", "002", Collections.emptyMap(), Lazy.lazily(Collections::emptyList));
+    assertTrue(result.isEmpty());
+  }
+
+  @SuppressWarnings("unchecked")
+  @Test
+  void testInitializeWithRealEngineContextAndIndexDataContent() throws IOException {
+    HoodieEngineContext engineContext = new HoodieLocalEngineContext(getDefaultStorageConf());
+    HoodieWriteConfig writeConfig = mock(HoodieWriteConfig.class);
+    HoodieMetadataConfig metadataConfig = mock(HoodieMetadataConfig.class);
+    HoodieRecordMerger recordMerger = mock(HoodieRecordMerger.class);
+    HoodieTableMetaClient metaClient = mock(HoodieTableMetaClient.class);
+    HoodieTableConfig tableConfig = mock(HoodieTableConfig.class);
+
+    when(metaClient.getTableConfig()).thenReturn(tableConfig);
+    when(tableConfig.isTablePartitioned()).thenReturn(true);
+    when(writeConfig.isMetadataColumnStatsIndexEnabled()).thenReturn(true);
+    when(writeConfig.getMetadataConfig()).thenReturn(metadataConfig);
+    when(writeConfig.getRecordMerger()).thenReturn(recordMerger);
+    when(recordMerger.getRecordType()).thenReturn(HoodieRecord.HoodieRecordType.AVRO);
+    when(metadataConfig.getPartitionStatsIndexFileGroupCount()).thenReturn(4);
+
+    HoodieData<HoodieRecord> records = (HoodieData<HoodieRecord>) (HoodieData<?>) engineContext.parallelize(
+        Collections.singletonList(HoodieMetadataPayload.createPartitionFilesRecord("p_part",
+            Collections.singletonMap("f_part.parquet", 33L), Collections.emptyList())),
+        1);
+
+    try (MockedStatic<HoodieTableMetadataUtil> mockedUtil = mockStatic(HoodieTableMetadataUtil.class)) {
+      mockedUtil.when(() -> HoodieTableMetadataUtil.convertFilesToPartitionStatsRecords(any(), any(), any(), any(), any(), any()))
+          .thenReturn(records);
+
+      ExposedPartitionStatsIndexer indexer = new ExposedPartitionStatsIndexer(engineContext, writeConfig, metaClient);
+      List<IndexPartitionInitialization> initializationList = indexer.callGetData("001", "002", Collections.emptyMap(), Lazy.lazily(Collections::emptyList));
+      assertEquals(1, initializationList.size());
+
+      assertEquals(4, initializationList.get(0).totalFileGroups());
+      List<HoodieRecord> collected = initializationList.get(0).dataPartitionAndRecords().get(0).indexRecords().collectAsList();
+      assertEquals(1, collected.size());
+      assertEquals("p_part", collected.get(0).getRecordKey());
+    }
+  }
+
+  private static class ExposedPartitionStatsIndexer extends PartitionStatsIndexer {
+    ExposedPartitionStatsIndexer(HoodieEngineContext engineContext, HoodieWriteConfig dataTableWriteConfig, HoodieTableMetaClient dataTableMetaClient) {
+      super(engineContext, dataTableWriteConfig, dataTableMetaClient);
+    }
+
+    List<IndexPartitionInitialization> callGetData(String dataTableInstantTime, String instantTimeForPartition,
+                                                   Map<String, List<FileInfo>> partitionIdToAllFilesMap,
+                                                   Lazy<List<FileSliceAndPartition>> lazyLatestMergedPartitionFileSliceList) throws IOException {
+      return buildInitialization(dataTableInstantTime, instantTimeForPartition, partitionIdToAllFilesMap, lazyLatestMergedPartitionFileSliceList);
+    }
+  }
+}

--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/metadata/index/record/TestPartitionedRecordIndexer.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/metadata/index/record/TestPartitionedRecordIndexer.java
@@ -1,0 +1,107 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.
+ */
+
+package org.apache.hudi.metadata.index.record;
+
+import org.apache.hudi.common.config.HoodieMetadataConfig;
+import org.apache.hudi.common.data.HoodieData;
+import org.apache.hudi.common.engine.HoodieEngineContext;
+import org.apache.hudi.common.engine.HoodieLocalEngineContext;
+import org.apache.hudi.common.model.FileSlice;
+import org.apache.hudi.common.model.HoodieRecord;
+import org.apache.hudi.common.table.HoodieTableConfig;
+import org.apache.hudi.common.table.HoodieTableMetaClient;
+import org.apache.hudi.common.util.Option;
+import org.apache.hudi.config.HoodieWriteConfig;
+import org.apache.hudi.metadata.HoodieMetadataPayload;
+import org.apache.hudi.metadata.index.model.DataPartitionAndRecords;
+import org.apache.hudi.metadata.index.model.IndexPartitionInitialization;
+import org.apache.hudi.metadata.model.FileSliceAndPartition;
+import org.apache.hudi.util.Lazy;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import static org.apache.hudi.common.testutils.HoodieTestUtils.getDefaultStorageConf;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
+
+class TestPartitionedRecordIndexer {
+
+  @SuppressWarnings("unchecked")
+  @Test
+  void testInitializeWithRealEngineContextAndIndexDataContent() throws IOException {
+    HoodieEngineContext engineContext = new HoodieLocalEngineContext(getDefaultStorageConf());
+    HoodieWriteConfig writeConfig = mock(HoodieWriteConfig.class);
+    HoodieMetadataConfig metadataConfig = mock(HoodieMetadataConfig.class);
+    HoodieTableMetaClient dataMetaClient = mock(HoodieTableMetaClient.class);
+    HoodieTableConfig tableConfig = mock(HoodieTableConfig.class);
+
+    when(writeConfig.getMetadataConfig()).thenReturn(metadataConfig);
+    when(metadataConfig.getRecordIndexMaxParallelism()).thenReturn(8);
+    when(dataMetaClient.getTableConfig()).thenReturn(tableConfig);
+
+    HoodieData<HoodieRecord> p1Data = (HoodieData<HoodieRecord>) (HoodieData<?>) engineContext.parallelize(
+        Collections.singletonList(HoodieMetadataPayload.createPartitionFilesRecord("p1_data",
+            Collections.singletonMap("f1.parquet", 1L), Collections.emptyList())),
+        1);
+    HoodieData<HoodieRecord> p2Data = (HoodieData<HoodieRecord>) (HoodieData<?>) engineContext.parallelize(
+        Collections.singletonList(HoodieMetadataPayload.createPartitionFilesRecord("p2_data",
+            Collections.singletonMap("f2.parquet", 2L), Collections.emptyList())),
+        1);
+
+    DataPartitionAndRecords p1Init = new DataPartitionAndRecords(1, Option.of("p1"), p1Data);
+    DataPartitionAndRecords p2Init = new DataPartitionAndRecords(2, Option.of("p2"), p2Data);
+
+    FileSliceAndPartition fs1 = FileSliceAndPartition.of("p1", new FileSlice("p1", "001", "f1"));
+    FileSliceAndPartition fs2 = FileSliceAndPartition.of("p2", new FileSlice("p2", "001", "f2"));
+    List<FileSliceAndPartition> input = Arrays.asList(fs1, fs2);
+
+    ExposedPartitionedRecordIndexer indexer = new ExposedPartitionedRecordIndexer(engineContext, writeConfig, dataMetaClient, p1Init, p2Init);
+
+    try (MockedStatic<org.apache.hudi.metadata.HoodieTableMetadataUtil> mockedUtil = mockStatic(org.apache.hudi.metadata.HoodieTableMetadataUtil.class)) {
+      List<IndexPartitionInitialization> initializationList = indexer.buildInitialization("001", "002", Map.of(), Lazy.lazily(() -> input));
+
+      mockedUtil.verify(() -> org.apache.hudi.metadata.HoodieTableMetadataUtil.createRecordIndexDefinition(any(), any()));
+      assertEquals(1, initializationList.size());
+      assertEquals(2, initializationList.get(0).dataPartitionAndRecords().size());
+      assertEquals(2, indexer.initializePartitionCalls);
+    }
+  }
+
+  private static class ExposedPartitionedRecordIndexer extends PartitionedRecordIndexer {
+    private final DataPartitionAndRecords p1;
+    private final DataPartitionAndRecords p2;
+    private int initializePartitionCalls;
+
+    ExposedPartitionedRecordIndexer(HoodieEngineContext engineContext, HoodieWriteConfig dataTableWriteConfig,
+                                    HoodieTableMetaClient dataTableMetaClient,
+                                    DataPartitionAndRecords p1,
+                                    DataPartitionAndRecords p2) {
+      super(engineContext, dataTableWriteConfig, dataTableMetaClient);
+      this.p1 = p1;
+      this.p2 = p2;
+    }
+
+    @Override
+    protected DataPartitionAndRecords initializeRecordIndexPartition(String dataPartition, List<FileSliceAndPartition> latestMergedPartitionFileSliceList,
+                                                                     int recordIndexMaxParallelism) {
+      initializePartitionCalls++;
+      if ("p1".equals(dataPartition)) {
+        return p1;
+      }
+      return p2;
+    }
+  }
+}

--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/metadata/index/record/TestPartitionedRecordIndexer.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/metadata/index/record/TestPartitionedRecordIndexer.java
@@ -5,20 +5,32 @@
 
 package org.apache.hudi.metadata.index.record;
 
+import org.apache.hudi.avro.model.HoodieCleanMetadata;
 import org.apache.hudi.common.config.HoodieMetadataConfig;
 import org.apache.hudi.common.data.HoodieData;
 import org.apache.hudi.common.engine.HoodieEngineContext;
 import org.apache.hudi.common.engine.HoodieLocalEngineContext;
 import org.apache.hudi.common.model.FileSlice;
+import org.apache.hudi.common.model.HoodieCommitMetadata;
+import org.apache.hudi.common.model.HoodieFileFormat;
+import org.apache.hudi.common.model.HoodieRecordGlobalLocation;
 import org.apache.hudi.common.model.HoodieRecord;
+import org.apache.hudi.common.model.HoodieWriteStat;
 import org.apache.hudi.common.table.HoodieTableConfig;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
+import org.apache.hudi.common.table.view.HoodieTableFileSystemView;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.config.HoodieWriteConfig;
+import org.apache.hudi.metadata.HoodieBackedTableMetadata;
 import org.apache.hudi.metadata.HoodieMetadataPayload;
+import org.apache.hudi.metadata.HoodieTableMetadataUtil;
+import org.apache.hudi.metadata.MetadataPartitionType;
+import org.apache.hudi.metadata.BaseFileRecordParsingUtils;
 import org.apache.hudi.metadata.index.model.DataPartitionAndRecords;
+import org.apache.hudi.metadata.index.model.IndexPartitionAndRecords;
 import org.apache.hudi.metadata.index.model.IndexPartitionInitialization;
 import org.apache.hudi.metadata.model.FileSliceAndPartition;
+import org.apache.hudi.storage.StoragePath;
 import org.apache.hudi.util.Lazy;
 
 import org.junit.jupiter.api.Test;
@@ -32,7 +44,11 @@ import java.util.Map;
 
 import static org.apache.hudi.common.testutils.HoodieTestUtils.getDefaultStorageConf;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.when;
@@ -70,14 +86,131 @@ class TestPartitionedRecordIndexer {
 
     ExposedPartitionedRecordIndexer indexer = new ExposedPartitionedRecordIndexer(engineContext, writeConfig, dataMetaClient, p1Init, p2Init);
 
-    try (MockedStatic<org.apache.hudi.metadata.HoodieTableMetadataUtil> mockedUtil = mockStatic(org.apache.hudi.metadata.HoodieTableMetadataUtil.class)) {
+    try (MockedStatic<HoodieTableMetadataUtil> mockedUtil = mockStatic(HoodieTableMetadataUtil.class)) {
       List<IndexPartitionInitialization> initializationList = indexer.buildInitialization("001", "002", Map.of(), Lazy.lazily(() -> input));
 
-      mockedUtil.verify(() -> org.apache.hudi.metadata.HoodieTableMetadataUtil.createRecordIndexDefinition(any(), any()));
+      mockedUtil.verify(() -> HoodieTableMetadataUtil.createRecordIndexDefinition(any(), any()));
       assertEquals(1, initializationList.size());
       assertEquals(2, initializationList.get(0).dataPartitionAndRecords().size());
       assertEquals(2, indexer.initializePartitionCalls);
     }
+  }
+
+  @SuppressWarnings("unchecked")
+  @Test
+  void testBuildUpdateWithEmptyCommitMetadataProducesEmptyRecords() {
+    HoodieEngineContext engineContext = new HoodieLocalEngineContext(getDefaultStorageConf());
+    HoodieWriteConfig writeConfig = mock(HoodieWriteConfig.class);
+    HoodieMetadataConfig metadataConfig = mock(HoodieMetadataConfig.class);
+    HoodieTableMetaClient dataMetaClient = mock(HoodieTableMetaClient.class);
+    HoodieTableConfig tableConfig = mock(HoodieTableConfig.class);
+
+    when(writeConfig.getMetadataConfig()).thenReturn(metadataConfig);
+    when(metadataConfig.getRecordIndexMaxParallelism()).thenReturn(8);
+    when(dataMetaClient.getTableConfig()).thenReturn(tableConfig);
+
+    HoodieData<HoodieRecord> empty = (HoodieData<HoodieRecord>) (HoodieData<?>) engineContext.emptyHoodieData();
+    ExposedPartitionedRecordIndexer indexer = new ExposedPartitionedRecordIndexer(
+        engineContext, writeConfig, dataMetaClient,
+        new DataPartitionAndRecords(1, Option.of("p1"), empty),
+        new DataPartitionAndRecords(1, Option.of("p2"), empty));
+
+    List<IndexPartitionAndRecords> result = indexer.buildUpdate(
+        "018",
+        mock(HoodieBackedTableMetadata.class),
+        Lazy.lazily(() -> mock(HoodieTableFileSystemView.class)),
+        new HoodieCommitMetadata());
+
+    assertEquals(1, result.size());
+    assertEquals(MetadataPartitionType.RECORD_INDEX.getPartitionPath(), result.get(0).indexPartitionName());
+    assertEquals(0, result.get(0).indexRecords().collectAsList().size());
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void testBuildUpdateWithNonEmptyCommitMetadataProducesPartitionEntry() {
+    HoodieEngineContext engineContext = new HoodieLocalEngineContext(getDefaultStorageConf());
+    HoodieWriteConfig writeConfig = mock(HoodieWriteConfig.class);
+    HoodieMetadataConfig metadataConfig = mock(HoodieMetadataConfig.class);
+    HoodieTableMetaClient dataMetaClient = mock(HoodieTableMetaClient.class);
+    HoodieTableConfig tableConfig = mock(HoodieTableConfig.class);
+
+    when(writeConfig.getMetadataConfig()).thenReturn(metadataConfig);
+    when(metadataConfig.getRecordIndexMaxParallelism()).thenReturn(8);
+    when(metadataConfig.isRecordLevelIndexEnabled()).thenReturn(true);
+    when(dataMetaClient.getTableConfig()).thenReturn(tableConfig);
+    when(tableConfig.getBaseFileFormat()).thenReturn(HoodieFileFormat.PARQUET);
+    when(dataMetaClient.getBasePath()).thenReturn(new StoragePath("/tmp/hudi-partitioned-record-index-test"));
+    when(dataMetaClient.getStorageConf()).thenReturn((org.apache.hudi.storage.StorageConfiguration) getDefaultStorageConf());
+
+    HoodieData<HoodieRecord> empty = (HoodieData<HoodieRecord>) (HoodieData<?>) engineContext.emptyHoodieData();
+    ExposedPartitionedRecordIndexer indexer = new ExposedPartitionedRecordIndexer(
+        engineContext, writeConfig, dataMetaClient,
+        new DataPartitionAndRecords(1, Option.of("p1"), empty),
+        new DataPartitionAndRecords(1, Option.of("p2"), empty));
+
+    HoodieCommitMetadata commitMetadata = new HoodieCommitMetadata();
+    HoodieWriteStat writeStat = new HoodieWriteStat();
+    writeStat.setPartitionPath("p1");
+    writeStat.setPath("p1/f1.parquet");
+    writeStat.setFileId("11111111-1111-1111-1111-111111111111");
+    writeStat.setNumInserts(1);
+    writeStat.setTotalWriteBytes(128L);
+    commitMetadata.addWriteStat("p1", writeStat);
+
+    List<HoodieRecord> indexRecords;
+    HoodieMetadataPayload payload;
+    try (MockedStatic<BaseFileRecordParsingUtils> mockedBaseFileParsingUtils =
+             mockStatic(BaseFileRecordParsingUtils.class);
+         MockedStatic<HoodieTableMetadataUtil> mockedMetadataUtil =
+             mockStatic(HoodieTableMetadataUtil.class)) {
+      mockedMetadataUtil.when(() -> HoodieTableMetadataUtil.tryResolveSchemaForTable(any()))
+          .thenReturn(Option.empty());
+      mockedMetadataUtil.when(() -> HoodieTableMetadataUtil.reduceByKeys(any(), anyInt(), anyBoolean()))
+          .thenAnswer(invocation -> invocation.getArgument(0));
+      mockedBaseFileParsingUtils.when(() -> BaseFileRecordParsingUtils
+              .generateRLIMetadataHoodieRecordsForBaseFile(any(), any(), any(), any(), any(), anyBoolean()))
+          .thenReturn(Collections.singletonList(
+              HoodieMetadataPayload.createRecordIndexUpdate(
+                  "rk1", "p1", "11111111-1111-1111-1111-111111111111", "20240101010101", 0)).iterator());
+
+      List<IndexPartitionAndRecords> result = indexer.buildUpdate(
+          "20240101010101",
+          mock(HoodieBackedTableMetadata.class),
+          Lazy.lazily(() -> mock(HoodieTableFileSystemView.class)),
+          commitMetadata);
+
+      assertEquals(1, result.size());
+      assertEquals(MetadataPartitionType.RECORD_INDEX.getPartitionPath(), result.get(0).indexPartitionName());
+      indexRecords = result.get(0).indexRecords().collectAsList();
+      assertEquals(1, indexRecords.size());
+      payload = (HoodieMetadataPayload) indexRecords.get(0).getData();
+      assertEquals("p1", payload.getDataPartition());
+
+      mockedBaseFileParsingUtils.verify(() -> BaseFileRecordParsingUtils
+          .generateRLIMetadataHoodieRecordsForBaseFile(any(), any(), anyInt(), any(), any(), eq(true)));
+      mockedMetadataUtil.verify(() -> HoodieTableMetadataUtil
+          .reduceByKeys(any(), anyInt(), eq(true)));
+    }
+
+    HoodieRecordGlobalLocation location = payload.getRecordGlobalLocation();
+    assertEquals("p1", location.getPartitionPath());
+    assertEquals("11111111-1111-1111-1111-111111111111", location.getFileId());
+  }
+
+  @SuppressWarnings("unchecked")
+  @Test
+  void testBuildCleanReturnsEmptyList() {
+    HoodieEngineContext engineContext = new HoodieLocalEngineContext(getDefaultStorageConf());
+    HoodieWriteConfig writeConfig = mock(HoodieWriteConfig.class);
+    HoodieTableMetaClient dataMetaClient = mock(HoodieTableMetaClient.class);
+    HoodieData<HoodieRecord> empty = (HoodieData<HoodieRecord>) (HoodieData<?>) engineContext.emptyHoodieData();
+    ExposedPartitionedRecordIndexer indexer = new ExposedPartitionedRecordIndexer(
+        engineContext, writeConfig, dataMetaClient,
+        new DataPartitionAndRecords(1, Option.of("p1"), empty),
+        new DataPartitionAndRecords(1, Option.of("p2"), empty));
+
+    assertTrue(indexer.buildClean("019", mock(HoodieCleanMetadata.class)).isEmpty());
   }
 
   private static class ExposedPartitionedRecordIndexer extends PartitionedRecordIndexer {

--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/metadata/index/record/TestRecordIndexer.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/metadata/index/record/TestRecordIndexer.java
@@ -1,0 +1,152 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.
+ */
+
+package org.apache.hudi.metadata.index.record;
+
+import org.apache.hudi.common.config.HoodieMetadataConfig;
+import org.apache.hudi.common.data.HoodieData;
+import org.apache.hudi.common.engine.HoodieEngineContext;
+import org.apache.hudi.common.engine.HoodieLocalEngineContext;
+import org.apache.hudi.common.model.HoodieRecord;
+import org.apache.hudi.common.table.HoodieTableConfig;
+import org.apache.hudi.common.table.HoodieTableMetaClient;
+import org.apache.hudi.common.util.Option;
+import org.apache.hudi.config.HoodieWriteConfig;
+import org.apache.hudi.metadata.HoodieMetadataPayload;
+import org.apache.hudi.metadata.index.model.DataPartitionAndRecords;
+import org.apache.hudi.metadata.index.model.IndexPartitionInitialization;
+import org.apache.hudi.metadata.model.FileInfo;
+import org.apache.hudi.metadata.model.FileSliceAndPartition;
+import org.apache.hudi.util.Lazy;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import static org.apache.hudi.common.testutils.HoodieTestUtils.getDefaultStorageConf;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class TestRecordIndexer {
+
+  @Test
+  void testGetDataCreatesDefinitionAndReturnsInitialization() throws IOException {
+    HoodieEngineContext engineContext = mock(HoodieEngineContext.class);
+    HoodieWriteConfig writeConfig = mock(HoodieWriteConfig.class);
+    HoodieMetadataConfig metadataConfig = mock(HoodieMetadataConfig.class);
+    HoodieTableMetaClient metaClient = mock(HoodieTableMetaClient.class);
+    HoodieData<HoodieRecord> records = mock(HoodieData.class);
+
+    when(writeConfig.getMetadataConfig()).thenReturn(metadataConfig);
+    when(metadataConfig.getRecordIndexMaxParallelism()).thenReturn(4);
+
+    DataPartitionAndRecords init = new DataPartitionAndRecords(2, Option.empty(), records);
+    ExposedRecordIndexer indexer = new ExposedRecordIndexer(engineContext, writeConfig, metaClient, init);
+
+    try (MockedStatic<org.apache.hudi.metadata.HoodieTableMetadataUtil> mockedUtil = mockStatic(org.apache.hudi.metadata.HoodieTableMetadataUtil.class)) {
+      List<IndexPartitionInitialization> result = indexer.callGetData("001", "002", Collections.emptyMap(), Lazy.lazily(Collections::emptyList));
+      assertEquals(1, result.size());
+      assertEquals(2, result.get(0).totalFileGroups());
+      mockedUtil.verify(() -> org.apache.hudi.metadata.HoodieTableMetadataUtil.createRecordIndexDefinition(any(), any()), times(1));
+    }
+  }
+
+  @Test
+  void testPostInitializationValidationAndUnpersist() {
+    HoodieEngineContext engineContext = mock(HoodieEngineContext.class);
+    HoodieWriteConfig writeConfig = mock(HoodieWriteConfig.class);
+    HoodieMetadataConfig metadataConfig = mock(HoodieMetadataConfig.class);
+    HoodieTableMetaClient metaClient = mock(HoodieTableMetaClient.class);
+    HoodieTableConfig tableConfig = mock(HoodieTableConfig.class);
+    HoodieData<HoodieRecord> records = mock(HoodieData.class);
+
+    when(writeConfig.getMetadataConfig()).thenReturn(metadataConfig);
+    when(metaClient.getTableConfig()).thenReturn(tableConfig);
+
+    ExposedRecordIndexer indexer = new ExposedRecordIndexer(
+        engineContext, writeConfig, metaClient, new DataPartitionAndRecords(1, Option.empty(), records));
+
+    when(metadataConfig.isRecordIndexInitializationValidationEnabled()).thenReturn(false);
+    indexer.callPost(metaClient, IndexPartitionInitialization.of(1, "record_index", records), "record_index");
+    assertFalse(indexer.validateCalled);
+    verify(records, times(1)).unpersist();
+
+    when(metadataConfig.isRecordIndexInitializationValidationEnabled()).thenReturn(true);
+    indexer.callPost(metaClient, IndexPartitionInitialization.of(1, "record_index", records), "record_index");
+    assertTrue(indexer.validateCalled);
+  }
+
+  @SuppressWarnings("unchecked")
+  @Test
+  void testGetDataWithRealEngineContextAndIndexDataContent() throws IOException {
+    HoodieEngineContext engineContext = new HoodieLocalEngineContext(getDefaultStorageConf());
+    HoodieWriteConfig writeConfig = mock(HoodieWriteConfig.class);
+    HoodieMetadataConfig metadataConfig = mock(HoodieMetadataConfig.class);
+    HoodieTableMetaClient metaClient = mock(HoodieTableMetaClient.class);
+
+    when(writeConfig.getMetadataConfig()).thenReturn(metadataConfig);
+    when(metadataConfig.getRecordIndexMaxParallelism()).thenReturn(4);
+
+    HoodieData<HoodieRecord> records = (HoodieData<HoodieRecord>) (HoodieData<?>) engineContext.parallelize(
+        Collections.singletonList(HoodieMetadataPayload.createPartitionFilesRecord("p_record",
+            Collections.singletonMap("f_record.parquet", 66L), Collections.emptyList())),
+        1);
+
+    ExposedRecordIndexer indexer = new ExposedRecordIndexer(
+        engineContext, writeConfig, metaClient, new DataPartitionAndRecords(2, Option.empty(), records));
+
+    try (MockedStatic<org.apache.hudi.metadata.HoodieTableMetadataUtil> mockedUtil = mockStatic(org.apache.hudi.metadata.HoodieTableMetadataUtil.class)) {
+      List<IndexPartitionInitialization> result = indexer.callGetData("001", "002", Collections.emptyMap(), Lazy.lazily(Collections::emptyList));
+      assertEquals(1, result.size());
+      assertEquals(1, result.get(0).dataPartitionAndRecords().get(0).indexRecords().collectAsList().size());
+      assertEquals("p_record", result.get(0).dataPartitionAndRecords().get(0).indexRecords().collectAsList().get(0).getRecordKey());
+      mockedUtil.verify(() -> org.apache.hudi.metadata.HoodieTableMetadataUtil.createRecordIndexDefinition(any(), any()), times(1));
+    }
+  }
+
+  private static class ExposedRecordIndexer extends RecordIndexer {
+    private final DataPartitionAndRecords predefined;
+    private boolean validateCalled;
+
+    ExposedRecordIndexer(HoodieEngineContext engineContext, HoodieWriteConfig dataTableWriteConfig,
+                         HoodieTableMetaClient dataTableMetaClient, DataPartitionAndRecords predefined) {
+      super(engineContext, dataTableWriteConfig, dataTableMetaClient);
+      this.predefined = predefined;
+    }
+
+    @Override
+    protected DataPartitionAndRecords initializeRecordIndexPartition(List<FileSliceAndPartition> latestMergedPartitionFileSliceList,
+                                                                     int recordIndexMaxParallelism) {
+      return predefined;
+    }
+
+    @Override
+    protected void validateRecordIndex(HoodieData<HoodieRecord> recordIndexRecords, int fileGroupCount, HoodieTableMetaClient metadataMetaClient) {
+      validateCalled = true;
+    }
+
+    List<IndexPartitionInitialization> callGetData(String dataTableInstantTime, String instantTimeForPartition,
+                                                   Map<String, List<FileInfo>> partitionIdToAllFilesMap,
+                                                   Lazy<List<FileSliceAndPartition>> lazyLatestMergedPartitionFileSliceList) throws IOException {
+      return buildInitialization(dataTableInstantTime, instantTimeForPartition, partitionIdToAllFilesMap, lazyLatestMergedPartitionFileSliceList);
+    }
+
+    void callPost(HoodieTableMetaClient metadataMetaClient, IndexPartitionInitialization indexPartitionInitialization, String relativePartitionPath) {
+      postInitialization(metadataMetaClient, indexPartitionInitialization.dataPartitionAndRecords().get(0).indexRecords(),
+          indexPartitionInitialization.totalFileGroups(), relativePartitionPath);
+    }
+  }
+}

--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/metadata/index/record/TestRecordIndexer.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/metadata/index/record/TestRecordIndexer.java
@@ -5,20 +5,32 @@
 
 package org.apache.hudi.metadata.index.record;
 
+import org.apache.hudi.avro.model.HoodieCleanMetadata;
 import org.apache.hudi.common.config.HoodieMetadataConfig;
 import org.apache.hudi.common.data.HoodieData;
 import org.apache.hudi.common.engine.HoodieEngineContext;
 import org.apache.hudi.common.engine.HoodieLocalEngineContext;
+import org.apache.hudi.common.model.HoodieCommitMetadata;
+import org.apache.hudi.common.model.HoodieFileFormat;
+import org.apache.hudi.common.model.HoodieRecordGlobalLocation;
 import org.apache.hudi.common.model.HoodieRecord;
+import org.apache.hudi.common.model.HoodieWriteStat;
 import org.apache.hudi.common.table.HoodieTableConfig;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
+import org.apache.hudi.common.table.view.HoodieTableFileSystemView;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.config.HoodieWriteConfig;
+import org.apache.hudi.metadata.HoodieBackedTableMetadata;
 import org.apache.hudi.metadata.HoodieMetadataPayload;
+import org.apache.hudi.metadata.HoodieTableMetadataUtil;
+import org.apache.hudi.metadata.MetadataPartitionType;
+import org.apache.hudi.metadata.BaseFileRecordParsingUtils;
 import org.apache.hudi.metadata.index.model.DataPartitionAndRecords;
+import org.apache.hudi.metadata.index.model.IndexPartitionAndRecords;
 import org.apache.hudi.metadata.index.model.IndexPartitionInitialization;
 import org.apache.hudi.metadata.model.FileInfo;
 import org.apache.hudi.metadata.model.FileSliceAndPartition;
+import org.apache.hudi.storage.StoragePath;
 import org.apache.hudi.util.Lazy;
 
 import org.junit.jupiter.api.Test;
@@ -28,12 +40,15 @@ import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 
 import static org.apache.hudi.common.testutils.HoodieTestUtils.getDefaultStorageConf;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.times;
@@ -56,11 +71,11 @@ class TestRecordIndexer {
     DataPartitionAndRecords init = new DataPartitionAndRecords(2, Option.empty(), records);
     ExposedRecordIndexer indexer = new ExposedRecordIndexer(engineContext, writeConfig, metaClient, init);
 
-    try (MockedStatic<org.apache.hudi.metadata.HoodieTableMetadataUtil> mockedUtil = mockStatic(org.apache.hudi.metadata.HoodieTableMetadataUtil.class)) {
+    try (MockedStatic<HoodieTableMetadataUtil> mockedUtil = mockStatic(HoodieTableMetadataUtil.class)) {
       List<IndexPartitionInitialization> result = indexer.callGetData("001", "002", Collections.emptyMap(), Lazy.lazily(Collections::emptyList));
       assertEquals(1, result.size());
       assertEquals(2, result.get(0).totalFileGroups());
-      mockedUtil.verify(() -> org.apache.hudi.metadata.HoodieTableMetadataUtil.createRecordIndexDefinition(any(), any()), times(1));
+      mockedUtil.verify(() -> HoodieTableMetadataUtil.createRecordIndexDefinition(any(), any()), times(1));
     }
   }
 
@@ -108,13 +123,115 @@ class TestRecordIndexer {
     ExposedRecordIndexer indexer = new ExposedRecordIndexer(
         engineContext, writeConfig, metaClient, new DataPartitionAndRecords(2, Option.empty(), records));
 
-    try (MockedStatic<org.apache.hudi.metadata.HoodieTableMetadataUtil> mockedUtil = mockStatic(org.apache.hudi.metadata.HoodieTableMetadataUtil.class)) {
+    try (MockedStatic<HoodieTableMetadataUtil> mockedUtil = mockStatic(HoodieTableMetadataUtil.class)) {
       List<IndexPartitionInitialization> result = indexer.callGetData("001", "002", Collections.emptyMap(), Lazy.lazily(Collections::emptyList));
       assertEquals(1, result.size());
       assertEquals(1, result.get(0).dataPartitionAndRecords().get(0).indexRecords().collectAsList().size());
       assertEquals("p_record", result.get(0).dataPartitionAndRecords().get(0).indexRecords().collectAsList().get(0).getRecordKey());
-      mockedUtil.verify(() -> org.apache.hudi.metadata.HoodieTableMetadataUtil.createRecordIndexDefinition(any(), any()), times(1));
+      mockedUtil.verify(() -> HoodieTableMetadataUtil.createRecordIndexDefinition(any(), any()), times(1));
     }
+  }
+
+  @Test
+  void testBuildUpdateWithEmptyCommitMetadataProducesEmptyRecords() {
+    HoodieEngineContext engineContext = new HoodieLocalEngineContext(getDefaultStorageConf());
+    HoodieWriteConfig writeConfig = mock(HoodieWriteConfig.class);
+    HoodieMetadataConfig metadataConfig = mock(HoodieMetadataConfig.class);
+    HoodieTableMetaClient metaClient = mock(HoodieTableMetaClient.class);
+
+    when(writeConfig.getMetadataConfig()).thenReturn(metadataConfig);
+    when(metadataConfig.getRecordIndexMaxParallelism()).thenReturn(4);
+
+    HoodieData<HoodieRecord> records = (HoodieData<HoodieRecord>) (HoodieData<?>) engineContext.emptyHoodieData();
+    ExposedRecordIndexer indexer = new ExposedRecordIndexer(
+        engineContext, writeConfig, metaClient, new DataPartitionAndRecords(1, Option.empty(), records));
+
+    List<IndexPartitionAndRecords> result = indexer.buildUpdate(
+        "016",
+        mock(HoodieBackedTableMetadata.class),
+        Lazy.lazily(() -> mock(HoodieTableFileSystemView.class)),
+        new HoodieCommitMetadata());
+
+    assertEquals(1, result.size());
+    assertEquals(MetadataPartitionType.RECORD_INDEX.getPartitionPath(), result.get(0).indexPartitionName());
+    assertEquals(0, result.get(0).indexRecords().collectAsList().size());
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void testBuildUpdateWithNonEmptyCommitMetadataProducesPartitionEntry() {
+    HoodieEngineContext engineContext = new HoodieLocalEngineContext(getDefaultStorageConf());
+    HoodieWriteConfig writeConfig = mock(HoodieWriteConfig.class);
+    HoodieMetadataConfig metadataConfig = mock(HoodieMetadataConfig.class);
+    HoodieTableMetaClient metaClient = mock(HoodieTableMetaClient.class);
+    HoodieTableConfig tableConfig = mock(HoodieTableConfig.class);
+
+    when(writeConfig.getMetadataConfig()).thenReturn(metadataConfig);
+    when(metadataConfig.getRecordIndexMaxParallelism()).thenReturn(4);
+    when(metaClient.getTableConfig()).thenReturn(tableConfig);
+    when(tableConfig.getBaseFileFormat()).thenReturn(HoodieFileFormat.PARQUET);
+    when(metaClient.getBasePath()).thenReturn(new StoragePath("/tmp/hudi-record-index-test"));
+    when(metaClient.getStorageConf()).thenReturn((org.apache.hudi.storage.StorageConfiguration) getDefaultStorageConf());
+
+    HoodieData<HoodieRecord> records = (HoodieData<HoodieRecord>) (HoodieData<?>) engineContext.emptyHoodieData();
+    ExposedRecordIndexer indexer = new ExposedRecordIndexer(
+        engineContext, writeConfig, metaClient, new DataPartitionAndRecords(1, Option.empty(), records));
+
+    HoodieCommitMetadata commitMetadata = new HoodieCommitMetadata();
+    HoodieWriteStat writeStat = new HoodieWriteStat();
+    writeStat.setPartitionPath("p1");
+    writeStat.setPath("p1/f1.parquet");
+    final String fileID = UUID.randomUUID().toString();
+    writeStat.setFileId(fileID);
+    writeStat.setNumInserts(1);
+    writeStat.setTotalWriteBytes(128L);
+    commitMetadata.addWriteStat("p1", writeStat);
+
+    List<HoodieRecord> indexRecords;
+    HoodieMetadataPayload payload;
+    try (MockedStatic<BaseFileRecordParsingUtils> mockedBaseFileParsingUtils =
+             mockStatic(BaseFileRecordParsingUtils.class);
+         MockedStatic<HoodieTableMetadataUtil> mockedMetadataUtil =
+             mockStatic(HoodieTableMetadataUtil.class)) {
+      mockedMetadataUtil.when(() -> HoodieTableMetadataUtil.tryResolveSchemaForTable(any()))
+          .thenReturn(Option.empty());
+      mockedMetadataUtil.when(() -> HoodieTableMetadataUtil.reduceByKeys(any(), anyInt(), anyBoolean()))
+          .thenAnswer(invocation -> invocation.getArgument(0));
+      mockedBaseFileParsingUtils.when(() -> BaseFileRecordParsingUtils
+              .generateRLIMetadataHoodieRecordsForBaseFile(any(), any(), any(), any(), any(), anyBoolean()))
+          .thenReturn(Collections.singletonList(
+              HoodieMetadataPayload.createRecordIndexUpdate(
+                  "rk1", "p1", fileID, "20240101010101", 0)).iterator());
+
+      List<IndexPartitionAndRecords> result = indexer.buildUpdate(
+          "20240101010101",
+          mock(HoodieBackedTableMetadata.class),
+          Lazy.lazily(() -> mock(HoodieTableFileSystemView.class)),
+          commitMetadata);
+
+      assertEquals(1, result.size());
+      assertEquals(MetadataPartitionType.RECORD_INDEX.getPartitionPath(), result.get(0).indexPartitionName());
+      indexRecords = result.get(0).indexRecords().collectAsList();
+      assertEquals(1, indexRecords.size());
+      payload = (HoodieMetadataPayload) indexRecords.get(0).getData();
+      assertEquals("p1", payload.getDataPartition());
+    }
+
+    HoodieRecordGlobalLocation location = payload.getRecordGlobalLocation();
+    assertEquals("p1", location.getPartitionPath());
+    assertEquals(fileID, location.getFileId());
+  }
+
+  @Test
+  void testBuildCleanReturnsEmptyList() {
+    HoodieEngineContext engineContext = mock(HoodieEngineContext.class);
+    HoodieWriteConfig writeConfig = mock(HoodieWriteConfig.class);
+    HoodieTableMetaClient metaClient = mock(HoodieTableMetaClient.class);
+    HoodieData<HoodieRecord> records = mock(HoodieData.class);
+    ExposedRecordIndexer indexer = new ExposedRecordIndexer(
+        engineContext, writeConfig, metaClient, new DataPartitionAndRecords(1, Option.empty(), records));
+
+    assertTrue(indexer.buildClean("017", mock(HoodieCleanMetadata.class)).isEmpty());
   }
 
   private static class ExposedRecordIndexer extends RecordIndexer {

--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/metadata/index/secondary/TestSecondaryIndexer.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/metadata/index/secondary/TestSecondaryIndexer.java
@@ -1,0 +1,116 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.
+ */
+
+package org.apache.hudi.metadata.index.secondary;
+
+import org.apache.hudi.common.config.HoodieMetadataConfig;
+import org.apache.hudi.common.config.TypedProperties;
+import org.apache.hudi.common.data.HoodieData;
+import org.apache.hudi.common.engine.HoodieEngineContext;
+import org.apache.hudi.common.engine.HoodieLocalEngineContext;
+import org.apache.hudi.common.model.HoodieIndexDefinition;
+import org.apache.hudi.common.model.HoodieRecord;
+import org.apache.hudi.common.table.HoodieTableMetaClient;
+import org.apache.hudi.config.HoodieWriteConfig;
+import org.apache.hudi.metadata.HoodieMetadataPayload;
+import org.apache.hudi.metadata.HoodieTableMetadataUtil;
+import org.apache.hudi.metadata.index.model.IndexPartitionInitialization;
+import org.apache.hudi.metadata.model.FileInfo;
+import org.apache.hudi.metadata.model.FileSliceAndPartition;
+import org.apache.hudi.util.Lazy;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.apache.hudi.common.testutils.HoodieTestUtils.getDefaultStorageConf;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyFloat;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
+
+class TestSecondaryIndexer {
+
+  @Test
+  void testSkipWhenMultipleSecondaryPartitions() throws IOException {
+    HoodieEngineContext engineContext = mock(HoodieEngineContext.class);
+    HoodieWriteConfig writeConfig = mock(HoodieWriteConfig.class);
+    HoodieMetadataConfig metadataConfig = mock(HoodieMetadataConfig.class);
+    HoodieTableMetaClient metaClient = mock(HoodieTableMetaClient.class);
+
+    when(writeConfig.getMetadataConfig()).thenReturn(metadataConfig);
+
+    try (MockedStatic<HoodieTableMetadataUtil> mockedUtil = mockStatic(HoodieTableMetadataUtil.class)) {
+      mockedUtil.when(() -> HoodieTableMetadataUtil.getSecondaryIndexPartitionsToInit(any(), any(), any()))
+          .thenReturn(Set.of("sec1", "sec2"));
+
+      ExposedSecondaryIndexer indexer = new ExposedSecondaryIndexer(engineContext, writeConfig, metaClient);
+      List<IndexPartitionInitialization> result = indexer.callGetData("001", "002", Collections.emptyMap(), Lazy.lazily(Collections::emptyList));
+      assertTrue(result.isEmpty());
+    }
+  }
+
+  @SuppressWarnings("unchecked")
+  @Test
+  void testInitializeWithRealEngineContextAndIndexDataContent() throws IOException {
+    HoodieEngineContext engineContext = new HoodieLocalEngineContext(getDefaultStorageConf());
+    HoodieWriteConfig writeConfig = mock(HoodieWriteConfig.class);
+    HoodieMetadataConfig metadataConfig = mock(HoodieMetadataConfig.class);
+    HoodieTableMetaClient metaClient = mock(HoodieTableMetaClient.class);
+    HoodieIndexDefinition definition = mock(HoodieIndexDefinition.class);
+
+    when(writeConfig.getMetadataConfig()).thenReturn(metadataConfig);
+    when(metadataConfig.getSecondaryIndexParallelism()).thenReturn(8);
+    when(writeConfig.getProps()).thenReturn(new TypedProperties());
+
+    HoodieData<HoodieRecord> records = (HoodieData<HoodieRecord>) (HoodieData<?>) engineContext.parallelize(
+        Collections.singletonList(HoodieMetadataPayload.createPartitionFilesRecord("p_sec",
+            Collections.singletonMap("f_sec.parquet", 44L), Collections.emptyList())),
+        1);
+
+    try (MockedStatic<HoodieTableMetadataUtil> mockedUtil = mockStatic(HoodieTableMetadataUtil.class);
+         MockedStatic<org.apache.hudi.metadata.SecondaryIndexRecordGenerationUtils> mockedSecondaryUtil = mockStatic(org.apache.hudi.metadata.SecondaryIndexRecordGenerationUtils.class)) {
+      mockedUtil.when(() -> HoodieTableMetadataUtil.getSecondaryIndexPartitionsToInit(any(), any(), any()))
+          .thenReturn(Collections.singleton("sec_idx"));
+      mockedUtil.when(() -> HoodieTableMetadataUtil.getHoodieIndexDefinition("sec_idx", metaClient)).thenReturn(definition);
+      mockedSecondaryUtil.when(() -> org.apache.hudi.metadata.SecondaryIndexRecordGenerationUtils.readSecondaryKeysFromFileSlices(any(), any(), anyInt(), any(), any(), any(), any()))
+          .thenReturn(records);
+      mockedUtil.when(() -> HoodieTableMetadataUtil.estimateFileGroupCount(any(), any(), anyInt(), anyInt(), anyInt(), anyFloat(), anyLong()))
+          .thenReturn(7);
+
+      ExposedSecondaryIndexer indexer = new ExposedSecondaryIndexer(engineContext, writeConfig, metaClient);
+      List<IndexPartitionInitialization> initializationList = indexer.callGetData("001", "002", Collections.emptyMap(), Lazy.lazily(Collections::emptyList));
+      assertEquals(1, initializationList.size());
+
+      assertEquals("sec_idx", initializationList.get(0).indexPartitionName());
+      assertEquals(7, initializationList.get(0).totalFileGroups());
+      List<HoodieRecord> collected = initializationList.get(0).dataPartitionAndRecords().get(0).indexRecords().collectAsList();
+      assertEquals(1, collected.size());
+      assertEquals("p_sec", collected.get(0).getRecordKey());
+    }
+  }
+
+  private static class ExposedSecondaryIndexer extends SecondaryIndexer {
+    ExposedSecondaryIndexer(HoodieEngineContext engineContext, HoodieWriteConfig dataTableWriteConfig, HoodieTableMetaClient dataTableMetaClient) {
+      super(engineContext, dataTableWriteConfig, dataTableMetaClient);
+    }
+
+    List<IndexPartitionInitialization> callGetData(String dataTableInstantTime, String instantTimeForPartition,
+                                                   Map<String, List<FileInfo>> partitionIdToAllFilesMap,
+                                                   Lazy<List<FileSliceAndPartition>> lazyLatestMergedPartitionFileSliceList) throws IOException {
+      return buildInitialization(dataTableInstantTime, instantTimeForPartition, partitionIdToAllFilesMap, lazyLatestMergedPartitionFileSliceList);
+    }
+  }
+}

--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/metadata/index/secondary/TestSecondaryIndexer.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/metadata/index/secondary/TestSecondaryIndexer.java
@@ -5,15 +5,21 @@
 
 package org.apache.hudi.metadata.index.secondary;
 
+import org.apache.hudi.avro.model.HoodieCleanMetadata;
 import org.apache.hudi.common.config.HoodieMetadataConfig;
 import org.apache.hudi.common.config.TypedProperties;
 import org.apache.hudi.common.data.HoodieData;
 import org.apache.hudi.common.engine.HoodieEngineContext;
 import org.apache.hudi.common.engine.HoodieLocalEngineContext;
+import org.apache.hudi.common.model.HoodieCommitMetadata;
 import org.apache.hudi.common.model.HoodieIndexDefinition;
+import org.apache.hudi.common.model.HoodieIndexMetadata;
 import org.apache.hudi.common.model.HoodieRecord;
+import org.apache.hudi.common.model.WriteOperationType;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
+import org.apache.hudi.common.table.view.HoodieTableFileSystemView;
 import org.apache.hudi.config.HoodieWriteConfig;
+import org.apache.hudi.metadata.HoodieBackedTableMetadata;
 import org.apache.hudi.metadata.HoodieMetadataPayload;
 import org.apache.hudi.metadata.HoodieTableMetadataUtil;
 import org.apache.hudi.metadata.index.model.IndexPartitionInitialization;
@@ -32,6 +38,7 @@ import java.util.Set;
 
 import static org.apache.hudi.common.testutils.HoodieTestUtils.getDefaultStorageConf;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyFloat;
@@ -100,6 +107,72 @@ class TestSecondaryIndexer {
       assertEquals(1, collected.size());
       assertEquals("p_sec", collected.get(0).getRecordKey());
     }
+  }
+
+  @Test
+  void testBuildUpdateReturnsEmptyWhenSecondaryIndexUnavailable() {
+    HoodieTableMetaClient metaClient = mock(HoodieTableMetaClient.class);
+    when(metaClient.getIndexMetadata()).thenReturn(org.apache.hudi.common.util.Option.empty());
+    ExposedSecondaryIndexer indexer = new ExposedSecondaryIndexer(
+        mock(HoodieEngineContext.class), mock(HoodieWriteConfig.class), metaClient);
+    assertTrue(indexer.buildUpdate(
+        "013",
+        mock(HoodieBackedTableMetadata.class),
+        Lazy.lazily(() -> mock(HoodieTableFileSystemView.class)),
+        new HoodieCommitMetadata()).isEmpty());
+  }
+
+  @Test
+  void testBuildUpdateThrowsForDeletePartitionOperation() {
+    HoodieEngineContext engineContext = mock(HoodieEngineContext.class);
+    HoodieWriteConfig writeConfig = mock(HoodieWriteConfig.class);
+    HoodieTableMetaClient metaClient = mock(HoodieTableMetaClient.class);
+    HoodieIndexMetadata indexMetadata = mock(HoodieIndexMetadata.class);
+    HoodieIndexDefinition indexDefinition = mock(HoodieIndexDefinition.class);
+
+    when(metaClient.getIndexMetadata()).thenReturn(org.apache.hudi.common.util.Option.of(indexMetadata));
+    when(indexMetadata.getIndexDefinitions()).thenReturn(Collections.singletonMap("secondary_index_idx", indexDefinition));
+    when(indexDefinition.getIndexName()).thenReturn("secondary_index_idx");
+
+    HoodieCommitMetadata commitMetadata = new HoodieCommitMetadata();
+    commitMetadata.setOperationType(WriteOperationType.DELETE_PARTITION);
+
+    ExposedSecondaryIndexer indexer = new ExposedSecondaryIndexer(engineContext, writeConfig, metaClient);
+    assertThrows(RuntimeException.class, () -> indexer.buildUpdate(
+        "014",
+        mock(HoodieBackedTableMetadata.class),
+        Lazy.lazily(() -> mock(HoodieTableFileSystemView.class)),
+        commitMetadata));
+  }
+
+  @Test
+  void testBuildUpdateForCompactReturnsEmpty() {
+    HoodieEngineContext engineContext = mock(HoodieEngineContext.class);
+    HoodieWriteConfig writeConfig = mock(HoodieWriteConfig.class);
+    HoodieTableMetaClient metaClient = mock(HoodieTableMetaClient.class);
+    HoodieIndexMetadata indexMetadata = mock(HoodieIndexMetadata.class);
+    HoodieIndexDefinition indexDefinition = mock(HoodieIndexDefinition.class);
+
+    when(metaClient.getIndexMetadata()).thenReturn(org.apache.hudi.common.util.Option.of(indexMetadata));
+    when(indexMetadata.getIndexDefinitions()).thenReturn(Collections.singletonMap("secondary_index_idx", indexDefinition));
+    when(indexDefinition.getIndexName()).thenReturn("secondary_index_idx");
+
+    HoodieCommitMetadata commitMetadata = new HoodieCommitMetadata();
+    commitMetadata.setOperationType(WriteOperationType.COMPACT);
+
+    ExposedSecondaryIndexer indexer = new ExposedSecondaryIndexer(engineContext, writeConfig, metaClient);
+    assertTrue(indexer.buildUpdate(
+        "015",
+        mock(HoodieBackedTableMetadata.class),
+        Lazy.lazily(() -> mock(HoodieTableFileSystemView.class)),
+        commitMetadata).isEmpty());
+  }
+
+  @Test
+  void testBuildCleanReturnsEmpty() {
+    ExposedSecondaryIndexer indexer = new ExposedSecondaryIndexer(
+        mock(HoodieEngineContext.class), mock(HoodieWriteConfig.class), mock(HoodieTableMetaClient.class));
+    assertTrue(indexer.buildClean("017", mock(HoodieCleanMetadata.class)).isEmpty());
   }
 
   private static class ExposedSecondaryIndexer extends SecondaryIndexer {

--- a/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/metadata/FlinkHoodieBackedTableMetadataWriter.java
+++ b/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/metadata/FlinkHoodieBackedTableMetadataWriter.java
@@ -35,6 +35,7 @@ import org.apache.hudi.common.util.collection.Pair;
 import org.apache.hudi.config.HoodieWriteConfig;
 import org.apache.hudi.exception.HoodieNotSupportedException;
 import org.apache.hudi.metadata.index.UnsupportedExpressionIndexRecordGenerator;
+import org.apache.hudi.metadata.index.model.IndexPartitionAndRecords;
 import org.apache.hudi.storage.StorageConfiguration;
 import org.apache.hudi.table.BulkInsertPartitioner;
 
@@ -42,7 +43,6 @@ import lombok.extern.slf4j.Slf4j;
 
 import java.util.Collections;
 import java.util.List;
-import java.util.Map;
 
 import static org.apache.hudi.common.model.HoodieFailedWritesCleaningPolicy.EAGER;
 
@@ -116,8 +116,8 @@ public class FlinkHoodieBackedTableMetadataWriter extends HoodieBackedTableMetad
   }
 
   @Override
-  protected void commit(String instantTime, Map<String, HoodieData<HoodieRecord>> partitionRecordsMap) {
-    commitInternal(instantTime, partitionRecordsMap, false, Option.empty());
+  protected void commit(String instantTime, List<IndexPartitionAndRecords> partitionRecords) {
+    commitInternal(instantTime, partitionRecords, false, Option.empty());
   }
 
   @Override
@@ -133,11 +133,11 @@ public class FlinkHoodieBackedTableMetadataWriter extends HoodieBackedTableMetad
   @Override
   protected void bulkCommit(String instantTime, String partitionPath, HoodieData<HoodieRecord> records, MetadataTableFileGroupIndexParser fileGroupIndexParser) {
     // TODO: functional and secondary index are not supported with Flink yet, but we should fix the partition name when we support them.
-    commitInternal(instantTime, Collections.singletonMap(partitionPath, records), true, Option.empty());
+    commitInternal(instantTime, Collections.singletonList(IndexPartitionAndRecords.of(partitionPath, records)), true, Option.empty());
   }
 
   @Override
-  protected void commitInternal(String instantTime, Map<String, HoodieData<HoodieRecord>> partitionRecordsMap, boolean isInitializing,
+  protected void commitInternal(String instantTime, List<IndexPartitionAndRecords> partitionRecords, boolean isInitializing,
                                 Option<BulkInsertPartitioner> bulkInsertPartitioner) {
     // this method will be invoked during compaction of data table, here table services for mdt is
     // not performed if streaming writes mdt is enabled, since the compaction/clean will be performed
@@ -146,7 +146,7 @@ public class FlinkHoodieBackedTableMetadataWriter extends HoodieBackedTableMetad
       performTableServices(Option.ofNullable(instantTime), false);
     }
     metadataMetaClient.reloadActiveTimeline();
-    super.commitInternal(instantTime, partitionRecordsMap, isInitializing, bulkInsertPartitioner);
+    super.commitInternal(instantTime, partitionRecords, isInitializing, bulkInsertPartitioner);
   }
 
   @Override

--- a/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/metadata/FlinkHoodieBackedTableMetadataWriter.java
+++ b/hudi-client/hudi-flink-client/src/main/java/org/apache/hudi/metadata/FlinkHoodieBackedTableMetadataWriter.java
@@ -27,16 +27,14 @@ import org.apache.hudi.common.engine.EngineType;
 import org.apache.hudi.common.engine.HoodieEngineContext;
 import org.apache.hudi.common.model.HoodieFailedWritesCleaningPolicy;
 import org.apache.hudi.common.model.HoodieFileGroupId;
-import org.apache.hudi.common.model.HoodieIndexDefinition;
 import org.apache.hudi.common.model.HoodieRecord;
-import org.apache.hudi.common.schema.HoodieSchema;
-import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.common.table.timeline.HoodieActiveTimeline;
 import org.apache.hudi.common.table.timeline.HoodieTimeline;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.common.util.collection.Pair;
 import org.apache.hudi.config.HoodieWriteConfig;
 import org.apache.hudi.exception.HoodieNotSupportedException;
+import org.apache.hudi.metadata.index.UnsupportedExpressionIndexRecordGenerator;
 import org.apache.hudi.storage.StorageConfiguration;
 import org.apache.hudi.table.BulkInsertPartitioner;
 
@@ -82,7 +80,7 @@ public class FlinkHoodieBackedTableMetadataWriter extends HoodieBackedTableMetad
                                        HoodieFailedWritesCleaningPolicy failedWritesCleaningPolicy,
                                        HoodieEngineContext engineContext,
                                        Option<String> inFlightInstantTimestamp) {
-    super(storageConf, writeConfig, failedWritesCleaningPolicy, engineContext, inFlightInstantTimestamp);
+    this(storageConf, writeConfig, failedWritesCleaningPolicy, engineContext, inFlightInstantTimestamp, false);
   }
 
   FlinkHoodieBackedTableMetadataWriter(StorageConfiguration<?> storageConf,
@@ -91,7 +89,7 @@ public class FlinkHoodieBackedTableMetadataWriter extends HoodieBackedTableMetad
                                        HoodieEngineContext engineContext,
                                        Option<String> inFlightInstantTimestamp,
                                        boolean streamingWrites) {
-    super(storageConf, writeConfig, failedWritesCleaningPolicy, engineContext, inFlightInstantTimestamp, streamingWrites);
+    super(storageConf, writeConfig, failedWritesCleaningPolicy, engineContext, new UnsupportedExpressionIndexRecordGenerator(EngineType.FLINK), inFlightInstantTimestamp, streamingWrites);
   }
 
   @Override
@@ -164,13 +162,6 @@ public class FlinkHoodieBackedTableMetadataWriter extends HoodieBackedTableMetad
   @Override
   protected void preWrite(String instantTime) {
     metadataMetaClient.getActiveTimeline().transitionRequestedToInflight(HoodieActiveTimeline.DELTA_COMMIT_ACTION, instantTime);
-  }
-
-  @Override
-  protected HoodieData<HoodieRecord> getExpressionIndexRecords(List<Pair<String, Pair<String, Long>>> partitionFilePathAndSizeTriplet, HoodieIndexDefinition indexDefinition,
-                                                               HoodieTableMetaClient metaClient, int parallelism, HoodieSchema tableSchema, HoodieSchema readerSchema,
-                                                               StorageConfiguration<?> storageConf, String instantTime) {
-    throw new HoodieNotSupportedException("Flink metadata table does not support expression index yet.");
   }
 
   @Override

--- a/hudi-client/hudi-java-client/src/main/java/org/apache/hudi/metadata/JavaHoodieBackedTableMetadataWriter.java
+++ b/hudi-client/hudi-java-client/src/main/java/org/apache/hudi/metadata/JavaHoodieBackedTableMetadataWriter.java
@@ -33,12 +33,12 @@ import org.apache.hudi.common.util.Option;
 import org.apache.hudi.config.HoodieWriteConfig;
 import org.apache.hudi.exception.HoodieNotSupportedException;
 import org.apache.hudi.metadata.index.UnsupportedExpressionIndexRecordGenerator;
+import org.apache.hudi.metadata.index.model.IndexPartitionAndRecords;
 import org.apache.hudi.storage.StorageConfiguration;
 import org.apache.hudi.table.BulkInsertPartitioner;
 
 import java.util.Collections;
 import java.util.List;
-import java.util.Map;
 
 import static org.apache.hudi.common.model.HoodieFailedWritesCleaningPolicy.EAGER;
 
@@ -91,8 +91,8 @@ public class JavaHoodieBackedTableMetadataWriter extends HoodieBackedTableMetada
   }
 
   @Override
-  protected void commit(String instantTime, Map<String, HoodieData<HoodieRecord>> partitionRecordsMap) {
-    commitInternal(instantTime, partitionRecordsMap, false, Option.empty());
+  protected void commit(String instantTime, List<IndexPartitionAndRecords> partitionRecords) {
+    commitInternal(instantTime, partitionRecords, false, Option.empty());
   }
 
   @Override
@@ -107,7 +107,7 @@ public class JavaHoodieBackedTableMetadataWriter extends HoodieBackedTableMetada
 
   @Override
   protected void bulkCommit(String instantTime, String partitionPath, HoodieData<HoodieRecord> records, MetadataTableFileGroupIndexParser indexParser) {
-    commitInternal(instantTime, Collections.singletonMap(partitionPath, records), true, Option.of(new JavaHoodieMetadataBulkInsertPartitioner()));
+    commitInternal(instantTime, Collections.singletonList(IndexPartitionAndRecords.of(partitionPath, records)), true, Option.of(new JavaHoodieMetadataBulkInsertPartitioner()));
   }
 
   @Override

--- a/hudi-client/hudi-java-client/src/main/java/org/apache/hudi/metadata/JavaHoodieBackedTableMetadataWriter.java
+++ b/hudi-client/hudi-java-client/src/main/java/org/apache/hudi/metadata/JavaHoodieBackedTableMetadataWriter.java
@@ -27,15 +27,12 @@ import org.apache.hudi.common.engine.EngineType;
 import org.apache.hudi.common.engine.HoodieEngineContext;
 import org.apache.hudi.common.model.HoodieFailedWritesCleaningPolicy;
 import org.apache.hudi.common.model.HoodieFileGroupId;
-import org.apache.hudi.common.model.HoodieIndexDefinition;
 import org.apache.hudi.common.model.HoodieRecord;
-import org.apache.hudi.common.schema.HoodieSchema;
-import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.common.table.timeline.HoodieActiveTimeline;
 import org.apache.hudi.common.util.Option;
-import org.apache.hudi.common.util.collection.Pair;
 import org.apache.hudi.config.HoodieWriteConfig;
 import org.apache.hudi.exception.HoodieNotSupportedException;
+import org.apache.hudi.metadata.index.UnsupportedExpressionIndexRecordGenerator;
 import org.apache.hudi.storage.StorageConfiguration;
 import org.apache.hudi.table.BulkInsertPartitioner;
 
@@ -59,7 +56,7 @@ public class JavaHoodieBackedTableMetadataWriter extends HoodieBackedTableMetada
   protected JavaHoodieBackedTableMetadataWriter(StorageConfiguration<?> storageConf, HoodieWriteConfig writeConfig, HoodieFailedWritesCleaningPolicy failedWritesCleaningPolicy,
                                                 HoodieEngineContext engineContext,
                                                 Option<String> inflightInstantTimestamp) {
-    super(storageConf, writeConfig, failedWritesCleaningPolicy, engineContext, inflightInstantTimestamp);
+    super(storageConf, writeConfig, failedWritesCleaningPolicy, engineContext, new UnsupportedExpressionIndexRecordGenerator(EngineType.JAVA), inflightInstantTimestamp);
   }
 
   public static HoodieTableMetadataWriter create(StorageConfiguration<?> conf,
@@ -145,13 +142,6 @@ public class JavaHoodieBackedTableMetadataWriter extends HoodieBackedTableMetada
   @Override
   protected void preWrite(String instantTime) {
     metadataMetaClient.getActiveTimeline().transitionRequestedToInflight(HoodieActiveTimeline.DELTA_COMMIT_ACTION, instantTime);
-  }
-
-  @Override
-  protected HoodieData<HoodieRecord> getExpressionIndexRecords(List<Pair<String, Pair<String, Long>>> partitionFilePathAndSizeTriplet, HoodieIndexDefinition indexDefinition,
-                                                               HoodieTableMetaClient metaClient, int parallelism, HoodieSchema tableSchema, HoodieSchema readerSchema,
-                                                               StorageConfiguration<?> storageConf, String instantTime) {
-    throw new HoodieNotSupportedException("Expression index not supported for Java metadata table writer yet.");
   }
 
   @Override

--- a/hudi-client/hudi-java-client/src/test/java/org/apache/hudi/client/TestJavaHoodieBackedMetadata.java
+++ b/hudi-client/hudi-java-client/src/test/java/org/apache/hudi/client/TestJavaHoodieBackedMetadata.java
@@ -2895,7 +2895,7 @@ public class TestJavaHoodieBackedMetadata extends TestHoodieMetadataBase {
       // check if the last instant is restore, then the metadata table should have only the partitions that are not deleted
       metaClient.reloadActiveTimeline().getReverseOrderedInstants().findFirst().ifPresent(instant -> {
         if (instant.getAction().equals(HoodieActiveTimeline.RESTORE_ACTION)) {
-          metadataWriter.getEnabledPartitionTypes().stream().filter(partitionType -> !MetadataPartitionType.shouldDeletePartitionOnRestore(partitionType.getPartitionPath()))
+          metadataWriter.getEnabledIndexerMap().keySet().stream().filter(partitionType -> !MetadataPartitionType.shouldDeletePartitionOnRestore(partitionType.getPartitionPath()))
               .forEach(partitionType -> assertTrue(metadataTablePartitions.contains(partitionType.getPartitionPath())));
         }
       });

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/client/utils/SparkMetadataWriterUtils.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/client/utils/SparkMetadataWriterUtils.java
@@ -65,6 +65,7 @@ import org.apache.hudi.metadata.HoodieIndexVersion;
 import org.apache.hudi.metadata.HoodieMetadataWriteUtils;
 import org.apache.hudi.metadata.HoodieTableMetadata;
 import org.apache.hudi.metadata.HoodieTableMetadataUtil;
+import org.apache.hudi.metadata.model.FileInfoAndPartition;
 import org.apache.hudi.stats.HoodieColumnRangeMetadata;
 import org.apache.hudi.stats.SparkValueMetadataUtils;
 import org.apache.hudi.stats.ValueMetadata;
@@ -260,20 +261,21 @@ public class SparkMetadataWriterUtils {
   /**
    * Generates expression index records
    *
-   * @param partitionFilePathAndSizeTriplet Triplet of file path, file size and partition name to which file belongs
-   * @param indexDefinition                 Hoodie Index Definition for the expression index for which records need to be generated
-   * @param metaClient                      Hoodie Table Meta Client
-   * @param parallelism                     Parallelism to use for engine operations
-   * @param readerSchema                    Schema of reader
-   * @param instantTime                     Instant time
-   * @param engineContext                   HoodieEngineContext
-   * @param dataWriteConfig                 Write Config for the data table
-   * @param partitionRecordsFunctionOpt     Function used to generate partition stat records for the EI. It takes the column range metadata generated for the provided partition files as input
+   * @param filesToIndex                Triplet of file path, file size and partition name to which file belongs
+   * @param indexDefinition             Hoodie Index Definition for the expression index for which records need to be generated
+   * @param metaClient                  Hoodie Table Meta Client
+   * @param parallelism                 Parallelism to use for engine operations
+   * @param tableSchema                 Table schema
+   * @param readerSchema                Schema of reader
+   * @param instantTime                 Instant time
+   * @param engineContext               HoodieEngineContext
+   * @param dataWriteConfig             Write Config for the data table
+   * @param partitionRecordsFunctionOpt Function used to generate partition stat records for the EI. It takes the column range metadata generated for the provided partition files as input
    *                                        and uses those to generate the final partition stats
    * @return ExpressionIndexComputationMetadata containing both EI column stat records and partition stat records if partitionRecordsFunctionOpt is provided
    */
   public static ExpressionIndexComputationMetadata getExprIndexRecords(
-      List<Pair<String, Pair<String, Long>>> partitionFilePathAndSizeTriplet, HoodieIndexDefinition indexDefinition,
+      List<FileInfoAndPartition> filesToIndex, HoodieIndexDefinition indexDefinition,
       HoodieTableMetaClient metaClient, int parallelism, HoodieSchema tableSchema, HoodieSchema readerSchema, String instantTime,
       HoodieEngineContext engineContext, HoodieWriteConfig dataWriteConfig,
       Option<Function<HoodiePairData<String, HoodieColumnRangeMetadata<Comparable>>, HoodieData<HoodieRecord>>> partitionRecordsFunctionOpt) {
@@ -290,8 +292,8 @@ public class SparkMetadataWriterUtils {
 
     ReaderContextFactory<InternalRow> readerContextFactory = engineContext.getReaderContextFactory(metaClient);
     // Read records and append expression index metadata to every row
-    HoodieData<Row> rowData = sparkEngineContext.parallelize(partitionFilePathAndSizeTriplet, parallelism)
-        .flatMap((SerializableFunction<Pair<String, Pair<String, Long>>, Iterator<Row>>) entry ->
+    HoodieData<Row> rowData = sparkEngineContext.parallelize(filesToIndex, parallelism)
+        .flatMap((SerializableFunction<FileInfoAndPartition, Iterator<Row>>) entry ->
             getExpressionIndexRecordsIterator(readerContextFactory.getContext(), metaClient, tableSchema, readerSchema, dataWriteConfig, entry));
 
     // Generate dataset with expression index metadata
@@ -319,12 +321,11 @@ public class SparkMetadataWriterUtils {
   }
 
   private static Iterator<Row> getExpressionIndexRecordsIterator(HoodieReaderContext<InternalRow> readerContext, HoodieTableMetaClient metaClient,
-                                                                 HoodieSchema tableSchema, HoodieSchema readerSchema, HoodieWriteConfig dataWriteConfig, Pair<String, Pair<String, Long>> entry) {
-    String partition = entry.getKey();
-    Pair<String, Long> filePathSizePair = entry.getValue();
-    String filePath = filePathSizePair.getKey();
+                                                                 HoodieSchema tableSchema, HoodieSchema readerSchema, HoodieWriteConfig dataWriteConfig, FileInfoAndPartition entry) {
+    String partition = entry.partitionPath();
+    String filePath = entry.name();
     String relativeFilePath = FSUtils.getRelativePartitionPath(metaClient.getBasePath(), new StoragePath(filePath));
-    long fileSize = filePathSizePair.getValue();
+    long fileSize = entry.size();
     boolean isBaseFile = FSUtils.isBaseFile(new StoragePath(filePath.substring(filePath.lastIndexOf("/") + 1)));
     Stream<HoodieLogFile> logFileStream;
     Option<HoodieBaseFile> baseFileOption;

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/metadata/SparkHoodieBackedTableMetadataWriter.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/metadata/SparkHoodieBackedTableMetadataWriter.java
@@ -38,7 +38,6 @@ import org.apache.hudi.common.model.HoodieRecord;
 import org.apache.hudi.common.model.HoodieTableType;
 import org.apache.hudi.common.model.WriteOperationType;
 import org.apache.hudi.common.schema.HoodieSchema;
-import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.common.table.TableSchemaResolver;
 import org.apache.hudi.common.util.CommitUtils;
 import org.apache.hudi.common.util.Option;
@@ -47,7 +46,8 @@ import org.apache.hudi.config.HoodieWriteConfig;
 import org.apache.hudi.data.HoodieJavaRDD;
 import org.apache.hudi.index.HoodieSparkIndexClient;
 import org.apache.hudi.index.expression.HoodieSparkExpressionIndex;
-import org.apache.hudi.index.expression.HoodieSparkExpressionIndex.ExpressionIndexComputationMetadata;
+import org.apache.hudi.metadata.index.SparkExpressionIndexRecordGenerator;
+import org.apache.hudi.metadata.model.FileInfoAndPartition;
 import org.apache.hudi.metrics.DistributedRegistry;
 import org.apache.hudi.metrics.MetricsReporterType;
 import org.apache.hudi.stats.HoodieColumnRangeMetadata;
@@ -124,7 +124,8 @@ public class SparkHoodieBackedTableMetadataWriter extends HoodieBackedTableMetad
                                        HoodieEngineContext engineContext,
                                        Option<String> inflightInstantTimestamp,
                                        boolean streamingWrites) {
-    super(hadoopConf, writeConfig, failedWritesCleaningPolicy, engineContext, inflightInstantTimestamp, streamingWrites);
+    super(hadoopConf, writeConfig, failedWritesCleaningPolicy, engineContext,
+        new SparkExpressionIndexRecordGenerator(engineContext, writeConfig), inflightInstantTimestamp, streamingWrites);
   }
 
   @Override
@@ -234,7 +235,7 @@ public class SparkHoodieBackedTableMetadataWriter extends HoodieBackedTableMetad
    */
   @Override
   protected HoodieData<HoodieRecord> getExpressionIndexUpdates(HoodieCommitMetadata commitMetadata, String indexPartition, String instantTime) throws Exception {
-    HoodieIndexDefinition indexDefinition = getIndexDefinition(indexPartition);
+    HoodieIndexDefinition indexDefinition = HoodieTableMetadataUtil.getHoodieIndexDefinition(indexPartition, dataMetaClient);
     boolean isExprIndexUsingColumnStats = indexDefinition.getIndexType().equals(PARTITION_NAME_COLUMN_STATS);
     Option<Function<HoodiePairData<String, HoodieColumnRangeMetadata<Comparable>>, HoodieData<HoodieRecord>>> partitionRecordsFunctionOpt = Option.empty();
     if (isExprIndexUsingColumnStats) {
@@ -250,10 +251,10 @@ public class SparkHoodieBackedTableMetadataWriter extends HoodieBackedTableMetad
     }
 
     // Step 1: Generate partition name, file path and size triplets from the newly created files in the commit metadata
-    List<Pair<String, Pair<String, Long>>> partitionFilePathPairs = new ArrayList<>();
-    commitMetadata.getPartitionToWriteStats().forEach((dataPartition, writeStats) -> writeStats.forEach(writeStat -> partitionFilePathPairs.add(
-        Pair.of(writeStat.getPartitionPath(), Pair.of(new StoragePath(dataMetaClient.getBasePath(), writeStat.getPath()).toString(), writeStat.getFileSizeInBytes())))));
-    int parallelism = Math.min(partitionFilePathPairs.size(), dataWriteConfig.getMetadataConfig().getExpressionIndexParallelism());
+    List<FileInfoAndPartition> filesToIndex = new ArrayList<>();
+    commitMetadata.getPartitionToWriteStats().forEach((dataPartition, writeStats) -> writeStats.forEach(writeStat -> filesToIndex.add(
+        FileInfoAndPartition.of(writeStat.getPartitionPath(), new StoragePath(dataMetaClient.getBasePath(), writeStat.getPath()).toString(), writeStat.getFileSizeInBytes()))));
+    int parallelism = Math.min(filesToIndex.size(), dataWriteConfig.getMetadataConfig().getExpressionIndexParallelism());
     HoodieSchema tableSchema = new TableSchemaResolver(dataMetaClient).getTableSchema();
     HoodieSchema readerSchema = getProjectedSchemaForExpressionIndex(indexDefinition, dataMetaClient, tableSchema);
     // Step 2: Compute the expression index column stat and partition stat records for these newly created files
@@ -262,28 +263,11 @@ public class SparkHoodieBackedTableMetadataWriter extends HoodieBackedTableMetad
     // In the partitionRecordsFunctionOpt function we merge the expression index records from the new files created in the commit metadata
     // with the expression index records from the unmodified files to get the new partition stat records
     HoodieSparkExpressionIndex.ExpressionIndexComputationMetadata expressionIndexComputationMetadata =
-        SparkMetadataWriterUtils.getExprIndexRecords(partitionFilePathPairs, indexDefinition, dataMetaClient, parallelism, tableSchema, readerSchema, instantTime, engineContext, dataWriteConfig,
+        SparkMetadataWriterUtils.getExprIndexRecords(filesToIndex, indexDefinition, dataMetaClient, parallelism, tableSchema, readerSchema, instantTime, engineContext, dataWriteConfig,
             partitionRecordsFunctionOpt);
     return expressionIndexComputationMetadata.getPartitionStatRecordsOpt().isPresent()
         ? expressionIndexComputationMetadata.getExpressionIndexRecords().union(expressionIndexComputationMetadata.getPartitionStatRecordsOpt().get())
         : expressionIndexComputationMetadata.getExpressionIndexRecords();
-  }
-
-  @Override
-  protected HoodieData<HoodieRecord> getExpressionIndexRecords(List<Pair<String, Pair<String, Long>>> partitionFilePathAndSizeTriplet,
-                                                               HoodieIndexDefinition indexDefinition,
-                                                               HoodieTableMetaClient metaClient, int parallelism,
-                                                               HoodieSchema tableSchema, HoodieSchema readerSchema, StorageConfiguration<?> storageConf,
-                                                               String instantTime) {
-    ExpressionIndexComputationMetadata expressionIndexComputationMetadata = SparkMetadataWriterUtils.getExprIndexRecords(partitionFilePathAndSizeTriplet, indexDefinition,
-        metaClient, parallelism, tableSchema, readerSchema, instantTime, engineContext, dataWriteConfig,
-        Option.of(rangeMetadata ->
-            HoodieTableMetadataUtil.collectAndProcessExprIndexPartitionStatRecords(rangeMetadata, true, Option.of(indexDefinition.getIndexName()))));
-    HoodieData<HoodieRecord> exprIndexRecords = expressionIndexComputationMetadata.getExpressionIndexRecords();
-    if (indexDefinition.getIndexType().equals(PARTITION_NAME_COLUMN_STATS)) {
-      exprIndexRecords = exprIndexRecords.union(expressionIndexComputationMetadata.getPartitionStatRecordsOpt().get());
-    }
-    return exprIndexRecords;
   }
 
   protected SparkRDDMetadataWriteClient getSparkWriteClient(Option<BaseHoodieWriteClient<?, JavaRDD<HoodieRecord>, ?, JavaRDD<WriteStatus>>> writeClientOpt) {

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/metadata/SparkHoodieBackedTableMetadataWriter.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/metadata/SparkHoodieBackedTableMetadataWriter.java
@@ -24,52 +24,38 @@ import org.apache.hudi.client.SparkRDDMetadataWriteClient;
 import org.apache.hudi.client.SparkRDDWriteClient;
 import org.apache.hudi.client.WriteStatus;
 import org.apache.hudi.client.common.HoodieSparkEngineContext;
-import org.apache.hudi.client.utils.SparkMetadataWriterUtils;
 import org.apache.hudi.common.data.HoodieData;
-import org.apache.hudi.common.data.HoodiePairData;
 import org.apache.hudi.common.engine.EngineType;
 import org.apache.hudi.common.engine.HoodieEngineContext;
 import org.apache.hudi.common.metrics.Registry;
-import org.apache.hudi.common.model.HoodieCommitMetadata;
 import org.apache.hudi.common.model.HoodieFailedWritesCleaningPolicy;
 import org.apache.hudi.common.model.HoodieFileGroupId;
-import org.apache.hudi.common.model.HoodieIndexDefinition;
 import org.apache.hudi.common.model.HoodieRecord;
 import org.apache.hudi.common.model.HoodieTableType;
 import org.apache.hudi.common.model.WriteOperationType;
-import org.apache.hudi.common.schema.HoodieSchema;
-import org.apache.hudi.common.table.TableSchemaResolver;
 import org.apache.hudi.common.util.CommitUtils;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.common.util.collection.Pair;
 import org.apache.hudi.config.HoodieWriteConfig;
 import org.apache.hudi.data.HoodieJavaRDD;
 import org.apache.hudi.index.HoodieSparkIndexClient;
-import org.apache.hudi.index.expression.HoodieSparkExpressionIndex;
 import org.apache.hudi.metadata.index.SparkExpressionIndexRecordGenerator;
-import org.apache.hudi.metadata.model.FileInfoAndPartition;
+import org.apache.hudi.metadata.index.model.IndexPartitionAndRecords;
 import org.apache.hudi.metrics.DistributedRegistry;
 import org.apache.hudi.metrics.MetricsReporterType;
-import org.apache.hudi.stats.HoodieColumnRangeMetadata;
 import org.apache.hudi.storage.StorageConfiguration;
-import org.apache.hudi.storage.StoragePath;
 import org.apache.hudi.table.BulkInsertPartitioner;
 
 import lombok.extern.slf4j.Slf4j;
 import org.apache.spark.api.java.JavaRDD;
 
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.Map;
-import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import static org.apache.hudi.common.model.HoodieFailedWritesCleaningPolicy.EAGER;
 import static org.apache.hudi.common.table.timeline.HoodieTimeline.DELTA_COMMIT_ACTION;
 import static org.apache.hudi.common.table.timeline.HoodieTimeline.REPLACE_COMMIT_ACTION;
-import static org.apache.hudi.metadata.HoodieTableMetadataUtil.PARTITION_NAME_COLUMN_STATS;
-import static org.apache.hudi.metadata.HoodieTableMetadataUtil.getProjectedSchemaForExpressionIndex;
 
 @Slf4j
 public class SparkHoodieBackedTableMetadataWriter extends HoodieBackedTableMetadataWriter<JavaRDD<HoodieRecord>, JavaRDD<WriteStatus>> {
@@ -146,8 +132,8 @@ public class SparkHoodieBackedTableMetadataWriter extends HoodieBackedTableMetad
   }
 
   @Override
-  protected void commit(String instantTime, Map<String, HoodieData<HoodieRecord>> partitionRecordsMap) {
-    commitInternal(instantTime, partitionRecordsMap, false, Option.empty());
+  protected void commit(String instantTime, List<IndexPartitionAndRecords> partitionRecords) {
+    commitInternal(instantTime, partitionRecords, false, Option.empty());
   }
 
   @Override
@@ -209,7 +195,7 @@ public class SparkHoodieBackedTableMetadataWriter extends HoodieBackedTableMetad
   protected void bulkCommit(String instantTime, String partitionPath, HoodieData<HoodieRecord> records,
       MetadataTableFileGroupIndexParser indexParser) {
     SparkHoodieMetadataBulkInsertPartitioner partitioner = new SparkHoodieMetadataBulkInsertPartitioner(indexParser);
-    commitInternal(instantTime, Collections.singletonMap(partitionPath, records), true, Option.of(partitioner));
+    commitInternal(instantTime, Collections.singletonList(IndexPartitionAndRecords.of(partitionPath, records)), true, Option.of(partitioner));
   }
 
   @Override
@@ -222,52 +208,6 @@ public class SparkHoodieBackedTableMetadataWriter extends HoodieBackedTableMetad
     writeClient.startCommitForMetadataTable(metadataMetaClient, instantTime, actionType);
     HoodieWriteResult result = writeClient.deletePartitions(partitionsToDrop, instantTime);
     writeClient.commit(instantTime, result.getWriteStatuses(), Option.empty(), REPLACE_COMMIT_ACTION, result.getPartitionToReplaceFileIds());
-  }
-
-  /**
-   * Loads the file slices touched by the commit due to given instant time and returns the records for the expression index.
-   * This generates partition stat record updates along with EI column stat update records. Partition stat record updates are generated
-   * by reloading the affected partitions column range metadata from EI and then merging it with partition stat record from the updated data.
-   *
-   * @param commitMetadata {@code HoodieCommitMetadata}
-   * @param indexPartition partition name of the expression index
-   * @param instantTime    timestamp at of the current update commit
-   */
-  @Override
-  protected HoodieData<HoodieRecord> getExpressionIndexUpdates(HoodieCommitMetadata commitMetadata, String indexPartition, String instantTime) throws Exception {
-    HoodieIndexDefinition indexDefinition = HoodieTableMetadataUtil.getHoodieIndexDefinition(indexPartition, dataMetaClient);
-    boolean isExprIndexUsingColumnStats = indexDefinition.getIndexType().equals(PARTITION_NAME_COLUMN_STATS);
-    Option<Function<HoodiePairData<String, HoodieColumnRangeMetadata<Comparable>>, HoodieData<HoodieRecord>>> partitionRecordsFunctionOpt = Option.empty();
-    if (isExprIndexUsingColumnStats) {
-      // Fetch column range metadata for affected partitions in the commit
-      HoodiePairData<String, HoodieColumnRangeMetadata<Comparable>> exprIndexPartitionStatUpdates =
-          SparkMetadataWriterUtils.getExpressionIndexPartitionStatsForExistingFiles(
-                  commitMetadata, indexPartition, engineContext, getTableMetadata(), dataMetaClient, dataWriteConfig.getMetadataConfig(),
-                  Option.of(dataWriteConfig.getRecordMerger().getRecordType()), instantTime, dataWriteConfig)
-              .flatMapValues(List::iterator);
-      // The function below merges the column range metadata from the updated data with latest column range metadata of affected partition computed above
-      partitionRecordsFunctionOpt = Option.of(rangeMetadata ->
-          HoodieTableMetadataUtil.collectAndProcessExprIndexPartitionStatRecords(exprIndexPartitionStatUpdates.union(rangeMetadata), true, Option.of(indexDefinition.getIndexName())));
-    }
-
-    // Step 1: Generate partition name, file path and size triplets from the newly created files in the commit metadata
-    List<FileInfoAndPartition> filesToIndex = new ArrayList<>();
-    commitMetadata.getPartitionToWriteStats().forEach((dataPartition, writeStats) -> writeStats.forEach(writeStat -> filesToIndex.add(
-        FileInfoAndPartition.of(writeStat.getPartitionPath(), new StoragePath(dataMetaClient.getBasePath(), writeStat.getPath()).toString(), writeStat.getFileSizeInBytes()))));
-    int parallelism = Math.min(filesToIndex.size(), dataWriteConfig.getMetadataConfig().getExpressionIndexParallelism());
-    HoodieSchema tableSchema = new TableSchemaResolver(dataMetaClient).getTableSchema();
-    HoodieSchema readerSchema = getProjectedSchemaForExpressionIndex(indexDefinition, dataMetaClient, tableSchema);
-    // Step 2: Compute the expression index column stat and partition stat records for these newly created files
-    // partitionRecordsFunctionOpt - Function used to generate partition stats. These stats are generated only for expression index created using column stats
-    //
-    // In the partitionRecordsFunctionOpt function we merge the expression index records from the new files created in the commit metadata
-    // with the expression index records from the unmodified files to get the new partition stat records
-    HoodieSparkExpressionIndex.ExpressionIndexComputationMetadata expressionIndexComputationMetadata =
-        SparkMetadataWriterUtils.getExprIndexRecords(filesToIndex, indexDefinition, dataMetaClient, parallelism, tableSchema, readerSchema, instantTime, engineContext, dataWriteConfig,
-            partitionRecordsFunctionOpt);
-    return expressionIndexComputationMetadata.getPartitionStatRecordsOpt().isPresent()
-        ? expressionIndexComputationMetadata.getExpressionIndexRecords().union(expressionIndexComputationMetadata.getPartitionStatRecordsOpt().get())
-        : expressionIndexComputationMetadata.getExpressionIndexRecords();
   }
 
   protected SparkRDDMetadataWriteClient getSparkWriteClient(Option<BaseHoodieWriteClient<?, JavaRDD<HoodieRecord>, ?, JavaRDD<WriteStatus>>> writeClientOpt) {

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/metadata/SparkHoodieBackedTableMetadataWriterTableVersionSix.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/metadata/SparkHoodieBackedTableMetadataWriterTableVersionSix.java
@@ -40,6 +40,7 @@ import org.apache.hudi.data.HoodieJavaRDD;
 import org.apache.hudi.exception.HoodieNotSupportedException;
 import org.apache.hudi.index.HoodieSparkIndexClient;
 import org.apache.hudi.metadata.index.UnsupportedExpressionIndexRecordGenerator;
+import org.apache.hudi.metadata.index.model.IndexPartitionAndRecords;
 import org.apache.hudi.metrics.DistributedRegistry;
 import org.apache.hudi.metrics.MetricsReporterType;
 import org.apache.hudi.storage.StorageConfiguration;
@@ -51,7 +52,6 @@ import org.slf4j.LoggerFactory;
 
 import java.util.Collections;
 import java.util.List;
-import java.util.Map;
 import java.util.stream.Collectors;
 
 import static org.apache.hudi.common.model.HoodieFailedWritesCleaningPolicy.EAGER;
@@ -110,8 +110,8 @@ public class SparkHoodieBackedTableMetadataWriterTableVersionSix extends HoodieB
   }
 
   @Override
-  protected void commit(String instantTime, Map<String, HoodieData<HoodieRecord>> partitionRecordsMap) {
-    commitInternal(instantTime, partitionRecordsMap, false, Option.empty());
+  protected void commit(String instantTime, List<IndexPartitionAndRecords> partitionRecords) {
+    commitInternal(instantTime, partitionRecords, false, Option.empty());
   }
 
   @Override
@@ -155,7 +155,7 @@ public class SparkHoodieBackedTableMetadataWriterTableVersionSix extends HoodieB
       String instantTime, String partitionPath, HoodieData<HoodieRecord> records,
       MetadataTableFileGroupIndexParser indexParser) {
     SparkHoodieMetadataBulkInsertPartitioner partitioner = new SparkHoodieMetadataBulkInsertPartitioner(indexParser);
-    commitInternal(instantTime, Collections.singletonMap(partitionPath, records), true, Option.of(partitioner));
+    commitInternal(instantTime, Collections.singletonList(IndexPartitionAndRecords.of(partitionPath, records)), true, Option.of(partitioner));
   }
 
   @Override

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/metadata/SparkHoodieBackedTableMetadataWriterTableVersionSix.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/metadata/SparkHoodieBackedTableMetadataWriterTableVersionSix.java
@@ -30,19 +30,16 @@ import org.apache.hudi.common.engine.HoodieEngineContext;
 import org.apache.hudi.common.metrics.Registry;
 import org.apache.hudi.common.model.HoodieFailedWritesCleaningPolicy;
 import org.apache.hudi.common.model.HoodieFileGroupId;
-import org.apache.hudi.common.model.HoodieIndexDefinition;
 import org.apache.hudi.common.model.HoodieRecord;
 import org.apache.hudi.common.model.HoodieTableType;
 import org.apache.hudi.common.model.WriteOperationType;
-import org.apache.hudi.common.schema.HoodieSchema;
-import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.common.util.CommitUtils;
 import org.apache.hudi.common.util.Option;
-import org.apache.hudi.common.util.collection.Pair;
 import org.apache.hudi.config.HoodieWriteConfig;
 import org.apache.hudi.data.HoodieJavaRDD;
 import org.apache.hudi.exception.HoodieNotSupportedException;
 import org.apache.hudi.index.HoodieSparkIndexClient;
+import org.apache.hudi.metadata.index.UnsupportedExpressionIndexRecordGenerator;
 import org.apache.hudi.metrics.DistributedRegistry;
 import org.apache.hudi.metrics.MetricsReporterType;
 import org.apache.hudi.storage.StorageConfiguration;
@@ -92,7 +89,7 @@ public class SparkHoodieBackedTableMetadataWriterTableVersionSix extends HoodieB
                                        HoodieFailedWritesCleaningPolicy failedWritesCleaningPolicy,
                                        HoodieEngineContext engineContext,
                                        Option<String> inflightInstantTimestamp) {
-    super(hadoopConf, writeConfig, failedWritesCleaningPolicy, engineContext, inflightInstantTimestamp);
+    super(hadoopConf, writeConfig, failedWritesCleaningPolicy, engineContext, new UnsupportedExpressionIndexRecordGenerator(EngineType.SPARK), inflightInstantTimestamp);
   }
 
   @Override
@@ -186,12 +183,5 @@ public class SparkHoodieBackedTableMetadataWriterTableVersionSix extends HoodieB
   @Override
   protected void updateColumnsToIndexWithColStats(List<String> columnsToIndex) {
     new HoodieSparkIndexClient(dataWriteConfig, engineContext).createOrUpdateColumnStatsIndexDefinition(dataMetaClient, columnsToIndex);
-  }
-
-  @Override
-  protected HoodieData<HoodieRecord> getExpressionIndexRecords(List<Pair<String, Pair<String, Long>>> partitionFilePathAndSizeTriplet, HoodieIndexDefinition indexDefinition,
-                                                               HoodieTableMetaClient metaClient, int parallelism, HoodieSchema tableSchema, HoodieSchema readerSchema,
-                                                               StorageConfiguration<?> storageConf, String instantTime) {
-    throw new HoodieNotSupportedException("Expression index not supported for Java metadata table writer yet.");
   }
 }

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/metadata/index/SparkExpressionIndexRecordGenerator.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/metadata/index/SparkExpressionIndexRecordGenerator.java
@@ -21,26 +21,36 @@ package org.apache.hudi.metadata.index;
 
 import org.apache.hudi.client.utils.SparkMetadataWriterUtils;
 import org.apache.hudi.common.data.HoodieData;
+import org.apache.hudi.common.data.HoodiePairData;
 import org.apache.hudi.common.engine.EngineType;
 import org.apache.hudi.common.engine.HoodieEngineContext;
+import org.apache.hudi.common.model.HoodieCommitMetadata;
 import org.apache.hudi.common.model.HoodieIndexDefinition;
 import org.apache.hudi.common.model.HoodieRecord;
 import org.apache.hudi.common.schema.HoodieSchema;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.common.table.HoodieTableVersion;
+import org.apache.hudi.common.table.TableSchemaResolver;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.config.HoodieWriteConfig;
 import org.apache.hudi.exception.HoodieNotSupportedException;
+import org.apache.hudi.exception.HoodieSchemaNotFoundException;
 import org.apache.hudi.index.expression.HoodieSparkExpressionIndex;
+import org.apache.hudi.metadata.HoodieTableMetadata;
 import org.apache.hudi.metadata.HoodieTableMetadataUtil;
 import org.apache.hudi.metadata.model.FileInfoAndPartition;
+import org.apache.hudi.stats.HoodieColumnRangeMetadata;
 import org.apache.hudi.storage.StorageConfiguration;
+import org.apache.hudi.storage.StoragePath;
 
 import lombok.extern.slf4j.Slf4j;
 
+import java.util.ArrayList;
 import java.util.List;
+import java.util.function.Function;
 
 import static org.apache.hudi.metadata.HoodieTableMetadataUtil.PARTITION_NAME_COLUMN_STATS;
+import static org.apache.hudi.metadata.HoodieTableMetadataUtil.getProjectedSchemaForExpressionIndex;
 
 /**
  * Spark implementation of {@link ExpressionIndexRecordGenerator}.
@@ -48,12 +58,12 @@ import static org.apache.hudi.metadata.HoodieTableMetadataUtil.PARTITION_NAME_CO
 @Slf4j
 public class SparkExpressionIndexRecordGenerator implements ExpressionIndexRecordGenerator {
   private final HoodieEngineContext engineContext;
-  private final HoodieWriteConfig dataTableWriteConfig;
+  private final HoodieWriteConfig dataWriteConfig;
 
   public SparkExpressionIndexRecordGenerator(HoodieEngineContext engineContext,
-                                             HoodieWriteConfig dataTableWriteConfig) {
+                                             HoodieWriteConfig dataWriteConfig) {
     this.engineContext = engineContext;
-    this.dataTableWriteConfig = dataTableWriteConfig;
+    this.dataWriteConfig = dataWriteConfig;
   }
 
   @Override
@@ -62,7 +72,7 @@ public class SparkExpressionIndexRecordGenerator implements ExpressionIndexRecor
   }
 
   @Override
-  public HoodieData<HoodieRecord> generate(
+  public HoodieData<HoodieRecord> buildInitialization(
       List<FileInfoAndPartition> filesToIndex,
       HoodieIndexDefinition indexDefinition,
       HoodieTableMetaClient metaClient,
@@ -74,7 +84,7 @@ public class SparkExpressionIndexRecordGenerator implements ExpressionIndexRecor
       throw new HoodieNotSupportedException("Hudi tables prior to version 8 do not support expression index.");
     }
     HoodieSparkExpressionIndex.ExpressionIndexComputationMetadata expressionIndexComputationMetadata = SparkMetadataWriterUtils.getExprIndexRecords(
-        filesToIndex, indexDefinition, metaClient, parallelism, tableSchema, readerSchema, instantTime, engineContext, dataTableWriteConfig,
+        filesToIndex, indexDefinition, metaClient, parallelism, tableSchema, readerSchema, instantTime, engineContext, dataWriteConfig,
         Option.of(rangeMetadata ->
             HoodieTableMetadataUtil.collectAndProcessExprIndexPartitionStatRecords(rangeMetadata, true, Option.of(indexDefinition.getIndexName()))));
     HoodieData<HoodieRecord> exprIndexRecords = expressionIndexComputationMetadata.getExpressionIndexRecords();
@@ -82,5 +92,52 @@ public class SparkExpressionIndexRecordGenerator implements ExpressionIndexRecor
       exprIndexRecords = exprIndexRecords.union(expressionIndexComputationMetadata.getPartitionStatRecordsOpt().get());
     }
     return exprIndexRecords;
+  }
+
+  @Override
+  public HoodieData<HoodieRecord> buildUpdate(
+      HoodieTableMetaClient dataMetaClient,
+      HoodieTableMetadata tableMetadata,
+      HoodieCommitMetadata commitMetadata,
+      String indexPartition,
+      String instantTime) {
+    HoodieIndexDefinition indexDefinition = HoodieTableMetadataUtil.getHoodieIndexDefinition(indexPartition, dataMetaClient);
+    boolean isExprIndexUsingColumnStats = indexDefinition.getIndexType().equals(PARTITION_NAME_COLUMN_STATS);
+    Option<Function<HoodiePairData<String, HoodieColumnRangeMetadata<Comparable>>, HoodieData<HoodieRecord>>> partitionRecordsFunctionOpt = Option.empty();
+    if (isExprIndexUsingColumnStats) {
+      // Fetch column range metadata for affected partitions in the commit
+      HoodiePairData<String, HoodieColumnRangeMetadata<Comparable>> exprIndexPartitionStatUpdates =
+          SparkMetadataWriterUtils.getExpressionIndexPartitionStatsForExistingFiles(
+                  commitMetadata, indexPartition, engineContext, tableMetadata, dataMetaClient, dataWriteConfig.getMetadataConfig(),
+                  Option.of(dataWriteConfig.getRecordMerger().getRecordType()), instantTime, dataWriteConfig)
+              .flatMapValues(List::iterator);
+      // The function below merges the column range metadata from the updated data with latest column range metadata of affected partition computed above
+      partitionRecordsFunctionOpt = Option.of(rangeMetadata ->
+          HoodieTableMetadataUtil.collectAndProcessExprIndexPartitionStatRecords(exprIndexPartitionStatUpdates.union(rangeMetadata), true, Option.of(indexDefinition.getIndexName())));
+    }
+
+    // Step 1: Generate partition name, file path and size triplets from the newly created files in the commit metadata
+    List<FileInfoAndPartition> filesToIndex = new ArrayList<>();
+    commitMetadata.getPartitionToWriteStats().forEach((dataPartition, writeStats) -> writeStats.forEach(writeStat -> filesToIndex.add(
+        FileInfoAndPartition.of(writeStat.getPartitionPath(), new StoragePath(dataMetaClient.getBasePath(), writeStat.getPath()).toString(), writeStat.getFileSizeInBytes()))));
+    int parallelism = Math.min(filesToIndex.size(), dataWriteConfig.getMetadataConfig().getExpressionIndexParallelism());
+    HoodieSchema tableSchema = null;
+    try {
+      tableSchema = new TableSchemaResolver(dataMetaClient).getTableSchema();
+    } catch (Exception e) {
+      throw new HoodieSchemaNotFoundException("No schema found for table at " + dataMetaClient.getBasePath());
+    }
+    HoodieSchema readerSchema = getProjectedSchemaForExpressionIndex(indexDefinition, dataMetaClient, tableSchema);
+    // Step 2: Compute the expression index column stat and partition stat records for these newly created files
+    // partitionRecordsFunctionOpt - Function used to generate partition stats. These stats are generated only for expression index created using column stats
+    //
+    // In the partitionRecordsFunctionOpt function we merge the expression index records from the new files created in the commit metadata
+    // with the expression index records from the unmodified files to get the new partition stat records
+    HoodieSparkExpressionIndex.ExpressionIndexComputationMetadata expressionIndexComputationMetadata =
+        SparkMetadataWriterUtils.getExprIndexRecords(filesToIndex, indexDefinition, dataMetaClient, parallelism, tableSchema, readerSchema, instantTime, engineContext, dataWriteConfig,
+            partitionRecordsFunctionOpt);
+    return expressionIndexComputationMetadata.getPartitionStatRecordsOpt().isPresent()
+        ? expressionIndexComputationMetadata.getExpressionIndexRecords().union(expressionIndexComputationMetadata.getPartitionStatRecordsOpt().get())
+        : expressionIndexComputationMetadata.getExpressionIndexRecords();
   }
 }

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/metadata/index/SparkExpressionIndexRecordGenerator.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/metadata/index/SparkExpressionIndexRecordGenerator.java
@@ -1,0 +1,86 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.hudi.metadata.index;
+
+import org.apache.hudi.client.utils.SparkMetadataWriterUtils;
+import org.apache.hudi.common.data.HoodieData;
+import org.apache.hudi.common.engine.EngineType;
+import org.apache.hudi.common.engine.HoodieEngineContext;
+import org.apache.hudi.common.model.HoodieIndexDefinition;
+import org.apache.hudi.common.model.HoodieRecord;
+import org.apache.hudi.common.schema.HoodieSchema;
+import org.apache.hudi.common.table.HoodieTableMetaClient;
+import org.apache.hudi.common.table.HoodieTableVersion;
+import org.apache.hudi.common.util.Option;
+import org.apache.hudi.config.HoodieWriteConfig;
+import org.apache.hudi.exception.HoodieNotSupportedException;
+import org.apache.hudi.index.expression.HoodieSparkExpressionIndex;
+import org.apache.hudi.metadata.HoodieTableMetadataUtil;
+import org.apache.hudi.metadata.model.FileInfoAndPartition;
+import org.apache.hudi.storage.StorageConfiguration;
+
+import lombok.extern.slf4j.Slf4j;
+
+import java.util.List;
+
+import static org.apache.hudi.metadata.HoodieTableMetadataUtil.PARTITION_NAME_COLUMN_STATS;
+
+/**
+ * Spark implementation of {@link ExpressionIndexRecordGenerator}.
+ */
+@Slf4j
+public class SparkExpressionIndexRecordGenerator implements ExpressionIndexRecordGenerator {
+  private final HoodieEngineContext engineContext;
+  private final HoodieWriteConfig dataTableWriteConfig;
+
+  public SparkExpressionIndexRecordGenerator(HoodieEngineContext engineContext,
+                                             HoodieWriteConfig dataTableWriteConfig) {
+    this.engineContext = engineContext;
+    this.dataTableWriteConfig = dataTableWriteConfig;
+  }
+
+  @Override
+  public EngineType getEngineType() {
+    return EngineType.SPARK;
+  }
+
+  @Override
+  public HoodieData<HoodieRecord> generate(
+      List<FileInfoAndPartition> filesToIndex,
+      HoodieIndexDefinition indexDefinition,
+      HoodieTableMetaClient metaClient,
+      int parallelism, HoodieSchema tableSchema,
+      HoodieSchema readerSchema,
+      StorageConfiguration<?> storageConf,
+      String instantTime) {
+    if (metaClient.getTableConfig().getTableVersion().lesserThan(HoodieTableVersion.EIGHT)) {
+      throw new HoodieNotSupportedException("Hudi tables prior to version 8 do not support expression index.");
+    }
+    HoodieSparkExpressionIndex.ExpressionIndexComputationMetadata expressionIndexComputationMetadata = SparkMetadataWriterUtils.getExprIndexRecords(
+        filesToIndex, indexDefinition, metaClient, parallelism, tableSchema, readerSchema, instantTime, engineContext, dataTableWriteConfig,
+        Option.of(rangeMetadata ->
+            HoodieTableMetadataUtil.collectAndProcessExprIndexPartitionStatRecords(rangeMetadata, true, Option.of(indexDefinition.getIndexName()))));
+    HoodieData<HoodieRecord> exprIndexRecords = expressionIndexComputationMetadata.getExpressionIndexRecords();
+    if (indexDefinition.getIndexType().equals(PARTITION_NAME_COLUMN_STATS)) {
+      exprIndexRecords = exprIndexRecords.union(expressionIndexComputationMetadata.getPartitionStatRecordsOpt().get());
+    }
+    return exprIndexRecords;
+  }
+}

--- a/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieMetadataMetrics.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieMetadataMetrics.java
@@ -165,7 +165,7 @@ public class HoodieMetadataMetrics implements Serializable {
     gaugeOpt.ifPresent(gauge -> gauge.setValue(gauge.getValue() + value));
   }
 
-  protected void setMetric(String action, long value) {
+  public void setMetric(String action, long value) {
     metrics.registerGauge(action, value);
   }
 

--- a/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieTableMetadataUtil.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieTableMetadataUtil.java
@@ -56,6 +56,10 @@ import org.apache.hudi.common.engine.ReaderContextFactory;
 import org.apache.hudi.common.fs.FSUtils;
 import org.apache.hudi.common.function.SerializableBiFunction;
 import org.apache.hudi.common.model.FileSlice;
+import org.apache.hudi.metadata.model.FileAndPartitionFlag;
+import org.apache.hudi.metadata.model.FileInfo;
+import org.apache.hudi.metadata.model.FileInfoAndPartition;
+import org.apache.hudi.metadata.model.FileSliceAndPartition;
 import org.apache.hudi.common.model.HoodieBaseFile;
 import org.apache.hudi.common.model.HoodieCommitMetadata;
 import org.apache.hudi.common.model.HoodieDeltaWriteStat;
@@ -64,7 +68,6 @@ import org.apache.hudi.common.model.HoodieIndexDefinition;
 import org.apache.hudi.common.model.HoodieIndexMetadata;
 import org.apache.hudi.common.model.HoodieKey;
 import org.apache.hudi.common.model.HoodieLogFile;
-import org.apache.hudi.common.model.HoodiePartitionMetadata;
 import org.apache.hudi.common.model.HoodieRecord;
 import org.apache.hudi.common.model.HoodieRecord.HoodieRecordType;
 import org.apache.hudi.common.model.HoodieRecordGlobalLocation;
@@ -103,7 +106,6 @@ import org.apache.hudi.common.util.ValidationUtils;
 import org.apache.hudi.common.util.VisibleForTesting;
 import org.apache.hudi.common.util.collection.ClosableIterator;
 import org.apache.hudi.common.util.collection.Pair;
-import org.apache.hudi.common.util.collection.Tuple3;
 import org.apache.hudi.common.util.hash.ColumnIndexID;
 import org.apache.hudi.common.util.hash.PartitionIndexID;
 import org.apache.hudi.exception.HoodieException;
@@ -119,11 +121,9 @@ import org.apache.hudi.storage.HoodieStorage;
 import org.apache.hudi.storage.HoodieStorageUtils;
 import org.apache.hudi.storage.StorageConfiguration;
 import org.apache.hudi.storage.StoragePath;
-import org.apache.hudi.storage.StoragePathInfo;
 import org.apache.hudi.util.Lazy;
 
 import lombok.AccessLevel;
-import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.avro.AvroTypeException;
@@ -134,7 +134,6 @@ import javax.annotation.Nonnull;
 
 import java.io.FileNotFoundException;
 import java.io.IOException;
-import java.io.Serializable;
 import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.nio.ByteBuffer;
@@ -156,7 +155,6 @@ import java.util.Properties;
 import java.util.Set;
 import java.util.TreeMap;
 import java.util.UUID;
-import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
@@ -175,7 +173,6 @@ import static org.apache.hudi.common.model.HoodieRecord.HOODIE_META_COLUMNS_WITH
 import static org.apache.hudi.common.model.HoodieRecord.PARTITION_PATH_METADATA_FIELD;
 import static org.apache.hudi.common.model.HoodieRecord.RECORD_KEY_METADATA_FIELD;
 import static org.apache.hudi.common.table.timeline.InstantComparison.GREATER_THAN;
-import static org.apache.hudi.common.table.timeline.InstantComparison.LESSER_THAN_OR_EQUALS;
 import static org.apache.hudi.common.table.timeline.InstantComparison.compareTimestamps;
 import static org.apache.hudi.common.util.ConfigUtils.getReaderConfigs;
 import static org.apache.hudi.common.util.StringUtils.getUTF8Bytes;
@@ -607,42 +604,7 @@ public class HoodieTableMetadataUtil {
     });
   }
 
-  /**
-   * Convert the clean action to metadata records.
-   */
-  public static Map<String, HoodieData<HoodieRecord>> convertMetadataToRecords(HoodieEngineContext engineContext,
-                                                                               HoodieCleanMetadata cleanMetadata,
-                                                                               String instantTime,
-                                                                               HoodieTableMetaClient dataMetaClient,
-                                                                               HoodieMetadataConfig metadataConfig,
-                                                                               List<MetadataPartitionType> enabledPartitionTypes,
-                                                                               int bloomIndexParallelism,
-                                                                               Option<HoodieRecordType> recordTypeOpt) {
-    final Map<String, HoodieData<HoodieRecord>> partitionToRecordsMap = new HashMap<>();
-    final HoodieData<HoodieRecord> filesPartitionRecordsRDD = engineContext.parallelize(
-        convertMetadataToFilesPartitionRecords(cleanMetadata, instantTime), 1);
-    partitionToRecordsMap.put(MetadataPartitionType.FILES.getPartitionPath(), filesPartitionRecordsRDD);
-    if (enabledPartitionTypes.contains(MetadataPartitionType.BLOOM_FILTERS)) {
-      final HoodieData<HoodieRecord> metadataBloomFilterRecordsRDD =
-          convertMetadataToBloomFilterRecords(cleanMetadata, engineContext, instantTime, bloomIndexParallelism);
-      partitionToRecordsMap.put(MetadataPartitionType.BLOOM_FILTERS.getPartitionPath(), metadataBloomFilterRecordsRDD);
-    }
-
-    if (enabledPartitionTypes.contains(MetadataPartitionType.COLUMN_STATS)) {
-      final HoodieData<HoodieRecord> metadataColumnStatsRDD =
-          convertMetadataToColumnStatsRecords(cleanMetadata, engineContext,
-              dataMetaClient, metadataConfig, recordTypeOpt);
-      partitionToRecordsMap.put(MetadataPartitionType.COLUMN_STATS.getPartitionPath(), metadataColumnStatsRDD);
-    }
-    if (enabledPartitionTypes.contains(MetadataPartitionType.EXPRESSION_INDEX)) {
-      convertMetadataToExpressionIndexRecords(engineContext, cleanMetadata, instantTime, dataMetaClient, metadataConfig, bloomIndexParallelism, partitionToRecordsMap,
-          recordTypeOpt);
-    }
-
-    return partitionToRecordsMap;
-  }
-
-  private static void convertMetadataToExpressionIndexRecords(HoodieEngineContext engineContext, HoodieCleanMetadata cleanMetadata,
+  public static void convertMetadataToExpressionIndexRecords(HoodieEngineContext engineContext, HoodieCleanMetadata cleanMetadata,
                                                               String instantTime, HoodieTableMetaClient dataMetaClient,
                                                               HoodieMetadataConfig metadataConfig, int bloomIndexParallelism,
                                                               Map<String, HoodieData<HoodieRecord>> partitionToRecordsMap,
@@ -752,7 +714,7 @@ public class HoodieTableMetadataUtil {
   }
 
   public static Map<String, HoodieData<HoodieRecord>> convertMissingPartitionRecords(HoodieEngineContext engineContext,
-                                                                                     List<String> deletedPartitions, Map<String, Map<String, Long>> filesAdded,
+                                                                                     List<String> deletedPartitions, Map<String, List<FileInfo>> filesAdded,
                                                                                      Map<String, List<String>> filesDeleted, String instantTime) {
     List<HoodieRecord> records = new LinkedList<>();
     int[] fileDeleteCount = {0};
@@ -762,7 +724,8 @@ public class HoodieTableMetadataUtil {
       filesAddedCount[0] += filesToAdd.size();
       List<String> filesToDelete = filesDeleted.getOrDefault(partition, Collections.emptyList());
       fileDeleteCount[0] += filesToDelete.size();
-      HoodieRecord record = HoodieMetadataPayload.createPartitionFilesRecord(partition, filesToAdd, filesToDelete);
+      Map<String, Long> filesToAddMap = filesToAdd.stream().collect(Collectors.toMap(FileInfo::fileName, FileInfo::size));
+      HoodieRecord record = HoodieMetadataPayload.createPartitionFilesRecord(partition, filesToAddMap, filesToDelete);
       records.add(record);
     });
 
@@ -1193,7 +1156,7 @@ public class HoodieTableMetadataUtil {
    */
   private static List<HoodieRecord> convertMetadataToRollbackRecords(HoodieRollbackMetadata rollbackMetadata,
                                                                      String instantTime) {
-    Map<String, Map<String, Long>> partitionToAppendedFiles = new HashMap<>();
+    Map<String, List<FileInfoAndPartition>> partitionToAppendedFiles = new HashMap<>();
     processRollbackMetadata(rollbackMetadata, partitionToAppendedFiles);
     return convertFilesToFilesPartitionRecords(Collections.emptyMap(), partitionToAppendedFiles, instantTime, "Rollback");
   }
@@ -1208,35 +1171,32 @@ public class HoodieTableMetadataUtil {
    * @param partitionToAppendedFiles The {@code Map} to fill with files appended per partition and their sizes.
    */
   private static void processRollbackMetadata(HoodieRollbackMetadata rollbackMetadata,
-                                              Map<String, Map<String, Long>> partitionToAppendedFiles) {
+                                              Map<String, List<FileInfoAndPartition>> partitionToAppendedFiles) {
     rollbackMetadata.getPartitionMetadata().values().forEach(pm -> {
       // Has this rollback produced new files?
       boolean hasRollbackLogFiles = pm.getRollbackLogFiles() != null && !pm.getRollbackLogFiles().isEmpty();
       final String partition = pm.getPartitionPath();
       final String partitionId = getPartitionIdentifierForFilesPartition(partition);
 
-      BiFunction<Long, Long, Long> fileMergeFn = (oldSize, newSizeCopy) -> {
-        // if a file exists in both written log files and rollback log files, we want to pick the one that is higher
-        // as rollback file could have been updated after written log files are computed.
-        return oldSize > newSizeCopy ? oldSize : newSizeCopy;
-      };
-
       if (hasRollbackLogFiles) {
-        if (!partitionToAppendedFiles.containsKey(partitionId)) {
-          partitionToAppendedFiles.put(partitionId, new HashMap<>());
-        }
+        partitionToAppendedFiles.putIfAbsent(partitionId, new ArrayList<>());
+        Map<String, Long> currentFileToSize = partitionToAppendedFiles.get(partitionId).stream()
+            .collect(Collectors.toMap(FileInfoAndPartition::name, FileInfoAndPartition::size));
 
         // Extract appended file name from the absolute paths saved in getAppendFiles()
         pm.getRollbackLogFiles().forEach((path, size) -> {
           String fileName = new StoragePath(path).getName();
-          partitionToAppendedFiles.get(partitionId).merge(fileName, size, fileMergeFn);
+          currentFileToSize.merge(fileName, size, Long::max);
         });
 
         // Extract original log files from failed commit
         pm.getLogFilesFromFailedCommit().forEach((path, size) -> {
           String fileName = new StoragePath(path).getName();
-          partitionToAppendedFiles.get(partitionId).merge(fileName, size, fileMergeFn);
+          currentFileToSize.merge(fileName, size, Long::max);
         });
+        partitionToAppendedFiles.put(partitionId, currentFileToSize.entrySet().stream()
+            .map(e -> FileInfoAndPartition.of(partitionId, e.getKey(), e.getValue()))
+            .collect(Collectors.toList()));
       }
     });
   }
@@ -1245,7 +1205,7 @@ public class HoodieTableMetadataUtil {
    * Convert rollback action metadata to files partition records.
    */
   protected static List<HoodieRecord> convertFilesToFilesPartitionRecords(Map<String, List<String>> partitionToDeletedFiles,
-                                                                          Map<String, Map<String, Long>> partitionToAppendedFiles,
+                                                                          Map<String, List<FileInfoAndPartition>> partitionToAppendedFiles,
                                                                           String instantTime, String operation) {
     List<HoodieRecord> records = new ArrayList<>(partitionToDeletedFiles.size() + partitionToAppendedFiles.size());
     int[] fileChangeCount = {0, 0}; // deletes, appends
@@ -1255,7 +1215,8 @@ public class HoodieTableMetadataUtil {
 
       Map<String, Long> filesAdded = Collections.emptyMap();
       if (partitionToAppendedFiles.containsKey(partitionName)) {
-        filesAdded = partitionToAppendedFiles.remove(partitionName);
+        filesAdded = partitionToAppendedFiles.remove(partitionName).stream()
+            .collect(Collectors.toMap(FileInfoAndPartition::name, FileInfoAndPartition::size));
       }
 
       HoodieRecord record = HoodieMetadataPayload.createPartitionFilesRecord(partitionName, filesAdded,
@@ -1263,9 +1224,10 @@ public class HoodieTableMetadataUtil {
       records.add(record);
     });
 
-    partitionToAppendedFiles.forEach((partitionName, appendedFileMap) -> {
+    partitionToAppendedFiles.forEach((partitionName, appendedFiles) -> {
       final String partition = getPartitionIdentifierForFilesPartition(partitionName);
-      fileChangeCount[1] += appendedFileMap.size();
+      fileChangeCount[1] += appendedFiles.size();
+      Map<String, Long> appendedFileMap = appendedFiles.stream().collect(Collectors.toMap(FileInfoAndPartition::name, FileInfoAndPartition::size));
 
       // Validate that no appended file has been deleted
       checkState(
@@ -1308,20 +1270,20 @@ public class HoodieTableMetadataUtil {
    */
   public static HoodieData<HoodieRecord> convertFilesToBloomFilterRecords(HoodieEngineContext engineContext,
                                                                           Map<String, List<String>> partitionToDeletedFiles,
-                                                                          Map<String, Map<String, Long>> partitionToAppendedFiles,
+                                                                          Map<String, List<FileInfo>> partitionToAppendedFiles,
                                                                           String instantTime,
                                                                           HoodieTableMetaClient dataMetaClient,
                                                                           int bloomIndexParallelism,
                                                                           String bloomFilterType) {
     // Create the tuple (partition, filename, isDeleted) to handle both deletes and appends
-    final List<Tuple3<String, String, Boolean>> partitionFileFlagTupleList = fetchPartitionFileInfoTriplets(partitionToDeletedFiles, partitionToAppendedFiles);
+    final List<FileAndPartitionFlag> partitionFileFlagTupleList = fetchPartitionFileInfo(partitionToDeletedFiles, partitionToAppendedFiles);
 
     // Create records MDT
     int parallelism = Math.max(Math.min(partitionFileFlagTupleList.size(), bloomIndexParallelism), 1);
     return engineContext.parallelize(partitionFileFlagTupleList, parallelism).flatMap(partitionFileFlagTuple -> {
-      final String partitionName = partitionFileFlagTuple.f0;
-      final String filename = partitionFileFlagTuple.f1;
-      final boolean isDeleted = partitionFileFlagTuple.f2;
+      final String partitionName = partitionFileFlagTuple.partitionPath();
+      final String filename = partitionFileFlagTuple.fileName();
+      final boolean isDeleted = partitionFileFlagTuple.flag();
       if (!FSUtils.isBaseFile(new StoragePath(filename))) {
         log.info("Ignoring file {} as it is not a base file", filename);
         return Stream.<HoodieRecord>empty().iterator();
@@ -1342,7 +1304,7 @@ public class HoodieTableMetadataUtil {
       }
 
       return Stream.<HoodieRecord>of(HoodieMetadataPayload.createBloomFilterMetadataRecord(
-              partitionName, filename, instantTime, bloomFilterType, bloomFilterBuffer, partitionFileFlagTuple.f2))
+              partitionName, filename, instantTime, bloomFilterType, bloomFilterBuffer, isDeleted))
           .iterator();
     });
   }
@@ -1352,9 +1314,8 @@ public class HoodieTableMetadataUtil {
    */
   public static HoodieData<HoodieRecord> convertFilesToColumnStatsRecords(HoodieEngineContext engineContext,
                                                                           Map<String, List<String>> partitionToDeletedFiles,
-                                                                          Map<String, Map<String, Long>> partitionToAppendedFiles,
+                                                                          Map<String, List<FileInfo>> partitionToAppendedFiles,
                                                                           HoodieTableMetaClient dataMetaClient,
-                                                                          HoodieMetadataConfig metadataConfig,
                                                                           int columnStatsIndexParallelism,
                                                                           int maxReaderBufferSize,
                                                                           List<String> columnsToIndex) {
@@ -1364,14 +1325,14 @@ public class HoodieTableMetadataUtil {
     log.info("Indexing {} columns for column stats index", columnsToIndex.size());
 
     // Create the tuple (partition, filename, isDeleted) to handle both deletes and appends
-    final List<Tuple3<String, String, Boolean>> partitionFileFlagTupleList = fetchPartitionFileInfoTriplets(partitionToDeletedFiles, partitionToAppendedFiles);
+    final List<FileAndPartitionFlag> partitionFileFlagTupleList = fetchPartitionFileInfo(partitionToDeletedFiles, partitionToAppendedFiles);
 
     // Create records MDT
     int parallelism = Math.max(Math.min(partitionFileFlagTupleList.size(), columnStatsIndexParallelism), 1);
     return engineContext.parallelize(partitionFileFlagTupleList, parallelism).flatMap(partitionFileFlagTuple -> {
-      final String partitionPath = partitionFileFlagTuple.f0;
-      final String filename = partitionFileFlagTuple.f1;
-      final boolean isDeleted = partitionFileFlagTuple.f2;
+      final String partitionPath = partitionFileFlagTuple.partitionPath();
+      final String filename = partitionFileFlagTuple.fileName();
+      final boolean isDeleted = partitionFileFlagTuple.flag();
       return getColumnStatsRecords(partitionPath, filename, dataMetaClient, columnsToIndex, isDeleted, maxReaderBufferSize).iterator();
     });
   }
@@ -1388,19 +1349,19 @@ public class HoodieTableMetadataUtil {
     }
   }
 
-  private static List<Tuple3<String, String, Boolean>> fetchPartitionFileInfoTriplets(
+  private static List<FileAndPartitionFlag> fetchPartitionFileInfo(
       Map<String, List<String>> partitionToDeletedFiles,
-      Map<String, Map<String, Long>> partitionToAppendedFiles) {
+      Map<String, List<FileInfo>> partitionToAppendedFiles) {
     // Total number of files which are added or deleted
     final int totalFiles = partitionToDeletedFiles.values().stream().mapToInt(List::size).sum()
-        + partitionToAppendedFiles.values().stream().mapToInt(Map::size).sum();
-    final List<Tuple3<String, String, Boolean>> partitionFileFlagTupleList = new ArrayList<>(totalFiles);
+        + partitionToAppendedFiles.values().stream().mapToInt(List::size).sum();
+    final List<FileAndPartitionFlag> partitionFileFlagTupleList = new ArrayList<>(totalFiles);
     partitionToDeletedFiles.entrySet().stream()
-        .flatMap(entry -> entry.getValue().stream().map(deletedFile -> Tuple3.of(entry.getKey(), deletedFile, true)))
+        .flatMap(entry -> entry.getValue().stream().map(deletedFile -> FileAndPartitionFlag.of(entry.getKey(), deletedFile, true)))
         .collect(Collectors.toCollection(() -> partitionFileFlagTupleList));
     partitionToAppendedFiles.entrySet().stream()
         .flatMap(
-            entry -> entry.getValue().keySet().stream().map(addedFile -> Tuple3.of(entry.getKey(), addedFile, false)))
+            entry -> entry.getValue().stream().map(addedFile -> FileAndPartitionFlag.of(entry.getKey(), addedFile.fileName(), false)))
         .collect(Collectors.toCollection(() -> partitionFileFlagTupleList));
     return partitionFileFlagTupleList;
   }
@@ -2665,7 +2626,7 @@ public class HoodieTableMetadataUtil {
   }
 
   public static HoodieData<HoodieRecord> convertFilesToPartitionStatsRecords(HoodieEngineContext engineContext,
-                                                                             List<Pair<String, FileSlice>> partitionInfoList,
+                                                                             List<FileSliceAndPartition> partitionInfoList,
                                                                              HoodieMetadataConfig metadataConfig,
                                                                              HoodieTableMetaClient dataTableMetaClient,
                                                                              Lazy<Option<HoodieSchema>> lazyWriterSchemaOpt,
@@ -2684,8 +2645,8 @@ public class HoodieTableMetadataUtil {
 
     // Group by partition path and collect file names (BaseFile and LogFiles)
     List<Pair<String, Set<String>>> partitionToFileNames = partitionInfoList.stream()
-        .collect(Collectors.groupingBy(Pair::getLeft,
-            Collectors.mapping(pair -> extractFileNames(pair.getRight()), Collectors.toList())))
+        .collect(Collectors.groupingBy(FileSliceAndPartition::partitionPath,
+            Collectors.mapping(pair -> extractFileNames(pair.fileSlice()), Collectors.toList())))
         .entrySet().stream()
         .map(entry -> Pair.of(entry.getKey(),
             entry.getValue().stream().flatMap(Set::stream).collect(Collectors.toSet())))
@@ -3058,8 +3019,7 @@ public class HoodieTableMetadataUtil {
     return indexPartitions;
   }
 
-  static void createRecordIndexDefinition(HoodieTableMetaClient metaClient,
-                                          Map<String, String> options) {
+  public static void createRecordIndexDefinition(HoodieTableMetaClient metaClient, Map<String, String> options) {
     String indexName = PARTITION_NAME_RECORD_INDEX;
     HoodieTableVersion tableVersion = metaClient.getTableConfig().getTableVersion();
     HoodieIndexVersion indexVersion = HoodieIndexVersion.getCurrentVersion(tableVersion, MetadataPartitionType.RECORD_INDEX);
@@ -3071,61 +3031,6 @@ public class HoodieTableMetadataUtil {
         .withVersion(indexVersion)
         .build();
     metaClient.buildIndexDefinition(indexDefinition);
-  }
-
-  /**
-   * A class which represents a directory and the files and directories inside it.
-   * <p>
-   * A {@code PartitionFileInfo} object saves the name of the partition and various properties requires of each file
-   * required for initializing the metadata table. Saving limited properties reduces the total memory footprint when
-   * a very large number of files are present in the dataset being initialized.
-   */
-  @Getter(AccessLevel.PACKAGE)
-  public static class DirectoryInfo implements Serializable {
-
-    // Relative path of the directory (relative to the base directory)
-    private final String relativePath;
-    // Map of filenames within this partition to their respective sizes
-    private final Map<String, Long> filenameToSizeMap;
-    // List of directories within this partition
-    private final List<StoragePath> subDirectories = new ArrayList<>();
-    // Is this a hoodie partition
-    private boolean isHoodiePartition = false;
-
-    public DirectoryInfo(String relativePath, List<StoragePathInfo> pathInfos, String maxInstantTime, Set<String> pendingDataInstants) {
-      this(relativePath, pathInfos, maxInstantTime, pendingDataInstants, true);
-    }
-
-    /**
-     * When files are directly fetched from Metadata table we do not need to validate HoodiePartitions.
-     */
-    public DirectoryInfo(String relativePath, List<StoragePathInfo> pathInfos, String maxInstantTime, Set<String> pendingDataInstants,
-                         boolean validateHoodiePartitions) {
-      this.relativePath = relativePath;
-
-      // Pre-allocate with the maximum length possible
-      filenameToSizeMap = new HashMap<>(pathInfos.size());
-
-      // Presence of partition meta file implies this is a HUDI partition
-      // if input files are directly fetched from MDT, it may not contain the HoodiePartitionMetadata file. So, we can ignore the validation for isHoodiePartition.
-      isHoodiePartition = !validateHoodiePartitions || pathInfos.stream().anyMatch(status -> status.getPath().getName().startsWith(HoodiePartitionMetadata.HOODIE_PARTITION_METAFILE_PREFIX));
-      for (StoragePathInfo pathInfo : pathInfos) {
-        // Do not attempt to search for more subdirectories inside directories that are partitions
-        if (!isHoodiePartition && pathInfo.isDirectory()) {
-          // Ignore .hoodie directory as there cannot be any partitions inside it
-          if (!pathInfo.getPath().getName().equals(HoodieTableMetaClient.METAFOLDER_NAME)) {
-            this.subDirectories.add(pathInfo.getPath());
-          }
-        } else if (isHoodiePartition && FSUtils.isDataFile(pathInfo.getPath())) {
-          // Regular HUDI data file (base file or log file)
-          String dataFileCommitTime = FSUtils.getCommitTime(pathInfo.getPath().getName());
-          // Limit the file listings to files which were created by successful commits before the maxInstant time.
-          if (!pendingDataInstants.contains(dataFileCommitTime) && compareTimestamps(dataFileCommitTime, LESSER_THAN_OR_EQUALS, maxInstantTime)) {
-            filenameToSizeMap.put(pathInfo.getPath().getName(), pathInfo.getLength());
-          }
-        }
-      }
-    }
   }
 
   private static TypedProperties getFileGroupReaderPropertiesFromStorageConf(StorageConfiguration<?> storageConf) {

--- a/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieTableMetadataUtil.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/HoodieTableMetadataUtil.java
@@ -25,7 +25,6 @@ import org.apache.hudi.avro.model.BooleanWrapper;
 import org.apache.hudi.avro.model.DateWrapper;
 import org.apache.hudi.avro.model.DoubleWrapper;
 import org.apache.hudi.avro.model.FloatWrapper;
-import org.apache.hudi.avro.model.HoodieCleanMetadata;
 import org.apache.hudi.avro.model.HoodieMetadataColumnStats;
 import org.apache.hudi.avro.model.HoodieMetadataFileInfo;
 import org.apache.hudi.avro.model.HoodieMetadataRecord;
@@ -44,11 +43,8 @@ import org.apache.hudi.common.config.HoodieMetadataConfig;
 import org.apache.hudi.common.config.HoodieReaderConfig;
 import org.apache.hudi.common.config.HoodieStorageConfig;
 import org.apache.hudi.common.config.TypedProperties;
-import org.apache.hudi.common.data.HoodieAccumulator;
-import org.apache.hudi.common.data.HoodieAtomicLongAccumulator;
 import org.apache.hudi.common.data.HoodieData;
 import org.apache.hudi.common.data.HoodiePairData;
-import org.apache.hudi.common.engine.EngineType;
 import org.apache.hudi.common.engine.HoodieEngineContext;
 import org.apache.hudi.common.engine.HoodieLocalEngineContext;
 import org.apache.hudi.common.engine.HoodieReaderContext;
@@ -72,7 +68,6 @@ import org.apache.hudi.common.model.HoodieRecord;
 import org.apache.hudi.common.model.HoodieRecord.HoodieRecordType;
 import org.apache.hudi.common.model.HoodieRecordGlobalLocation;
 import org.apache.hudi.common.model.HoodieWriteStat;
-import org.apache.hudi.common.model.WriteOperationType;
 import org.apache.hudi.common.schema.HoodieSchema;
 import org.apache.hudi.common.schema.HoodieSchema.TimePrecision;
 import org.apache.hudi.common.schema.HoodieSchemaField;
@@ -186,7 +181,6 @@ import static org.apache.hudi.metadata.HoodieMetadataPayload.RECORD_INDEX_MISSIN
 import static org.apache.hudi.metadata.HoodieTableMetadata.EMPTY_PARTITION_NAME;
 import static org.apache.hudi.metadata.HoodieTableMetadata.NON_PARTITIONED_NAME;
 import static org.apache.hudi.metadata.HoodieTableMetadata.SOLO_COMMIT_TIMESTAMP;
-import static org.apache.hudi.metadata.MetadataPartitionType.fromPartitionPath;
 import static org.apache.hudi.metadata.MetadataPartitionType.isNewExpressionIndexDefinitionRequired;
 import static org.apache.hudi.metadata.MetadataPartitionType.isNewSecondaryIndexDefinitionRequired;
 import static org.apache.hudi.stats.ValueMetadata.getValueMetadata;
@@ -448,71 +442,6 @@ public class HoodieTableMetadataUtil {
     return metadataPartitionExists(basePath.toString(), context, partitionPath);
   }
 
-  /**
-   * Finds all new files/partitions created as part of commit and creates metadata table records for them.
-   *
-   * @param commitMetadata - Commit action metadata
-   * @param instantTime    - Commit action instant time
-   * @return List of metadata table records
-   */
-  public static List<HoodieRecord> convertMetadataToFilesPartitionRecords(HoodieCommitMetadata commitMetadata,
-                                                                          String instantTime) {
-    List<HoodieRecord> records = new ArrayList<>(commitMetadata.getPartitionToWriteStats().size());
-
-    // Add record bearing added partitions list
-    List<String> partitionsAdded = getPartitionsAdded(commitMetadata);
-
-    records.add(HoodieMetadataPayload.createPartitionListRecord(partitionsAdded));
-
-    // Update files listing records for each individual partition
-    HoodieAccumulator newFileCount = HoodieAtomicLongAccumulator.create();
-    List<HoodieRecord<HoodieMetadataPayload>> updatedPartitionFilesRecords =
-        commitMetadata.getPartitionToWriteStats().entrySet()
-            .stream()
-            .map(entry -> {
-              String partitionStatName = entry.getKey();
-              List<HoodieWriteStat> writeStats = entry.getValue();
-
-              HashMap<String, Long> updatedFilesToSizesMapping =
-                  writeStats.stream().reduce(new HashMap<>(writeStats.size()),
-                      (map, stat) -> {
-                        String pathWithPartition = stat.getPath();
-                        if (pathWithPartition == null) {
-                          // Empty partition
-                          log.warn("Unable to find path in write stat to update metadata table {}", stat);
-                          return map;
-                        }
-
-                        String fileName = FSUtils.getFileName(pathWithPartition, partitionStatName);
-
-                        // Since write-stats are coming in no particular order, if the same
-                        // file have previously been appended to w/in the txn, we simply pick max
-                        // of the sizes as reported after every write, since file-sizes are
-                        // monotonically increasing (ie file-size never goes down, unless deleted)
-                        map.merge(fileName, stat.getFileSizeInBytes(), Math::max);
-
-                        Map<String, Long> cdcPathAndSizes = stat.getCdcStats();
-                        if (cdcPathAndSizes != null && !cdcPathAndSizes.isEmpty()) {
-                          cdcPathAndSizes.forEach((key, value) -> map.put(FSUtils.getFileName(key, partitionStatName), value));
-                        }
-                        return map;
-                      },
-                      CollectionUtils::combine);
-
-              newFileCount.add(updatedFilesToSizesMapping.size());
-              return HoodieMetadataPayload.createPartitionFilesRecord(partitionStatName, updatedFilesToSizesMapping,
-                  Collections.emptyList());
-            })
-            .collect(Collectors.toList());
-
-    records.addAll(updatedPartitionFilesRecords);
-
-    log.info("Updating at {} from Commit/{}. #partitions_updated={}, #files_added={}", instantTime, commitMetadata.getOperationType(),
-        records.size(), newFileCount.value());
-
-    return records;
-  }
-
   private static List<String> getPartitionsAdded(HoodieCommitMetadata commitMetadata) {
     return commitMetadata.getPartitionToWriteStats().keySet().stream()
         // We need to make sure we properly handle case of non-partitioned tables
@@ -531,116 +460,6 @@ public class HoodieTableMetadataUtil {
         .map(HoodieCommitMetadata::getWritePartitionPaths)
         .flatMap(Collection::stream)
         .collect(Collectors.toSet());
-  }
-
-  /**
-   * Convert commit action metadata to bloom filter records.
-   *
-   * @param context                 - Engine context to use
-   * @param hoodieConfig            - Hudi configs
-   * @param commitMetadata          - Commit action metadata
-   * @param instantTime             - Action instant time
-   * @param dataMetaClient          - HoodieTableMetaClient for data
-   * @param bloomFilterType         - Type of generated bloom filter records
-   * @param bloomIndexParallelism   - Parallelism for bloom filter record generation
-   * @return HoodieData of metadata table records
-   */
-  public static HoodieData<HoodieRecord> convertMetadataToBloomFilterRecords(HoodieEngineContext context,
-                                                                             HoodieConfig hoodieConfig,
-                                                                             HoodieCommitMetadata commitMetadata,
-                                                                             String instantTime,
-                                                                             HoodieTableMetaClient dataMetaClient,
-                                                                             String bloomFilterType,
-                                                                             int bloomIndexParallelism) {
-    final List<HoodieWriteStat> allWriteStats = commitMetadata.getPartitionToWriteStats().values().stream()
-        .flatMap(Collection::stream).collect(Collectors.toList());
-    if (allWriteStats.isEmpty()) {
-      return context.emptyHoodieData();
-    }
-
-    final int parallelism = Math.max(Math.min(allWriteStats.size(), bloomIndexParallelism), 1);
-    HoodieData<HoodieWriteStat> allWriteStatsRDD = context.parallelize(allWriteStats, parallelism);
-    return allWriteStatsRDD.flatMap(hoodieWriteStat -> {
-      final String partition = hoodieWriteStat.getPartitionPath();
-
-      // For bloom filter index, delta writes do not change the base file bloom filter entries
-      if (hoodieWriteStat instanceof HoodieDeltaWriteStat) {
-        return Collections.emptyListIterator();
-      }
-
-      String pathWithPartition = hoodieWriteStat.getPath();
-      if (pathWithPartition == null) {
-        // Empty partition
-        log.error("Failed to find path in write stat to update metadata table {}", hoodieWriteStat);
-        return Collections.emptyListIterator();
-      }
-
-      String fileName = FSUtils.getFileName(pathWithPartition, partition);
-      if (!FSUtils.isBaseFile(new StoragePath(fileName))) {
-        return Collections.emptyListIterator();
-      }
-
-      final StoragePath writeFilePath = new StoragePath(dataMetaClient.getBasePath(), pathWithPartition);
-      try (HoodieFileReader fileReader = HoodieIOFactory.getIOFactory(dataMetaClient.getStorage())
-          .getReaderFactory(HoodieRecordType.AVRO).getFileReader(hoodieConfig, writeFilePath)) {
-        try {
-          final BloomFilter fileBloomFilter = fileReader.readBloomFilter();
-          if (fileBloomFilter == null) {
-            log.error("Failed to read bloom filter for {}", writeFilePath);
-            return Collections.emptyListIterator();
-          }
-          ByteBuffer bloomByteBuffer = ByteBuffer.wrap(getUTF8Bytes(fileBloomFilter.serializeToString()));
-          HoodieRecord record = HoodieMetadataPayload.createBloomFilterMetadataRecord(
-              partition, fileName, instantTime, bloomFilterType, bloomByteBuffer, false);
-          return Collections.singletonList(record).iterator();
-        } catch (Exception e) {
-          log.error("Failed to read bloom filter for {}", writeFilePath);
-          return Collections.emptyListIterator();
-        }
-      } catch (IOException e) {
-        log.error("Failed to get bloom filter for file: {}, write stat: {}", writeFilePath, hoodieWriteStat);
-      }
-      return Collections.emptyListIterator();
-    });
-  }
-
-  public static void convertMetadataToExpressionIndexRecords(HoodieEngineContext engineContext, HoodieCleanMetadata cleanMetadata,
-                                                              String instantTime, HoodieTableMetaClient dataMetaClient,
-                                                              HoodieMetadataConfig metadataConfig, int bloomIndexParallelism,
-                                                              Map<String, HoodieData<HoodieRecord>> partitionToRecordsMap,
-                                                              Option<HoodieRecordType> recordTypeOpt) {
-    Option<HoodieIndexMetadata> indexMetadata = dataMetaClient.getIndexMetadata();
-    if (indexMetadata.isPresent()) {
-      HoodieIndexMetadata metadata = indexMetadata.get();
-      Map<String, HoodieIndexDefinition> indexDefinitions = metadata.getIndexDefinitions();
-      if (indexDefinitions.isEmpty()) {
-        throw new HoodieMetadataException("Expression index metadata not found");
-      }
-      // iterate over each index definition and check:
-      // if it is an expression index using column_stats, then follow the same approach as column_stats
-      // if it is an expression index using bloom_filters, then follow the same approach as bloom_filters
-      // else throw an exception
-      for (Map.Entry<String, HoodieIndexDefinition> entry : indexDefinitions.entrySet()) {
-        String indexName = entry.getKey();
-        HoodieIndexDefinition indexDefinition = entry.getValue();
-        if (MetadataPartitionType.EXPRESSION_INDEX.equals(fromPartitionPath(indexDefinition.getIndexName()))) {
-          if (indexDefinition.getIndexType().equalsIgnoreCase(PARTITION_NAME_BLOOM_FILTERS)) {
-            partitionToRecordsMap.put(indexName, convertMetadataToBloomFilterRecords(cleanMetadata, engineContext, instantTime, bloomIndexParallelism));
-          } else if (indexDefinition.getIndexType().equalsIgnoreCase(PARTITION_NAME_COLUMN_STATS)) {
-            HoodieMetadataConfig modifiedMetadataConfig = HoodieMetadataConfig.newBuilder()
-                .withProperties(metadataConfig.getProps())
-                .withColumnStatsIndexForColumns(String.join(",", indexDefinition.getSourceFields()))
-                .build();
-            partitionToRecordsMap.put(indexName,
-                convertMetadataToColumnStatsRecords(cleanMetadata, engineContext, dataMetaClient, modifiedMetadataConfig, recordTypeOpt));
-          } else {
-            throw new HoodieMetadataException("Unsupported expression index type");
-          }
-        }
-      }
-    } else {
-      throw new HoodieMetadataException("Expression index metadata not found");
-    }
   }
 
   /**
@@ -678,263 +497,6 @@ public class HoodieTableMetadataUtil {
       return timestampSchema.getPrecision().equals(TimePrecision.MILLIS);
     }
     return false;
-  }
-
-  /**
-   * Finds all files that were deleted as part of a clean and creates metadata table records for them.
-   *
-   * @param cleanMetadata
-   * @param instantTime
-   * @return a list of metadata table records
-   */
-  public static List<HoodieRecord> convertMetadataToFilesPartitionRecords(HoodieCleanMetadata cleanMetadata,
-                                                                          String instantTime) {
-    List<HoodieRecord> records = new LinkedList<>();
-    int[] fileDeleteCount = {0};
-    List<String> deletedPartitions = new ArrayList<>();
-    cleanMetadata.getPartitionMetadata().forEach((partitionName, partitionMetadata) -> {
-      boolean isPartitionDeleted = partitionMetadata.getIsPartitionDeleted();
-      // Files deleted from a partition
-      List<String> deletedFiles = partitionMetadata.getDeletePathPatterns();
-      records.add(HoodieMetadataPayload.createPartitionFilesRecord(partitionName, Collections.emptyMap(),
-          deletedFiles, isPartitionDeleted));
-      fileDeleteCount[0] += deletedFiles.size();
-      if (isPartitionDeleted) {
-        deletedPartitions.add(partitionName);
-      }
-    });
-
-    if (!deletedPartitions.isEmpty()) {
-      // if there are partitions to be deleted, add them to delete list
-      records.add(HoodieMetadataPayload.createPartitionListRecord(deletedPartitions, true));
-    }
-    log.info("Updating at {} from Clean. #partitions_updated={}, #files_deleted={}, #partitions_deleted={}",
-            instantTime, records.size(), fileDeleteCount[0], deletedPartitions.size());
-    return records;
-  }
-
-  public static Map<String, HoodieData<HoodieRecord>> convertMissingPartitionRecords(HoodieEngineContext engineContext,
-                                                                                     List<String> deletedPartitions, Map<String, List<FileInfo>> filesAdded,
-                                                                                     Map<String, List<String>> filesDeleted, String instantTime) {
-    List<HoodieRecord> records = new LinkedList<>();
-    int[] fileDeleteCount = {0};
-    int[] filesAddedCount = {0};
-
-    filesAdded.forEach((partition, filesToAdd) -> {
-      filesAddedCount[0] += filesToAdd.size();
-      List<String> filesToDelete = filesDeleted.getOrDefault(partition, Collections.emptyList());
-      fileDeleteCount[0] += filesToDelete.size();
-      Map<String, Long> filesToAddMap = filesToAdd.stream().collect(Collectors.toMap(FileInfo::fileName, FileInfo::size));
-      HoodieRecord record = HoodieMetadataPayload.createPartitionFilesRecord(partition, filesToAddMap, filesToDelete);
-      records.add(record);
-    });
-
-    // there could be partitions which only has missing deleted files.
-    filesDeleted.forEach((partition, filesToDelete) -> {
-      if (!filesAdded.containsKey(partition)) {
-        fileDeleteCount[0] += filesToDelete.size();
-        HoodieRecord record = HoodieMetadataPayload.createPartitionFilesRecord(partition, Collections.emptyMap(), filesToDelete);
-        records.add(record);
-      }
-    });
-
-    if (!deletedPartitions.isEmpty()) {
-      // if there are partitions to be deleted, add them to delete list
-      records.add(HoodieMetadataPayload.createPartitionListRecord(deletedPartitions, true));
-    }
-
-    log.info("Re-adding missing records at {} during Restore. #partitions_updated={}, #files_added={}, #files_deleted={}, #partitions_deleted={}",
-            instantTime, records.size(), filesAddedCount[0], fileDeleteCount[0], deletedPartitions.size());
-    return Collections.singletonMap(MetadataPartitionType.FILES.getPartitionPath(), engineContext.parallelize(records, 1));
-  }
-
-  /**
-   * Convert clean metadata to bloom filter index records.
-   *
-   * @param cleanMetadata           - Clean action metadata
-   * @param engineContext           - Engine context
-   * @param instantTime             - Clean action instant time
-   * @param bloomIndexParallelism   - Parallelism for bloom filter record generation
-   * @return List of bloom filter index records for the clean metadata
-   */
-  public static HoodieData<HoodieRecord> convertMetadataToBloomFilterRecords(HoodieCleanMetadata cleanMetadata,
-                                                                             HoodieEngineContext engineContext,
-                                                                             String instantTime,
-                                                                             int bloomIndexParallelism) {
-    List<Pair<String, String>> deleteFileList = new ArrayList<>();
-    cleanMetadata.getPartitionMetadata().forEach((partition, partitionMetadata) -> {
-      // Files deleted from a partition
-      List<String> deletedFiles = partitionMetadata.getDeletePathPatterns();
-      deletedFiles.forEach(entry -> {
-        final StoragePath deletedFilePath = new StoragePath(entry);
-        if (FSUtils.isBaseFile(deletedFilePath)) {
-          deleteFileList.add(Pair.of(partition, deletedFilePath.getName()));
-        }
-      });
-    });
-
-    final int parallelism = Math.max(Math.min(deleteFileList.size(), bloomIndexParallelism), 1);
-    HoodieData<Pair<String, String>> deleteFileListRDD = engineContext.parallelize(deleteFileList, parallelism);
-    return deleteFileListRDD.map(deleteFileInfoPair -> HoodieMetadataPayload.createBloomFilterMetadataRecord(
-        deleteFileInfoPair.getLeft(), deleteFileInfoPair.getRight(), instantTime, StringUtils.EMPTY_STRING,
-        ByteBuffer.allocate(0), true));
-  }
-
-  /**
-   * Convert clean metadata to column stats index records.
-   *
-   * @param cleanMetadata                    - Clean action metadata
-   * @param engineContext                    - Engine context
-   * @param dataMetaClient                   - HoodieTableMetaClient for data
-   * @param metadataConfig                   - HoodieMetadataConfig
-   * @return List of column stats index records for the clean metadata
-   */
-  public static HoodieData<HoodieRecord> convertMetadataToColumnStatsRecords(HoodieCleanMetadata cleanMetadata,
-                                                                             HoodieEngineContext engineContext,
-                                                                             HoodieTableMetaClient dataMetaClient,
-                                                                             HoodieMetadataConfig metadataConfig,
-                                                                             Option<HoodieRecordType> recordTypeOpt) {
-    List<Pair<String, String>> deleteFileList = new ArrayList<>();
-    cleanMetadata.getPartitionMetadata().forEach((partition, partitionMetadata) -> {
-      // Files deleted from a partition
-      List<String> deletedFiles = partitionMetadata.getDeletePathPatterns();
-      deletedFiles.forEach(entry -> deleteFileList.add(Pair.of(partition, entry)));
-    });
-    if (deleteFileList.isEmpty()) {
-      return engineContext.emptyHoodieData();
-    }
-
-    HoodieIndexVersion indexVersion = existingIndexVersionOrDefault(PARTITION_NAME_COLUMN_STATS, dataMetaClient);
-
-    List<String> columnsToIndex = new ArrayList<>(getColumnsToIndex(dataMetaClient.getTableConfig(), metadataConfig,
-        Lazy.lazily(() -> tryResolveSchemaForTable(dataMetaClient)), false, recordTypeOpt, indexVersion).keySet());
-
-    if (columnsToIndex.isEmpty()) {
-      // In case there are no columns to index, bail
-      log.info("No columns to index for column stats index.");
-      return engineContext.emptyHoodieData();
-    }
-
-    int parallelism = Math.max(Math.min(deleteFileList.size(), metadataConfig.getColumnStatsIndexParallelism()), 1);
-    return engineContext.parallelize(deleteFileList, parallelism)
-        .flatMap(deleteFileInfoPair -> {
-          String partitionPath = deleteFileInfoPair.getLeft();
-          String fileName = deleteFileInfoPair.getRight();
-          return getColumnStatsRecords(partitionPath, fileName, dataMetaClient, columnsToIndex, true).iterator();
-        });
-  }
-
-  @VisibleForTesting
-  public static <T> HoodieData<HoodieRecord> convertMetadataToRecordIndexRecords(HoodieEngineContext engineContext,
-                                                                                 HoodieCommitMetadata commitMetadata,
-                                                                                 HoodieMetadataConfig metadataConfig,
-                                                                                 HoodieTableMetaClient dataTableMetaClient,
-                                                                                 int writesFileIdEncoding,
-                                                                                 String instantTime,
-                                                                                 EngineType engineType) {
-    List<HoodieWriteStat> allWriteStats = commitMetadata.getPartitionToWriteStats().values().stream()
-        .flatMap(Collection::stream).collect(Collectors.toList());
-    // Return early if there are no write stats, or if the operation is a compaction.
-    if (allWriteStats.isEmpty() || commitMetadata.getOperationType() == WriteOperationType.COMPACT) {
-      return engineContext.emptyHoodieData();
-    }
-    // RLI cannot support logs having inserts with current offering. So, lets validate that.
-    if (allWriteStats.stream().anyMatch(writeStat -> {
-      String fileName = FSUtils.getFileName(writeStat.getPath(), writeStat.getPartitionPath());
-      return FSUtils.isLogFile(fileName) && writeStat.getNumInserts() > 0;
-    })) {
-      throw new HoodieIOException("RLI cannot support logs having inserts with current offering. Would recommend disabling Record Level Index");
-    }
-
-    try {
-      Map<String, List<HoodieWriteStat>> writeStatsByFileId = allWriteStats.stream().collect(Collectors.groupingBy(HoodieWriteStat::getFileId));
-      int parallelism = Math.max(Math.min(writeStatsByFileId.size(), metadataConfig.getRecordIndexMaxParallelism()), 1);
-      String basePath = dataTableMetaClient.getBasePath().toString();
-      HoodieFileFormat baseFileFormat = dataTableMetaClient.getTableConfig().getBaseFileFormat();
-      StorageConfiguration storageConfiguration = dataTableMetaClient.getStorageConf();
-      Option<HoodieSchema> writerSchemaOpt = tryResolveSchemaForTable(dataTableMetaClient);
-      Option<HoodieSchema> finalWriterSchemaOpt = writerSchemaOpt;
-      ReaderContextFactory<T> readerContextFactory = engineContext.getReaderContextFactory(dataTableMetaClient);
-      HoodieData<HoodieRecord> recordIndexRecords = engineContext.parallelize(new ArrayList<>(writeStatsByFileId.entrySet()), parallelism)
-          .flatMap(writeStatsByFileIdEntry -> {
-            String fileId = writeStatsByFileIdEntry.getKey();
-            List<HoodieWriteStat> writeStats = writeStatsByFileIdEntry.getValue();
-            // Partition the write stats into base file and log file write stats
-            List<HoodieWriteStat> baseFileWriteStats = writeStats.stream()
-                .filter(writeStat -> writeStat.getPath().endsWith(baseFileFormat.getFileExtension()))
-                .collect(Collectors.toList());
-            List<HoodieWriteStat> logFileWriteStats = writeStats.stream()
-                .filter(writeStat -> FSUtils.isLogFile(new StoragePath(writeStats.get(0).getPath())))
-                .collect(Collectors.toList());
-            // Ensure that only one of base file or log file write stats exists
-            checkState(baseFileWriteStats.isEmpty() || logFileWriteStats.isEmpty(),
-                "A single fileId cannot have both base file and log file write stats in the same commit. FileId: " + fileId);
-            // Process base file write stats
-            if (!baseFileWriteStats.isEmpty()) {
-              return baseFileWriteStats.stream()
-                  .flatMap(writeStat -> {
-                    HoodieStorage storage = HoodieStorageUtils.getStorage(new StoragePath(writeStat.getPath()), storageConfiguration);
-                    return CollectionUtils.toStream(BaseFileRecordParsingUtils
-                        .generateRLIMetadataHoodieRecordsForBaseFile(basePath, writeStat, writesFileIdEncoding, instantTime, storage, metadataConfig.isRecordLevelIndexEnabled()));
-                  })
-                  .iterator();
-            }
-            // Process log file write stats
-            if (!logFileWriteStats.isEmpty()) {
-              String partitionPath = logFileWriteStats.get(0).getPartitionPath();
-              List<String> currentLogFilePaths = logFileWriteStats.stream()
-                  .map(writeStat -> new StoragePath(dataTableMetaClient.getBasePath(), writeStat.getPath()).toString())
-                  .collect(Collectors.toList());
-              List<String> allLogFilePaths = logFileWriteStats.stream()
-                  .flatMap(writeStat -> {
-                    checkState(writeStat instanceof HoodieDeltaWriteStat, "Log file should be associated with a delta write stat");
-                    List<String> currentLogFiles = ((HoodieDeltaWriteStat) writeStat).getLogFiles().stream()
-                        .map(logFile -> new StoragePath(new StoragePath(dataTableMetaClient.getBasePath(), writeStat.getPartitionPath()), logFile).toString())
-                        .collect(Collectors.toList());
-                    return currentLogFiles.stream();
-                  })
-                  .collect(Collectors.toList());
-              // Extract revived and deleted keys
-              Pair<Set<String>, Set<String>> revivedAndDeletedKeys = getRevivedAndDeletedKeysFromMergedLogs(dataTableMetaClient, instantTime, allLogFilePaths, finalWriterSchemaOpt,
-                  currentLogFilePaths, partitionPath, readerContextFactory.getContext());
-              Set<String> revivedKeys = revivedAndDeletedKeys.getLeft();
-              Set<String> deletedKeys = revivedAndDeletedKeys.getRight();
-              // Process revived keys to create updates
-              List<HoodieRecord> revivedRecords = revivedKeys.stream()
-                  .map(recordKey -> HoodieMetadataPayload.createRecordIndexUpdate(recordKey, partitionPath, fileId, instantTime, writesFileIdEncoding))
-                  .collect(Collectors.toList());
-              // Process deleted keys to create deletes
-              List<HoodieRecord> deletedRecords = deletedKeys.stream()
-                  .map(key -> HoodieMetadataPayload.createRecordIndexDelete(key, partitionPath, metadataConfig.isRecordLevelIndexEnabled()))
-                  .collect(Collectors.toList());
-              // Combine all records into one list
-              List<HoodieRecord> allRecords = new ArrayList<>();
-              allRecords.addAll(revivedRecords);
-              allRecords.addAll(deletedRecords);
-              return allRecords.iterator();
-            }
-            log.warn("No base file or log file write stats found for fileId: {}", fileId);
-            return Collections.emptyIterator();
-          });
-
-      // there are chances that same record key from data table has 2 entries (1 delete from older partition and 1 insert to newer partition)
-      // lets do reduce by key to ignore the deleted entry.
-      // first deduce parallelism to avoid too few tasks for large number of records.
-      long totalWriteBytesForRLI = allWriteStats.stream().mapToLong(writeStat -> {
-        // if there are no inserts or deletes, we can ignore this write stat for RLI
-        if (writeStat.getNumInserts() == 0 && writeStat.getNumDeletes() == 0) {
-          return 0;
-        }
-        return writeStat.getTotalWriteBytes();
-      }).sum();
-      // approximate task partition size of 100MB
-      // (TODO: make this configurable)
-      long targetPartitionSize = 100 * 1024 * 1024;
-      parallelism = (int) Math.max(1, (totalWriteBytesForRLI + targetPartitionSize - 1) / targetPartitionSize);
-      return reduceByKeys(recordIndexRecords, parallelism, metadataConfig.isRecordLevelIndexEnabled());
-    } catch (Exception e) {
-      throw new HoodieException("Failed to generate RLI records for metadata table", e);
-    }
   }
 
   /**
@@ -1135,27 +697,11 @@ public class HoodieTableMetadataUtil {
   }
 
   /**
-   * Convert rollback action metadata to metadata table records.
-   * <p>
-   * We only need to handle FILES partition here as HUDI rollbacks on MOR table may end up adding a new log file. All other partitions
-   * are handled by actual rollback of the deltacommit which added records to those partitions.
-   */
-  public static Map<String, HoodieData<HoodieRecord>> convertMetadataToRecords(
-      HoodieEngineContext engineContext, HoodieTableMetaClient dataTableMetaClient, HoodieRollbackMetadata rollbackMetadata, String instantTime) {
-
-    List<HoodieRecord> filesPartitionRecords = HoodieTableMetadataUtil.convertMetadataToRollbackRecords(rollbackMetadata, instantTime);
-    final HoodieData<HoodieRecord> rollbackRecordsRDD = filesPartitionRecords.isEmpty() ? engineContext.emptyHoodieData()
-        : engineContext.parallelize(filesPartitionRecords, filesPartitionRecords.size());
-
-    return Collections.singletonMap(MetadataPartitionType.FILES.getPartitionPath(), rollbackRecordsRDD);
-  }
-
-  /**
    * Convert rollback action metadata to files partition records.
    * Consider only new log files added.
    */
-  private static List<HoodieRecord> convertMetadataToRollbackRecords(HoodieRollbackMetadata rollbackMetadata,
-                                                                     String instantTime) {
+  public static List<HoodieRecord> convertMetadataToRollbackRecords(HoodieRollbackMetadata rollbackMetadata,
+                                                                    String instantTime) {
     Map<String, List<FileInfoAndPartition>> partitionToAppendedFiles = new HashMap<>();
     processRollbackMetadata(rollbackMetadata, partitionToAppendedFiles);
     return convertFilesToFilesPartitionRecords(Collections.emptyMap(), partitionToAppendedFiles, instantTime, "Rollback");
@@ -1518,34 +1064,6 @@ public class HoodieTableMetadataUtil {
     }
   }
 
-  public static HoodieData<HoodieRecord> convertMetadataToColumnStatsRecords(HoodieCommitMetadata commitMetadata,
-                                                                             HoodieEngineContext engineContext,
-                                                                             HoodieTableMetaClient dataMetaClient,
-                                                                             HoodieMetadataConfig metadataConfig,
-                                                                             Option<HoodieRecordType> recordTypeOpt) {
-    List<HoodieWriteStat> allWriteStats = commitMetadata.getPartitionToWriteStats().values().stream()
-        .flatMap(Collection::stream).collect(Collectors.toList());
-
-    if (allWriteStats.isEmpty()) {
-      return engineContext.emptyHoodieData();
-    }
-
-    try {
-      Map<String, HoodieSchema> columnsToIndexSchemaMap = getColumnsToIndex(commitMetadata, dataMetaClient, metadataConfig, recordTypeOpt);
-      if (columnsToIndexSchemaMap.isEmpty()) {
-        // In case there are no columns to index, bail
-        return engineContext.emptyHoodieData();
-      }
-      List<String> columnsToIndex = new ArrayList<>(columnsToIndexSchemaMap.keySet());
-      int parallelism = Math.max(Math.min(allWriteStats.size(), metadataConfig.getColumnStatsIndexParallelism()), 1);
-      return engineContext.parallelize(allWriteStats, parallelism)
-          .flatMap(writeStat ->
-              translateWriteStatToColumnStats(writeStat, dataMetaClient, columnsToIndex).iterator());
-    } catch (Exception e) {
-      throw new HoodieException("Failed to generate column stats records for metadata table", e);
-    }
-  }
-
   public static Map<String, HoodieSchema> getColumnsToIndex(HoodieCommitMetadata commitMetadata, HoodieTableMetaClient dataMetaClient,
                                                HoodieMetadataConfig metadataConfig, Option<HoodieRecordType> recordTypeOpt) {
     Option<HoodieSchema> writerSchema =
@@ -1673,20 +1191,7 @@ public class HoodieTableMetadataUtil {
     return fieldSchemaPairStream.filter(fieldSchemaPair -> !HOODIE_META_COLUMNS_WITH_OPERATION.contains(fieldSchemaPair.getKey())).limit(n);
   }
 
-  private static Stream<HoodieRecord> translateWriteStatToColumnStats(HoodieWriteStat writeStat,
-                                                                      HoodieTableMetaClient datasetMetaClient,
-                                                                      List<String> columnsToIndex) {
-    if (writeStat.getColumnStats().isPresent()) {
-      Map<String, HoodieColumnRangeMetadata<Comparable>> columnRangeMap = writeStat.getColumnStats().get();
-      Collection<HoodieColumnRangeMetadata<Comparable>> columnRangeMetadataList = columnRangeMap.values();
-      return HoodieMetadataPayload.createColumnStatsRecords(writeStat.getPartitionPath(), columnRangeMetadataList, false);
-    }
-
-    String filePath = writeStat.getPath();
-    return getColumnStatsRecords(writeStat.getPartitionPath(), getFileNameFromPath(filePath), datasetMetaClient, columnsToIndex, false);
-  }
-
-  private static Stream<HoodieRecord> getColumnStatsRecords(String partitionPath,
+  public static Stream<HoodieRecord> getColumnStatsRecords(String partitionPath,
                                                             String fileName,
                                                             HoodieTableMetaClient datasetMetaClient,
                                                             List<String> columnsToIndex,
@@ -2689,7 +2194,7 @@ public class HoodieTableMetadataUtil {
     return readColumnRangeMetadataFrom(partitionPath, fileName, datasetMetaClient, columnsToIndex, maxBufferSize, indexVersion);
   }
 
-  static HoodieData<HoodieRecord> convertMetadataToPartitionStatsRecords(HoodiePairData<String, List<HoodieColumnRangeMetadata<Comparable>>> columnRangeMetadataPartitionPair,
+  public static HoodieData<HoodieRecord> convertMetadataToPartitionStatsRecords(HoodiePairData<String, List<HoodieColumnRangeMetadata<Comparable>>> columnRangeMetadataPartitionPair,
                                                                                  HoodieTableMetaClient dataMetaClient,
                                                                                  Map<String, HoodieSchema> colsToIndexSchemaMap,
                                                                                  HoodieIndexVersion partitionStatsIndexVersion
@@ -2770,7 +2275,7 @@ public class HoodieTableMetadataUtil {
     return keys;
   }
 
-  static List<HoodieColumnRangeMetadata<Comparable>> translateWriteStatToFileStats(HoodieWriteStat writeStat,
+  public static List<HoodieColumnRangeMetadata<Comparable>> translateWriteStatToFileStats(HoodieWriteStat writeStat,
                                                                                            HoodieTableMetaClient datasetMetaClient,
                                                                                            List<String> columnsToIndex,
                                                                                            HoodieIndexVersion indexVersion) {

--- a/hudi-common/src/main/java/org/apache/hudi/metadata/MetadataPartitionType.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/MetadataPartitionType.java
@@ -28,6 +28,7 @@ import org.apache.hudi.common.function.SerializableBiFunction;
 import org.apache.hudi.common.model.HoodieIndexDefinition;
 import org.apache.hudi.common.table.HoodieTableConfig;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
+import org.apache.hudi.common.table.HoodieTableVersion;
 import org.apache.hudi.common.util.StringUtils;
 import org.apache.hudi.common.util.ValidationUtils;
 import org.apache.hudi.index.expression.HoodieExpressionIndex;
@@ -453,8 +454,25 @@ public enum MetadataPartitionType {
    */
   public static MetadataPartitionType[] getValidValues() {
     // ALL_PARTITIONS is just another record type in FILES partition
+    return getValidValues(HoodieTableVersion.current());
+  }
+
+  /**
+   * Returns the set of all valid metadata partition types. Prefer using this method over {@link #values()}.
+   */
+  public static MetadataPartitionType[] getValidValues(HoodieTableVersion tableVersion) {
+    if (tableVersion.greaterThanOrEquals(HoodieTableVersion.EIGHT)) {
+      // ALL_PARTITIONS is just another record type in FILES partition
+      return EnumSet.complementOf(EnumSet.of(
+          ALL_PARTITIONS)).toArray(new MetadataPartitionType[0]);
+    }
     return EnumSet.complementOf(EnumSet.of(
-        ALL_PARTITIONS)).toArray(new MetadataPartitionType[0]);
+            ALL_PARTITIONS))
+        .stream()
+        .filter(type -> type != SECONDARY_INDEX
+            && type != EXPRESSION_INDEX
+            && type != PARTITION_STATS)
+        .toArray(MetadataPartitionType[]::new);
   }
 
   /**
@@ -464,7 +482,7 @@ public enum MetadataPartitionType {
     if (!dataMetadataConfig.isEnabled()) {
       return Collections.emptyList();
     }
-    return Arrays.stream(getValidValues())
+    return Arrays.stream(getValidValues(metaClient.getTableConfig().getTableVersion()))
         .filter(partitionType -> partitionType.isMetadataPartitionEnabled(dataMetadataConfig, metaClient.getTableConfig()) || partitionType.isMetadataPartitionAvailable(metaClient))
         .collect(Collectors.toList());
   }

--- a/hudi-common/src/main/java/org/apache/hudi/metadata/model/DirectoryInfo.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/model/DirectoryInfo.java
@@ -1,0 +1,108 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.hudi.metadata.model;
+
+import org.apache.hudi.common.fs.FSUtils;
+import org.apache.hudi.common.model.HoodiePartitionMetadata;
+import org.apache.hudi.common.table.HoodieTableMetaClient;
+import org.apache.hudi.common.util.collection.Pair;
+import org.apache.hudi.metadata.HoodieTableMetadataUtil;
+import org.apache.hudi.storage.StoragePath;
+import org.apache.hudi.storage.StoragePathInfo;
+
+import lombok.Getter;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static org.apache.hudi.common.table.timeline.InstantComparison.LESSER_THAN_OR_EQUALS;
+import static org.apache.hudi.common.table.timeline.InstantComparison.compareTimestamps;
+
+/**
+ * A class which represents a directory and the files and directories inside it.
+ * <p>
+ * A {@code PartitionFileInfo} object saves the name of the partition and various properties requires of each file
+ * required for initializing the metadata table. Saving limited properties reduces the total memory footprint when
+ * a very large number of files are present in the dataset being initialized.
+ */
+@Getter
+public class DirectoryInfo implements Serializable {
+
+  // Relative path of the directory (relative to the base directory)
+  private final String relativePath;
+  // Map of filenames within this partition to their respective sizes
+  private final Map<String, Long> filenameToSizeMap;
+  // List of directories within this partition
+  private final List<StoragePath> subDirectories = new ArrayList<>();
+  // Is this a hoodie partition
+  private boolean isHoodiePartition = false;
+
+  public DirectoryInfo(String relativePath, List<StoragePathInfo> pathInfos, String maxInstantTime, Set<String> pendingDataInstants) {
+    this(relativePath, pathInfos, maxInstantTime, pendingDataInstants, true);
+  }
+
+  /**
+   * When files are directly fetched from Metadata table we do not need to validate HoodiePartitions.
+   */
+  public DirectoryInfo(String relativePath, List<StoragePathInfo> pathInfos, String maxInstantTime, Set<String> pendingDataInstants,
+                       boolean validateHoodiePartitions) {
+    this.relativePath = relativePath;
+
+    // Pre-allocate with the maximum length possible
+    filenameToSizeMap = new HashMap<>(pathInfos.size());
+
+    // Presence of partition meta file implies this is a HUDI partition
+    // if input files are directly fetched from MDT, it may not contain the HoodiePartitionMetadata file. So, we can ignore the validation for isHoodiePartition.
+    isHoodiePartition = !validateHoodiePartitions || pathInfos.stream().anyMatch(status -> status.getPath().getName().startsWith(HoodiePartitionMetadata.HOODIE_PARTITION_METAFILE_PREFIX));
+    for (StoragePathInfo pathInfo : pathInfos) {
+      // Do not attempt to search for more subdirectories inside directories that are partitions
+      if (!isHoodiePartition && pathInfo.isDirectory()) {
+        // Ignore .hoodie directory as there cannot be any partitions inside it
+        if (!pathInfo.getPath().getName().equals(HoodieTableMetaClient.METAFOLDER_NAME)) {
+          this.subDirectories.add(pathInfo.getPath());
+        }
+      } else if (isHoodiePartition && FSUtils.isDataFile(pathInfo.getPath())) {
+        // Regular HUDI data file (base file or log file)
+        String dataFileCommitTime = FSUtils.getCommitTime(pathInfo.getPath().getName());
+        // Limit the file listings to files which were created by successful commits before the maxInstant time.
+        if (!pendingDataInstants.contains(dataFileCommitTime) && compareTimestamps(dataFileCommitTime, LESSER_THAN_OR_EQUALS, maxInstantTime)) {
+          filenameToSizeMap.put(pathInfo.getPath().getName(), pathInfo.getLength());
+        }
+      }
+    }
+  }
+
+  public static Map<String, List<FileInfo>> getPartitionToFileInfo(List<DirectoryInfo> partitionInfoList) {
+    return partitionInfoList.stream()
+        .map(p -> {
+          String partitionName = HoodieTableMetadataUtil.getPartitionIdentifierForFilesPartition(p.getRelativePath());
+          List<FileInfo> files = p.getFilenameToSizeMap().entrySet().stream()
+              .map(entry -> FileInfo.of(entry.getKey(), entry.getValue()))
+              .collect(Collectors.toList());
+          return Pair.of(partitionName, files);
+        })
+        .collect(Collectors.toMap(Pair::getKey, Pair::getValue));
+  }
+}

--- a/hudi-common/src/main/java/org/apache/hudi/metadata/model/FileAndPartitionFlag.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/model/FileAndPartitionFlag.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.hudi.metadata.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.experimental.Accessors;
+
+/**
+ * Data class representing a file and partition with a flag.
+ */
+@Getter
+@AllArgsConstructor
+@Accessors(fluent = true)
+public class FileAndPartitionFlag {
+  private final String partitionPath;
+  private final String fileName;
+  private final boolean flag;
+
+  public static FileAndPartitionFlag of(String partition, String file, boolean flag) {
+    return new FileAndPartitionFlag(partition, file, flag);
+  }
+}

--- a/hudi-common/src/main/java/org/apache/hudi/metadata/model/FileInfo.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/model/FileInfo.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.hudi.metadata.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.experimental.Accessors;
+
+/**
+ * Immutable descriptor for a file and its size.
+ */
+@AllArgsConstructor
+@Getter
+@Accessors(fluent = true)
+public class FileInfo {
+  private final String fileName;
+  private final long size;
+
+  public static FileInfo of(String fileName, long size) {
+    return new FileInfo(fileName, size);
+  }
+}

--- a/hudi-common/src/main/java/org/apache/hudi/metadata/model/FileInfoAndPartition.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/model/FileInfoAndPartition.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.hudi.metadata.model;
+
+import lombok.Getter;
+import lombok.experimental.Accessors;
+
+/**
+ * Immutable descriptor for a file that should be scanned during index bootstrap.
+ */
+@Getter
+@Accessors(fluent = true)
+public class FileInfoAndPartition {
+  private final String partitionPath;
+  private final String name;
+  private final long size;
+
+  private FileInfoAndPartition(String partitionPath, String name, long size) {
+    this.partitionPath = partitionPath;
+    this.name = name;
+    this.size = size;
+  }
+
+  public static FileInfoAndPartition of(String partition, String path, long size) {
+    return new FileInfoAndPartition(partition, path, size);
+  }
+}

--- a/hudi-common/src/main/java/org/apache/hudi/metadata/model/FileSliceAndPartition.java
+++ b/hudi-common/src/main/java/org/apache/hudi/metadata/model/FileSliceAndPartition.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.metadata.model;
+
+import org.apache.hudi.common.model.FileSlice;
+
+import lombok.AllArgsConstructor;
+import lombok.ToString;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.experimental.Accessors;
+
+/**
+ * Holder for a {@link FileSlice} and its partition path.
+ */
+@AllArgsConstructor
+@Getter
+@Setter
+@ToString
+@Accessors(fluent = true)
+public class FileSliceAndPartition {
+  private FileSlice fileSlice;
+  private String partitionPath;
+
+  public static FileSliceAndPartition of(String partitionPath, FileSlice fileSlice) {
+    return new FileSliceAndPartition(fileSlice, partitionPath);
+  }
+}

--- a/hudi-common/src/test/java/org/apache/hudi/metadata/TestMetadataPartitionType.java
+++ b/hudi-common/src/test/java/org/apache/hudi/metadata/TestMetadataPartitionType.java
@@ -40,6 +40,8 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -62,30 +64,34 @@ public class TestMetadataPartitionType {
             return Stream.of(Arguments.of(type, true));
           }
           return Stream.of(Arguments.of(type, true), Arguments.of(type, false));
-        });
+        }).flatMap(arguments ->
+            Stream.of(Arguments.of(arguments.get()[0], arguments.get()[1], HoodieTableVersion.current()),
+                Arguments.of(arguments.get()[0], arguments.get()[1], HoodieTableVersion.SIX)));
   }
 
   @ParameterizedTest
   @MethodSource("partitionTypeAndPartitionPairs")
-  public void testPartitionEnabledByConfigOnly(MetadataPartitionType partitionType, boolean isTablePartitioned) {
+  public void testPartitionEnabledByConfigOnly(MetadataPartitionType partitionType, boolean isTablePartitioned, HoodieTableVersion tableVersion) {
     HoodieTableMetaClient metaClient = Mockito.mock(HoodieTableMetaClient.class);
     HoodieTableConfig tableConfig = Mockito.mock(HoodieTableConfig.class);
 
     // Simulate the configuration enabling given partition type, but the meta client not having it available (yet to initialize the partition)
     Mockito.when(tableConfig.isTablePartitioned()).thenReturn(isTablePartitioned);
     Mockito.when(metaClient.getTableConfig()).thenReturn(tableConfig);
+    Mockito.when(tableConfig.getTableVersion()).thenReturn(tableVersion);
     Mockito.when(tableConfig.isMetadataPartitionAvailable(partitionType)).thenReturn(false);
     Mockito.when(metaClient.getIndexMetadata()).thenReturn(Option.empty());
     HoodieMetadataConfig.Builder metadataConfigBuilder = HoodieMetadataConfig.newBuilder();
     int expectedEnabledPartitions;
+    boolean tableVersionEightOrAbove = tableVersion.greaterThanOrEquals(HoodieTableVersion.EIGHT);
     switch (partitionType) {
       case EXPRESSION_INDEX:
         metadataConfigBuilder.enable(true).withExpressionIndexEnabled(true);
-        expectedEnabledPartitions = 3;
+        expectedEnabledPartitions = tableVersionEightOrAbove ? 3 : 2;
         break;
       case SECONDARY_INDEX:
         metadataConfigBuilder.enable(true).withEnableGlobalRecordLevelIndex(true).withSecondaryIndexEnabled(true).withSecondaryIndexForColumn("col1");
-        expectedEnabledPartitions = 4;
+        expectedEnabledPartitions = tableVersionEightOrAbove ? 4 : 3;
         break;
       case BLOOM_FILTERS:
         metadataConfigBuilder.enable(true).withMetadataIndexBloomFilter(true);
@@ -100,15 +106,15 @@ public class TestMetadataPartitionType {
         expectedEnabledPartitions = 2; // by default, FILES, COLUMN_STATS are enabled
         break;
     }
-    if (isTablePartitioned) {
+    if (isTablePartitioned && tableVersionEightOrAbove) {
       expectedEnabledPartitions++; // PARTITION_STATS is enabled by default if table is partitioned
     }
 
     List<MetadataPartitionType> enabledPartitions = MetadataPartitionType.getEnabledPartitions(metadataConfigBuilder.build(), metaClient);
-
     // Verify partition type is enabled due to config
     assertEquals(expectedEnabledPartitions, enabledPartitions.size());
-    assertTrue(enabledPartitions.contains(partitionType) || MetadataPartitionType.ALL_PARTITIONS.equals(partitionType));
+    Set<MetadataPartitionType> validPartitions = Arrays.stream(MetadataPartitionType.getValidValues(tableVersion)).collect(Collectors.toSet());
+    assertTrue(!validPartitions.contains(partitionType) || enabledPartitions.contains(partitionType) || MetadataPartitionType.ALL_PARTITIONS.equals(partitionType));
   }
 
   @Test
@@ -119,6 +125,7 @@ public class TestMetadataPartitionType {
     // Simulate the meta client having RECORD_INDEX available but config not enabling it
     Mockito.when(metaClient.getTableConfig()).thenReturn(tableConfig);
     Mockito.when(tableConfig.isTablePartitioned()).thenReturn(true);
+    Mockito.when(tableConfig.getTableVersion()).thenReturn(HoodieTableVersion.current());
     Mockito.when(tableConfig.isMetadataPartitionAvailable(MetadataPartitionType.FILES)).thenReturn(true);
     Mockito.when(metaClient.getIndexMetadata()).thenReturn(Option.empty());
     Mockito.when(metaClient.getTableConfig().isMetadataPartitionAvailable(MetadataPartitionType.RECORD_INDEX)).thenReturn(true);
@@ -159,6 +166,7 @@ public class TestMetadataPartitionType {
     // Simulate the meta client having EXPRESSION_INDEX available
     Mockito.when(metaClient.getTableConfig()).thenReturn(tableConfig);
     Mockito.when(tableConfig.isTablePartitioned()).thenReturn(true);
+    Mockito.when(tableConfig.getTableVersion()).thenReturn(HoodieTableVersion.current());
     Mockito.when(tableConfig.isMetadataPartitionAvailable(MetadataPartitionType.FILES)).thenReturn(true);
     HoodieIndexDefinition expressionIndexDefinition = createIndexDefinition(MetadataPartitionType.EXPRESSION_INDEX, "dummy", "column_stats", "lower", Collections.singletonList("name"), null);
     HoodieIndexMetadata expressionIndexMetadata = new HoodieIndexMetadata(Collections.singletonMap("expr_index_dummy", expressionIndexDefinition));

--- a/hudi-hadoop-common/src/test/java/org/apache/hudi/metadata/TestHoodieTableMetadataUtil.java
+++ b/hudi-hadoop-common/src/test/java/org/apache/hudi/metadata/TestHoodieTableMetadataUtil.java
@@ -24,6 +24,7 @@ import org.apache.hudi.common.data.HoodieData;
 import org.apache.hudi.common.engine.HoodieLocalEngineContext;
 import org.apache.hudi.common.function.SerializableBiFunction;
 import org.apache.hudi.common.model.FileSlice;
+import org.apache.hudi.metadata.model.FileSliceAndPartition;
 import org.apache.hudi.common.model.HoodieBaseFile;
 import org.apache.hudi.common.model.HoodieCommitMetadata;
 import org.apache.hudi.common.model.HoodieLogFile;
@@ -130,7 +131,7 @@ public class TestHoodieTableMetadataUtil extends HoodieCommonTestHarness {
     hoodieTestTable = hoodieTestTable.addCommit(instant1);
     String instant2 = "20230918121110000";
     hoodieTestTable = hoodieTestTable.addCommit(instant2);
-    List<Pair<String, FileSlice>> partitionFileSlicePairs = new ArrayList<>();
+    List<FileSliceAndPartition> partitionFileSlicePairs = new ArrayList<>();
     // Generate 10 inserts for each partition and populate partitionBaseFilePairs and recordKeys.
     DATE_PARTITIONS.forEach(p -> {
       try {
@@ -156,8 +157,8 @@ public class TestHoodieTableMetadataUtil extends HoodieCommonTestHarness {
             engineContext);
         HoodieBaseFile baseFile2 = new HoodieBaseFile(hoodieTestTable.getBaseFilePath(p, fileId2).toString());
         fileSlice2.setBaseFile(baseFile2);
-        partitionFileSlicePairs.add(Pair.of(p, fileSlice1));
-        partitionFileSlicePairs.add(Pair.of(p, fileSlice2));
+        partitionFileSlicePairs.add(FileSliceAndPartition.of(p, fileSlice1));
+        partitionFileSlicePairs.add(FileSliceAndPartition.of(p, fileSlice2));
       } catch (Exception e) {
         throw new RuntimeException(e);
       }
@@ -239,7 +240,7 @@ public class TestHoodieTableMetadataUtil extends HoodieCommonTestHarness {
     hoodieTestTable = hoodieTestTable.addCommit(instant1, Option.of(commitMetadata));
     String instant2 = "20230918121110000";
     hoodieTestTable = hoodieTestTable.addCommit(instant2);
-    List<Pair<String, FileSlice>> partitionFileSlicePairs = new ArrayList<>();
+    List<FileSliceAndPartition> partitionFileSlicePairs = new ArrayList<>();
     List<String> columnsToIndex = Arrays.asList("rider", "driver");
     // Generate 10 inserts for each partition and populate partitionBaseFilePairs and recordKeys.
     DATE_PARTITIONS.forEach(p -> {
@@ -260,8 +261,8 @@ public class TestHoodieTableMetadataUtil extends HoodieCommonTestHarness {
         writeLogFiles(new StoragePath(metaClient.getBasePath(), p), HOODIE_SCHEMA, HoodieTestDataGenerator.HOODIE_SCHEMA_WITH_METADATA_FIELDS,
             dataGen.generateInsertsForPartition(instant2, 10, p), 1, metaClient.getStorage(), new Properties(), fileId1, instant2);
         fileSlice2.addLogFile(new HoodieLogFile(storagePath2.toUri().toString()));
-        partitionFileSlicePairs.add(Pair.of(p, fileSlice1));
-        partitionFileSlicePairs.add(Pair.of(p, fileSlice2));
+        partitionFileSlicePairs.add(FileSliceAndPartition.of(p, fileSlice1));
+        partitionFileSlicePairs.add(FileSliceAndPartition.of(p, fileSlice2));
         // NOTE: we need to set table config as we are not using write client explicitly and these configs are needed for log record reader
         metaClient.getTableConfig().setValue(HoodieTableConfig.POPULATE_META_FIELDS.key(), "false");
         metaClient.getTableConfig().setValue(HoodieTableConfig.RECORDKEY_FIELDS.key(), "_row_key");

--- a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/client/functional/TestMetadataUtilRLIandSIRecordGeneration.java
+++ b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/client/functional/TestMetadataUtilRLIandSIRecordGeneration.java
@@ -30,7 +30,7 @@ import org.apache.hudi.common.engine.EngineType;
 import org.apache.hudi.common.engine.HoodieReaderContext;
 import org.apache.hudi.common.fs.FSUtils;
 import org.apache.hudi.common.model.EmptyHoodieRecordPayload;
-import org.apache.hudi.common.model.FileSlice;
+import org.apache.hudi.metadata.model.FileSliceAndPartition;
 import org.apache.hudi.common.model.HoodieCommitMetadata;
 import org.apache.hudi.common.model.HoodieFailedWritesCleaningPolicy;
 import org.apache.hudi.common.model.HoodieIndexDefinition;
@@ -49,7 +49,6 @@ import org.apache.hudi.common.table.view.HoodieTableFileSystemView;
 import org.apache.hudi.common.util.CollectionUtils;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.common.util.collection.ClosableIterator;
-import org.apache.hudi.common.util.collection.Pair;
 import org.apache.hudi.config.HoodieCompactionConfig;
 import org.apache.hudi.config.HoodieWriteConfig;
 import org.apache.hudi.exception.HoodieException;
@@ -345,10 +344,10 @@ public class TestMetadataUtilRLIandSIRecordGeneration extends HoodieClientTestBa
       HoodieTableMetadata metadata = metaClient.getTableFormat().getMetadataFactory().create(engineContext, storage, metadataConfig, metaClient.getBasePath().toString());
       HoodieTableFileSystemView metadataView = new HoodieTableFileSystemView(metadata, metaClient, metaClient.getActiveTimeline());
       metadataView.loadAllPartitions();
-      List<Pair<String, FileSlice>> partitionFileSlicePairs = new ArrayList<>();
+      List<FileSliceAndPartition> partitionFileSlicePairs = new ArrayList<>();
       HoodieTableFileSystemView finalMetadataView = metadataView;
       Arrays.asList(dataGen.getPartitionPaths()).forEach(partition -> finalMetadataView.getLatestMergedFileSlicesBeforeOrOn(partition, firstCommitTime)
-          .forEach(fs -> partitionFileSlicePairs.add(Pair.of(partition, fs))));
+          .forEach(fs -> partitionFileSlicePairs.add(FileSliceAndPartition.of(partition, fs))));
       List<HoodieRecord> secondaryIndexRecords = readSecondaryKeysFromFileSlices(
           engineContext, partitionFileSlicePairs, metadataConfig.getSecondaryIndexParallelism(), this.getClass().getSimpleName(), metaClient, indexDefinition, writeConfig.getProps()).collectAsList();
       assertListEquality(expectedSecondaryIndexKeys, secondaryIndexRecords.stream().map(HoodieRecord::getRecordKey).collect(Collectors.toList()));

--- a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/client/functional/TestMetadataUtilRLIandSIRecordGeneration.java
+++ b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/client/functional/TestMetadataUtilRLIandSIRecordGeneration.java
@@ -26,7 +26,6 @@ import org.apache.hudi.client.WriteStatus;
 import org.apache.hudi.client.common.HoodieSparkEngineContext;
 import org.apache.hudi.common.config.HoodieMetadataConfig;
 import org.apache.hudi.common.config.TypedProperties;
-import org.apache.hudi.common.engine.EngineType;
 import org.apache.hudi.common.engine.HoodieReaderContext;
 import org.apache.hudi.common.fs.FSUtils;
 import org.apache.hudi.common.model.EmptyHoodieRecordPayload;
@@ -83,13 +82,13 @@ import java.util.stream.Collectors;
 import static org.apache.hudi.common.table.timeline.HoodieTimeline.DELTA_COMMIT_ACTION;
 import static org.apache.hudi.common.testutils.HoodieTestDataGenerator.HOODIE_SCHEMA;
 import static org.apache.hudi.common.testutils.HoodieTestDataGenerator.TRIP_EXAMPLE_SCHEMA;
-import static org.apache.hudi.metadata.HoodieTableMetadataUtil.convertMetadataToRecordIndexRecords;
 import static org.apache.hudi.metadata.HoodieTableMetadataUtil.getRevivedAndDeletedKeysFromMergedLogs;
 import static org.apache.hudi.metadata.HoodieTableMetadataUtil.reduceByKeys;
 import static org.apache.hudi.metadata.SecondaryIndexKeyUtils.constructSecondaryIndexKey;
 import static org.apache.hudi.metadata.SecondaryIndexKeyUtils.getRecordKeyFromSecondaryIndexKey;
 import static org.apache.hudi.metadata.SecondaryIndexRecordGenerationUtils.convertWriteStatsToSecondaryIndexRecords;
 import static org.apache.hudi.metadata.SecondaryIndexRecordGenerationUtils.readSecondaryKeysFromFileSlices;
+import static org.apache.hudi.metadata.index.record.BaseRecordIndexer.convertMetadataToRecordIndexRecords;
 import static org.apache.hudi.testutils.Assertions.assertNoWriteErrors;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -297,7 +296,7 @@ public class TestMetadataUtilRLIandSIRecordGeneration extends HoodieClientTestBa
       HoodieCommitMetadata compactionCommitMetadata = (HoodieCommitMetadata) compactionWriteMetadata.getCommitMetadata().get();
       // no RLI records should be generated for compaction operation.
       assertTrue(convertMetadataToRecordIndexRecords(context, compactionCommitMetadata, writeConfig.getMetadataConfig(),
-          metaClient, writeConfig.getWritesFileIdEncoding(), compactionInstantOpt.get(), EngineType.SPARK).isEmpty());
+          metaClient, writeConfig.getWritesFileIdEncoding(), compactionInstantOpt.get()).isEmpty());
     }
   }
 

--- a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/functional/TestHoodieBackedMetadata.java
+++ b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/functional/TestHoodieBackedMetadata.java
@@ -964,7 +964,7 @@ public class TestHoodieBackedMetadata extends TestHoodieMetadataBase {
         assertEquals("0000003", completedReplaceInstant.get().requestedTime());
 
         final Map<String, MetadataPartitionType> metadataEnabledPartitionTypes = new HashMap<>();
-        metadataWriter.getEnabledPartitionTypes().forEach(e -> metadataEnabledPartitionTypes.put(e.getPartitionPath(), e));
+        metadataWriter.getEnabledIndexerMap().keySet().forEach(e -> metadataEnabledPartitionTypes.put(e.getPartitionPath(), e));
         HoodieTableFileSystemView fsView = HoodieTableFileSystemView.fileListingBasedFileSystemView(engineContext, metadataMetaClient, metadataMetaClient.getActiveTimeline());
         metadataTablePartitions.forEach(partition -> {
           List<FileSlice> latestSlices = fsView.getLatestFileSlices(partition).collect(Collectors.toList());
@@ -4089,12 +4089,12 @@ public class TestHoodieBackedMetadata extends TestHoodieMetadataBase {
     List<String> metadataTablePartitions = FSUtils.getAllPartitionPaths(engineContext, metadataMetaClient, false);
     // Secondary index is enabled by default but no MDT partition corresponding to it is available
     final boolean isPartitionStatsEnabled;
-    if (!metadataWriter.getEnabledPartitionTypes().contains(COLUMN_STATS)) {
+    if (!metadataWriter.getEnabledIndexerMap().containsKey(COLUMN_STATS)) {
       isPartitionStatsEnabled = false;
     } else {
       isPartitionStatsEnabled = true;
     }
-    long enabledMDTPartitionsSize = metadataWriter.getEnabledPartitionTypes().stream()
+    long enabledMDTPartitionsSize = metadataWriter.getEnabledIndexerMap().keySet().stream()
         .filter(partition -> !partition.equals(SECONDARY_INDEX))
         // Filter out partition stats if column stats is disabled since it does not get initialized in such a case
         .filter(partition -> isPartitionStatsEnabled || !partition.equals(PARTITION_STATS))
@@ -4102,7 +4102,7 @@ public class TestHoodieBackedMetadata extends TestHoodieMetadataBase {
     assertEquals(enabledMDTPartitionsSize, metadataTablePartitions.size());
 
     final Map<String, MetadataPartitionType> metadataEnabledPartitionTypes = new HashMap<>();
-    metadataWriter.getEnabledPartitionTypes().forEach(e -> metadataEnabledPartitionTypes.put(e.getPartitionPath(), e));
+    metadataWriter.getEnabledIndexerMap().keySet().forEach(e -> metadataEnabledPartitionTypes.put(e.getPartitionPath(), e));
 
     // Metadata table should automatically compact and clean
     // versions are +1 as autoclean / compaction happens end of commits
@@ -4267,7 +4267,8 @@ public class TestHoodieBackedMetadata extends TestHoodieMetadataBase {
       // check if the last instant is restore, then the metadata table should have only the partitions that are not deleted
       metaClient.reloadActiveTimeline().getReverseOrderedInstants().findFirst().ifPresent(instant -> {
         if (instant.getAction().equals(HoodieActiveTimeline.RESTORE_ACTION)) {
-          metadataWriter.getEnabledPartitionTypes().stream().filter(partitionType -> !MetadataPartitionType.shouldDeletePartitionOnRestore(partitionType.getPartitionPath()))
+          metadataWriter.getEnabledIndexerMap().keySet().stream().filter(
+              partitionType -> !MetadataPartitionType.shouldDeletePartitionOnRestore(partitionType.getPartitionPath()))
               .forEach(partitionType -> assertTrue(metadataTablePartitions.contains(partitionType.getPartitionPath())));
         }
       });

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestGlobalRecordLevelIndex.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestGlobalRecordLevelIndex.scala
@@ -595,7 +595,7 @@ class TestGlobalRecordLevelIndex extends RecordLevelIndexTestBase {
     doWriteAndValidateDataAndRecordIndex(hudiOpts,
       operation = DataSourceWriteOptions.UPSERT_OPERATION_OPT_VAL,
       saveMode = SaveMode.Append)
-    assertTrue(metadataWriter(getWriteConfig(hudiOpts)).getEnabledPartitionTypes.containsAll(metadataPartitions.asJava))
+    assertTrue(metadataWriter(getWriteConfig(hudiOpts)).getEnabledIndexerMap.keySet().containsAll(metadataPartitions.asJava))
   }
 
   @ParameterizedTest

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestGlobalRecordLevelIndexTableVersionSix.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestGlobalRecordLevelIndexTableVersionSix.scala
@@ -18,10 +18,21 @@
 
 package org.apache.hudi.functional
 
-import org.apache.hudi.common.table.HoodieTableConfig
+import org.apache.hudi.DataSourceWriteOptions
+import org.apache.hudi.common.config.HoodieMetadataConfig
+import org.apache.hudi.common.model.HoodieTableType
+import org.apache.hudi.common.table.{HoodieTableConfig, HoodieTableMetaClient}
+import org.apache.hudi.common.testutils.HoodieTestDataGenerator
 import org.apache.hudi.config.HoodieWriteConfig
+import org.apache.hudi.metadata.MetadataPartitionType
 
+import org.apache.spark.sql.SaveMode
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Tag
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.EnumSource
+
+import java.util.Collections
 
 @Tag("functional-b")
 class TestGlobalRecordLevelIndexTableVersionSix extends TestGlobalRecordLevelIndex {
@@ -29,4 +40,27 @@ class TestGlobalRecordLevelIndexTableVersionSix extends TestGlobalRecordLevelInd
     HoodieTableConfig.VERSION.key() -> "6",
     HoodieWriteConfig.WRITE_TABLE_VERSION.key() -> "6"
   )
+
+  @ParameterizedTest
+  @EnumSource(classOf[HoodieTableType])
+  override def testRLIUpsertAndDropIndex(tableType: HoodieTableType): Unit = {
+    val hudiOpts = commonOpts ++ Map(DataSourceWriteOptions.TABLE_TYPE.key -> tableType.name(),
+      HoodieMetadataConfig.ENABLE_METADATA_INDEX_COLUMN_STATS.key -> "true")
+    doWriteAndValidateDataAndRecordIndex(hudiOpts,
+      operation = DataSourceWriteOptions.INSERT_OPERATION_OPT_VAL,
+      saveMode = SaveMode.Overwrite)
+
+    val writeConfig = getWriteConfig(hudiOpts)
+    writeConfig.setSchema(HoodieTestDataGenerator.TRIP_EXAMPLE_SCHEMA)
+    getHoodieWriteClient(writeConfig).dropIndex(Collections.singletonList(MetadataPartitionType.RECORD_INDEX.getPartitionPath))
+    assertEquals(0, getFileGroupCountForRecordIndex(writeConfig))
+    metaClient = HoodieTableMetaClient.reload(metaClient)
+    assertEquals(0, metaClient.getTableConfig.getMetadataPartitionsInflight.size())
+    // only files, col stats, partition stats partition should be present.
+    assertEquals(2, metaClient.getTableConfig.getMetadataPartitions.size())
+
+    doWriteAndValidateDataAndRecordIndex(hudiOpts,
+      operation = DataSourceWriteOptions.UPSERT_OPERATION_OPT_VAL,
+      saveMode = SaveMode.Append)
+  }
 }


### PR DESCRIPTION
Mirror of https://github.com/apache/hudi/pull/18372 for automated bot review.

**Original author:** @cshuo
**Base branch:** master


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Refactored metadata indexing system with generalized indexer-driven approach for improved modularity and maintainability.
  * Enhanced expression index support with engine-specific record generation for Spark, Flink, and Java engines.
  * Added support for partitioned record-level indexing with improved initialization and validation.

* **Improvements**
  * Streamlined metadata partition initialization and update flows across all index types (files, bloom filters, column stats, partition stats, record index, secondary index, expression index).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->