### PR TITLE
[OSS PR #18375] feat(lance): Ensure Spark-SQL works correctly when using lance as base file format

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieWriteConfig.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieWriteConfig.java
@@ -3693,6 +3693,9 @@ public class HoodieWriteConfig extends HoodieConfig {
       if (format == null || !format.requiresSparkRecordType()) {
         return;
       }
+      if (engineType != EngineType.SPARK) {
+        throw new HoodieNotSupportedException(format + " base file format requires the SPARK engine");
+      }
       // Only inject when the user has not explicitly configured any merger class. A user who
       // knowingly picks a non-Spark merger for a Spark-only format will still fail fast at
       // write time — that's a deliberate choice, not a usability gap.

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieWriteConfig.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieWriteConfig.java
@@ -3627,6 +3627,7 @@ public class HoodieWriteConfig extends HoodieConfig {
       writeConfig.setDefaultValue(MARKERS_TYPE, getDefaultMarkersType(engineType));
       // Check for mandatory properties
       writeConfig.setDefaults(HoodieWriteConfig.class.getName());
+      autoSelectSparkRecordMergerForBaseFileFormat();
       // Make sure the props is propagated
       writeConfig.setDefaultOnCondition(
           !isIndexConfigSet, HoodieIndexConfig.newBuilder().withEngineType(engineType).fromProperties(
@@ -3673,6 +3674,33 @@ public class HoodieWriteConfig extends HoodieConfig {
           HoodieTTLConfig.newBuilder().fromProperties(writeConfig.getProps()).build());
 
       autoAdjustConfigsForConcurrencyMode(isLockProviderPropertySet);
+    }
+
+    // Class name referenced by string so hudi-client-common does not depend on hudi-spark-client.
+    private static final String DEFAULT_SPARK_RECORD_MERGER_CLASS = "org.apache.hudi.DefaultSparkRecordMerger";
+
+    /**
+     * When the table's base file format requires SPARK record type (e.g. Lance) but the user
+     * has not configured a Spark-compatible record merger, inject
+     * {@link #DEFAULT_SPARK_RECORD_MERGER_CLASS} into {@link HoodieWriteConfig#RECORD_MERGE_IMPL_CLASSES}
+     * so every downstream consumer — write handles, file readers, and metadata writers — observes
+     * a SPARK-typed merger consistently. This removes the usability gap where users had to set
+     * the merger override manually for every Lance table.
+     */
+    private void autoSelectSparkRecordMergerForBaseFileFormat() {
+      HoodieFileFormat tableLevel = HoodieFileFormat.getValue(writeConfig.getString(HoodieTableConfig.BASE_FILE_FORMAT.key()));
+      HoodieFileFormat format = tableLevel != null ? tableLevel : writeConfig.getBaseFileFormat();
+      if (format == null || !format.requiresSparkRecordType()) {
+        return;
+      }
+      // Only inject when the user has not explicitly configured any merger class. A user who
+      // knowingly picks a non-Spark merger for a Spark-only format will still fail fast at
+      // write time — that's a deliberate choice, not a usability gap.
+      String currentMergers = writeConfig.getString(RECORD_MERGE_IMPL_CLASSES);
+      if (!StringUtils.isNullOrEmpty(currentMergers)) {
+        return;
+      }
+      writeConfig.setValue(RECORD_MERGE_IMPL_CLASSES, DEFAULT_SPARK_RECORD_MERGER_CLASS);
     }
 
     private boolean isLockRequiredForSingleWriter() {

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/index/HoodieIndexUtils.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/index/HoodieIndexUtils.java
@@ -30,10 +30,10 @@ import org.apache.hudi.common.fs.FSUtils;
 import org.apache.hudi.common.model.FileSlice;
 import org.apache.hudi.common.model.HoodieAvroIndexedRecord;
 import org.apache.hudi.common.model.HoodieBaseFile;
+import org.apache.hudi.common.model.HoodieFileFormat;
 import org.apache.hudi.common.model.HoodieIndexDefinition;
 import org.apache.hudi.common.model.HoodieKey;
 import org.apache.hudi.common.model.HoodieRecord;
-import org.apache.hudi.common.model.HoodieRecord.HoodieRecordType;
 import org.apache.hudi.common.model.HoodieRecordGlobalLocation;
 import org.apache.hudi.common.model.HoodieRecordLocation;
 import org.apache.hudi.common.model.HoodieTableType;
@@ -251,8 +251,11 @@ public class HoodieIndexUtils {
       return Collections.emptyList();
     }
     log.info("Going to filter {} keys from file {}", candidateRecordKeys.size(), filePath);
+    HoodieRecord.HoodieRecordType recordType =
+        HoodieFileFormat.fromFileExtension(FSUtils.getFileExtension(filePath.toString())).requiresSparkRecordType()
+            ? HoodieRecord.HoodieRecordType.SPARK : HoodieRecord.HoodieRecordType.AVRO;
     try (HoodieFileReader fileReader = HoodieIOFactory.getIOFactory(storage)
-        .getReaderFactory(HoodieRecordType.AVRO)
+        .getReaderFactory(recordType)
         .getFileReader(DEFAULT_HUDI_CONFIG_FOR_READER, filePath)) {
       // Load all rowKeys from the file, to double-confirm
       HoodieTimer timer = HoodieTimer.start();
@@ -396,8 +399,21 @@ public class HoodieIndexUtils {
     }
 
     //record is inserted or updated
-    String partitionPath = inferPartitionPath(incoming, existing, writeSchemaWithMetaFields, keyGenerator, existingRecordContext, mergeResult);
-    HoodieRecord<R> result = existingRecordContext.constructHoodieRecord(mergeResult, partitionPath);
+    String partitionPath = inferPartitionPath(incoming, existing, writeSchemaWithMetaFields, keyGenerator,
+        existingRecordContext, mergeResult, incomingBufferedRecord, existingBufferedRecord, incomingRecordContext);
+    // When HoodieAvroRecordMerger creates a genuinely new BufferedRecord, it encodes the schema into
+    // incomingRecordContext. Re-encode into existingRecordContext so constructHoodieRecord (which uses
+    // existingRecordContext for the correct payload class) can resolve the schema for SPARK records.
+    BufferedRecord<R> mergeResultForConstruct = mergeResult;
+    if (mergeResult != incomingBufferedRecord && mergeResult != existingBufferedRecord) {
+      HoodieSchema mergedSchema = incomingRecordContext.getSchemaFromBufferRecord(mergeResult);
+      if (mergedSchema != null && existingRecordContext.getSchemaFromBufferRecord(mergeResult) == null) {
+        mergeResultForConstruct = BufferedRecords.fromEngineRecord(
+            mergeResult.getRecord(), mergeResult.getRecordKey(), mergedSchema,
+            existingRecordContext, Arrays.asList(orderingFieldNames), mergeResult.getHoodieOperation());
+      }
+    }
+    HoodieRecord<R> result = existingRecordContext.constructHoodieRecord(mergeResultForConstruct, partitionPath);
     HoodieRecord<R> withMeta = result.prependMetaFields(writeSchema, writeSchemaWithMetaFields,
         new MetadataValues().setRecordKey(incoming.getRecordKey()).setPartitionPath(partitionPath), properties);
     return Option.of(withMeta.wrapIntoHoodieRecordPayloadWithParams(writeSchemaWithMetaFields, properties, Option.empty(),
@@ -405,15 +421,29 @@ public class HoodieIndexUtils {
   }
 
   private static <R> String inferPartitionPath(HoodieRecord<R> incoming, HoodieRecord<R> existing, HoodieSchema recordSchema, BaseKeyGenerator keyGenerator,
-                                               RecordContext<R> recordContext, BufferedRecord<R> resultingBufferedRecord) {
-    R record = resultingBufferedRecord.getRecord();
-    if (record == incoming.getData()) {
+                                               RecordContext<R> existingRecordContext, BufferedRecord<R> resultingBufferedRecord,
+                                               BufferedRecord<R> incomingBufferedRecord, BufferedRecord<R> existingBufferedRecord,
+                                               RecordContext<R> incomingRecordContext) {
+    // Compare by BufferedRecord identity first: for payload-based records (e.g. ExpressionPayload),
+    // incoming.getData() is the payload object, not the InternalRow extracted from it, so data-identity
+    // checks would incorrectly fall through to the schema-based conversion path.
+    if (resultingBufferedRecord == incomingBufferedRecord || resultingBufferedRecord.getRecord() == incoming.getData()) {
       return incoming.getPartitionPath();
-    } else if (record == existing.getData()) {
+    } else if (resultingBufferedRecord == existingBufferedRecord || resultingBufferedRecord.getRecord() == existing.getData()) {
       return existing.getPartitionPath();
     } else {
-      // the merged record is not the same as either incoming or existing, so we need to compute the partition path
-      return keyGenerator.getPartitionPath(recordContext.convertToAvroRecord(record, recordSchema));
+      // The merged record is genuinely new (e.g. created by HoodieAvroRecordMerger.merge).
+      // Its InternalRow was produced and its schemaId was encoded by incomingRecordContext,
+      // so use incomingRecordContext with the record's actual schema (which may be the data schema,
+      // without meta fields) rather than existingRecordContext with writeSchemaWithMetaFields.
+      HoodieSchema actualSchema = incomingRecordContext.getSchemaFromBufferRecord(resultingBufferedRecord);
+      if (actualSchema == null) {
+        actualSchema = existingRecordContext.getSchemaFromBufferRecord(resultingBufferedRecord);
+      }
+      if (actualSchema == null) {
+        actualSchema = recordSchema;
+      }
+      return keyGenerator.getPartitionPath(incomingRecordContext.convertToAvroRecord(resultingBufferedRecord.getRecord(), actualSchema));
     }
   }
 
@@ -448,7 +478,8 @@ public class HoodieIndexUtils {
         // the record was deleted
         return Option.empty();
       }
-      String partitionPath = inferPartitionPath(incoming, existing, writeSchemaWithMetaFields, keyGenerator, existingRecordContext, mergeResult);
+      String partitionPath = inferPartitionPath(incoming, existing, writeSchemaWithMetaFields, keyGenerator,
+          existingRecordContext, mergeResult, incomingBufferedRecord, existingBufferedRecord, incomingRecordContext);
       if (config.isFileGroupReaderBasedMergeHandle() && HoodieRecordUtils.isPayloadClassDeprecated(ConfigUtils.getPayloadClass(properties))) {
         return Option.of(existingRecordContext.constructHoodieRecord(mergeResult, partitionPath));
       } else {
@@ -494,8 +525,11 @@ public class HoodieIndexUtils {
     RecordContext<R> incomingRecordContext = readerContext.getRecordContext();
     // Create a reader context for the existing records. In the case of merge-into commands, the incoming records
     // can be using an expression payload so here we rely on the table's configured payload class if it is required.
+    HoodieRecord.HoodieRecordType recordTypeForExistingRecords =
+        hoodieTable.getMetaClient().getTableConfig().getBaseFileFormat().requiresSparkRecordType()
+            ? HoodieRecord.HoodieRecordType.SPARK : config.getRecordMerger().getRecordType();
     ReaderContextFactory<R> readerContextFactoryForExistingRecords = (ReaderContextFactory<R>) hoodieTable.getContext()
-        .getReaderContextFactoryForWrite(hoodieTable.getMetaClient(), config.getRecordMerger().getRecordType(), hoodieTable.getMetaClient().getTableConfig().getProps());
+        .getReaderContextFactoryForWrite(hoodieTable.getMetaClient(), recordTypeForExistingRecords, hoodieTable.getMetaClient().getTableConfig().getProps());
     RecordContext<R> existingRecordContext = readerContextFactoryForExistingRecords.getContext().getRecordContext();
     // merged existing records with current locations being set
     HoodieSchema writerSchemaWithMetaFields = HoodieSchemaUtils.addMetadataFields(writerSchema, updatedConfig.allowOperationMetadataField());
@@ -581,8 +615,11 @@ public class HoodieIndexUtils {
     HoodiePairData<String, HoodieRecord<R>> keyAndIncomingRecords =
         incomingRecords.mapToPair(record -> Pair.of(record.getRecordKey(), record));
 
+    HoodieRecord.HoodieRecordType recordType =
+        table.getMetaClient().getTableConfig().getBaseFileFormat().requiresSparkRecordType()
+            ? HoodieRecord.HoodieRecordType.SPARK : config.getRecordMerger().getRecordType();
     ReaderContextFactory<R> readerContextFactory = (ReaderContextFactory<R>) table.getContext()
-        .getReaderContextFactoryForWrite(table.getMetaClient(), config.getRecordMerger().getRecordType(), config.getProps());
+        .getReaderContextFactoryForWrite(table.getMetaClient(), recordType, config.getProps());
     HoodieReaderContext<R> readerContext = readerContextFactory.getContext();
     readerContext.initRecordMergerForIngestion(config.getProps());
     TypedProperties properties = readerContext.getMergeProps(config.getProps());

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/index/HoodieIndexUtils.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/index/HoodieIndexUtils.java
@@ -251,8 +251,9 @@ public class HoodieIndexUtils {
       return Collections.emptyList();
     }
     log.info("Going to filter {} keys from file {}", candidateRecordKeys.size(), filePath);
-    // TODO: The AVRO fallback here ignores the merger's configured type. This pre-dates the Lance PR
-    //  and should be addressed in a follow-up to respect the merger's record type for all formats.
+    // TODO: The AVRO fallback here ignores the merger's configured type. This pre-dates
+    //  the Lance PR and is tracked at https://github.com/apache/hudi/issues/18496 — respect the
+    //  merger's record type for all formats.
     HoodieRecord.HoodieRecordType recordType =
         HoodieFileFormat.fromFileExtension(FSUtils.getFileExtension(filePath.toString())).resolveRecordType(HoodieRecord.HoodieRecordType.AVRO);
     try (HoodieFileReader fileReader = HoodieIOFactory.getIOFactory(storage)

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/index/HoodieIndexUtils.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/index/HoodieIndexUtils.java
@@ -254,8 +254,10 @@ public class HoodieIndexUtils {
     // TODO: The AVRO fallback here ignores the merger's configured type. This pre-dates
     //  the Lance PR and is tracked at https://github.com/apache/hudi/issues/18496 — respect the
     //  merger's record type for all formats.
-    HoodieRecord.HoodieRecordType recordType =
-        HoodieFileFormat.fromFileExtension(FSUtils.getFileExtension(filePath.toString())).resolveRecordType(HoodieRecord.HoodieRecordType.AVRO);
+    HoodieFileFormat format = HoodieFileFormat.fromFileExtensionOrNull(FSUtils.getFileExtension(filePath.toString()));
+    HoodieRecord.HoodieRecordType recordType = format != null
+        ? format.resolveRecordType(HoodieRecord.HoodieRecordType.AVRO)
+        : HoodieRecord.HoodieRecordType.AVRO;
     try (HoodieFileReader fileReader = HoodieIOFactory.getIOFactory(storage)
         .getReaderFactory(recordType)
         .getFileReader(DEFAULT_HUDI_CONFIG_FOR_READER, filePath)) {

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/index/HoodieIndexUtils.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/index/HoodieIndexUtils.java
@@ -404,18 +404,12 @@ public class HoodieIndexUtils {
     String partitionPath = inferPartitionPath(incoming, existing, writeSchemaWithMetaFields, keyGenerator,
         existingRecordContext, mergeResult, incomingBufferedRecord, existingBufferedRecord, incomingRecordContext);
     // When HoodieAvroRecordMerger creates a genuinely new BufferedRecord, it encodes the schema into
-    // incomingRecordContext. Re-encode into existingRecordContext so constructHoodieRecord (which uses
-    // existingRecordContext for the correct payload class) can resolve the schema for SPARK records.
-    BufferedRecord<R> mergeResultForConstruct = mergeResult;
-    if (mergeResult != incomingBufferedRecord && mergeResult != existingBufferedRecord) {
-      HoodieSchema mergedSchema = incomingRecordContext.getSchemaFromBufferRecord(mergeResult);
-      if (mergedSchema != null && existingRecordContext.getSchemaFromBufferRecord(mergeResult) == null) {
-        mergeResultForConstruct = BufferedRecords.fromEngineRecord(
-            mergeResult.getRecord(), mergeResult.getRecordKey(), mergedSchema,
-            existingRecordContext, Arrays.asList(orderingFieldNames), mergeResult.getHoodieOperation());
-      }
-    }
-    HoodieRecord<R> result = existingRecordContext.constructHoodieRecord(mergeResultForConstruct, partitionPath);
+    // incomingRecordContext. Use the schema-aware constructHoodieRecord overload so existingRecordContext
+    // can register the schema locally and resolve it for SPARK records.
+    HoodieSchema mergedSchema = incomingRecordContext.getSchemaFromBufferRecord(mergeResult);
+    HoodieRecord<R> result = mergedSchema != null
+        ? existingRecordContext.constructHoodieRecord(mergeResult, partitionPath, mergedSchema)
+        : existingRecordContext.constructHoodieRecord(mergeResult, partitionPath);
     HoodieRecord<R> withMeta = result.prependMetaFields(writeSchema, writeSchemaWithMetaFields,
         new MetadataValues().setRecordKey(incoming.getRecordKey()).setPartitionPath(partitionPath), properties);
     return Option.of(withMeta.wrapIntoHoodieRecordPayloadWithParams(writeSchemaWithMetaFields, properties, Option.empty(),
@@ -445,7 +439,7 @@ public class HoodieIndexUtils {
       if (actualSchema == null) {
         actualSchema = recordSchema;
       }
-      return keyGenerator.getPartitionPath(incomingRecordContext.convertToAvroRecord(resultingBufferedRecord.getRecord(), actualSchema));
+      return keyGenerator.getPartitionPath(incomingRecordContext.convertToAvroRecord(resultingBufferedRecord, actualSchema));
     }
   }
 

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/index/HoodieIndexUtils.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/index/HoodieIndexUtils.java
@@ -251,9 +251,10 @@ public class HoodieIndexUtils {
       return Collections.emptyList();
     }
     log.info("Going to filter {} keys from file {}", candidateRecordKeys.size(), filePath);
+    // TODO: The AVRO fallback here ignores the merger's configured type. This pre-dates the Lance PR
+    //  and should be addressed in a follow-up to respect the merger's record type for all formats.
     HoodieRecord.HoodieRecordType recordType =
-        HoodieFileFormat.fromFileExtension(FSUtils.getFileExtension(filePath.toString())).requiresSparkRecordType()
-            ? HoodieRecord.HoodieRecordType.SPARK : HoodieRecord.HoodieRecordType.AVRO;
+        HoodieFileFormat.fromFileExtension(FSUtils.getFileExtension(filePath.toString())).resolveRecordType(HoodieRecord.HoodieRecordType.AVRO);
     try (HoodieFileReader fileReader = HoodieIOFactory.getIOFactory(storage)
         .getReaderFactory(recordType)
         .getFileReader(DEFAULT_HUDI_CONFIG_FOR_READER, filePath)) {
@@ -526,8 +527,7 @@ public class HoodieIndexUtils {
     // Create a reader context for the existing records. In the case of merge-into commands, the incoming records
     // can be using an expression payload so here we rely on the table's configured payload class if it is required.
     HoodieRecord.HoodieRecordType recordTypeForExistingRecords =
-        hoodieTable.getMetaClient().getTableConfig().getBaseFileFormat().requiresSparkRecordType()
-            ? HoodieRecord.HoodieRecordType.SPARK : config.getRecordMerger().getRecordType();
+        hoodieTable.getMetaClient().getTableConfig().getBaseFileFormat().resolveRecordType(config.getRecordMerger().getRecordType());
     ReaderContextFactory<R> readerContextFactoryForExistingRecords = (ReaderContextFactory<R>) hoodieTable.getContext()
         .getReaderContextFactoryForWrite(hoodieTable.getMetaClient(), recordTypeForExistingRecords, hoodieTable.getMetaClient().getTableConfig().getProps());
     RecordContext<R> existingRecordContext = readerContextFactoryForExistingRecords.getContext().getRecordContext();
@@ -616,8 +616,7 @@ public class HoodieIndexUtils {
         incomingRecords.mapToPair(record -> Pair.of(record.getRecordKey(), record));
 
     HoodieRecord.HoodieRecordType recordType =
-        table.getMetaClient().getTableConfig().getBaseFileFormat().requiresSparkRecordType()
-            ? HoodieRecord.HoodieRecordType.SPARK : config.getRecordMerger().getRecordType();
+        table.getMetaClient().getTableConfig().getBaseFileFormat().resolveRecordType(config.getRecordMerger().getRecordType());
     ReaderContextFactory<R> readerContextFactory = (ReaderContextFactory<R>) table.getContext()
         .getReaderContextFactoryForWrite(table.getMetaClient(), recordType, config.getProps());
     HoodieReaderContext<R> readerContext = readerContextFactory.getContext();

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/io/FileGroupReaderBasedMergeHandle.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/io/FileGroupReaderBasedMergeHandle.java
@@ -430,7 +430,7 @@ public class FileGroupReaderBasedMergeHandle<T, I, K, O> extends HoodieWriteMerg
       if (record == null || record.getRecord() == null) {
         return null;
       }
-      return recordContext.convertToAvroRecord(record.getRecord(), recordContext.getSchemaFromBufferRecord(record));
+      return recordContext.convertToAvroRecord(record, recordContext.getSchemaFromBufferRecord(record));
     }
   }
 

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/io/HoodieReadHandle.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/io/HoodieReadHandle.java
@@ -75,8 +75,10 @@ public abstract class HoodieReadHandle<T, I, K, O> extends HoodieIOHandle<T, I, 
 
   protected HoodieFileReader createNewFileReader(HoodieBaseFile hoodieBaseFile) throws IOException {
     String extension = hoodieBaseFile.getStoragePath().getFileExtension();
-    HoodieRecord.HoodieRecordType recordType =
-        HoodieFileFormat.fromFileExtension(extension).resolveRecordType(this.config.getRecordMerger().getRecordType());
+    HoodieFileFormat format = HoodieFileFormat.fromFileExtensionOrNull(extension);
+    HoodieRecord.HoodieRecordType recordType = format != null
+        ? format.resolveRecordType(this.config.getRecordMerger().getRecordType())
+        : this.config.getRecordMerger().getRecordType();
     return HoodieIOFactory.getIOFactory(hoodieTable.getStorage())
         .getReaderFactory(recordType)
         .getFileReader(config, hoodieBaseFile.getStoragePath());

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/io/HoodieReadHandle.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/io/HoodieReadHandle.java
@@ -74,10 +74,9 @@ public abstract class HoodieReadHandle<T, I, K, O> extends HoodieIOHandle<T, I, 
   }
 
   protected HoodieFileReader createNewFileReader(HoodieBaseFile hoodieBaseFile) throws IOException {
-    String ext = hoodieBaseFile.getStoragePath().getFileExtension();
+    String extension = hoodieBaseFile.getStoragePath().getFileExtension();
     HoodieRecord.HoodieRecordType recordType =
-        HoodieFileFormat.fromFileExtension(ext).requiresSparkRecordType()
-            ? HoodieRecord.HoodieRecordType.SPARK : this.config.getRecordMerger().getRecordType();
+        HoodieFileFormat.fromFileExtension(extension).resolveRecordType(this.config.getRecordMerger().getRecordType());
     return HoodieIOFactory.getIOFactory(hoodieTable.getStorage())
         .getReaderFactory(recordType)
         .getFileReader(config, hoodieBaseFile.getStoragePath());

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/io/HoodieReadHandle.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/io/HoodieReadHandle.java
@@ -19,6 +19,8 @@
 package org.apache.hudi.io;
 
 import org.apache.hudi.common.model.HoodieBaseFile;
+import org.apache.hudi.common.model.HoodieFileFormat;
+import org.apache.hudi.common.model.HoodieRecord;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.common.util.collection.Pair;
 import org.apache.hudi.config.HoodieWriteConfig;
@@ -68,14 +70,16 @@ public abstract class HoodieReadHandle<T, I, K, O> extends HoodieIOHandle<T, I, 
   }
 
   protected HoodieFileReader createNewFileReader() throws IOException {
-    return HoodieIOFactory.getIOFactory(hoodieTable.getStorage())
-        .getReaderFactory(this.config.getRecordMerger().getRecordType())
-        .getFileReader(config, getLatestBaseFile().getStoragePath());
+    return createNewFileReader(getLatestBaseFile());
   }
 
   protected HoodieFileReader createNewFileReader(HoodieBaseFile hoodieBaseFile) throws IOException {
+    String ext = hoodieBaseFile.getStoragePath().getFileExtension();
+    HoodieRecord.HoodieRecordType recordType =
+        HoodieFileFormat.fromFileExtension(ext).requiresSparkRecordType()
+            ? HoodieRecord.HoodieRecordType.SPARK : this.config.getRecordMerger().getRecordType();
     return HoodieIOFactory.getIOFactory(hoodieTable.getStorage())
-        .getReaderFactory(this.config.getRecordMerger().getRecordType())
+        .getReaderFactory(recordType)
         .getFileReader(config, hoodieBaseFile.getStoragePath());
   }
 }

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/HoodieTable.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/HoodieTable.java
@@ -1278,7 +1278,7 @@ public abstract class HoodieTable<T, I, K, O> implements Serializable {
 
   public ReaderContextFactory<T> getReaderContextFactoryForWrite() {
     HoodieRecord.HoodieRecordType recordType =
-        metaClient.getTableConfig().getBaseFileFormat().resolveRecordType(config.getRecordMerger().getRecordType());
+        getBaseFileFormat().resolveRecordType(config.getRecordMerger().getRecordType());
     // question: should we just return null when context is serialized as null? the mismatch reader context would throw anyway.
     return (ReaderContextFactory<T>) getContext().getReaderContextFactoryForWrite(metaClient, recordType, config.getProps());
   }

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/HoodieTable.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/HoodieTable.java
@@ -1277,8 +1277,8 @@ public abstract class HoodieTable<T, I, K, O> implements Serializable {
   }
 
   public ReaderContextFactory<T> getReaderContextFactoryForWrite() {
-    HoodieRecord.HoodieRecordType recordType = metaClient.getTableConfig().getBaseFileFormat().requiresSparkRecordType()
-        ? HoodieRecord.HoodieRecordType.SPARK : config.getRecordMerger().getRecordType();
+    HoodieRecord.HoodieRecordType recordType =
+        metaClient.getTableConfig().getBaseFileFormat().resolveRecordType(config.getRecordMerger().getRecordType());
     // question: should we just return null when context is serialized as null? the mismatch reader context would throw anyway.
     return (ReaderContextFactory<T>) getContext().getReaderContextFactoryForWrite(metaClient, recordType, config.getProps());
   }

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/HoodieTable.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/HoodieTable.java
@@ -47,6 +47,7 @@ import org.apache.hudi.common.model.HoodieFileFormat;
 import org.apache.hudi.common.model.HoodieIndexDefinition;
 import org.apache.hudi.common.model.HoodieIndexMetadata;
 import org.apache.hudi.common.model.HoodieKey;
+import org.apache.hudi.common.model.HoodieRecord;
 import org.apache.hudi.common.model.HoodieWriteStat;
 import org.apache.hudi.common.schema.HoodieSchema;
 import org.apache.hudi.common.schema.HoodieSchemaCompatibility;
@@ -1276,8 +1277,9 @@ public abstract class HoodieTable<T, I, K, O> implements Serializable {
   }
 
   public ReaderContextFactory<T> getReaderContextFactoryForWrite() {
+    HoodieRecord.HoodieRecordType recordType = metaClient.getTableConfig().getBaseFileFormat().requiresSparkRecordType()
+        ? HoodieRecord.HoodieRecordType.SPARK : config.getRecordMerger().getRecordType();
     // question: should we just return null when context is serialized as null? the mismatch reader context would throw anyway.
-    return (ReaderContextFactory<T>) getContext().getReaderContextFactoryForWrite(metaClient, config.getRecordMerger().getRecordType(),
-        config.getProps());
+    return (ReaderContextFactory<T>) getContext().getReaderContextFactoryForWrite(metaClient, recordType, config.getProps());
   }
 }

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/io/storage/row/HoodieInternalRowFileWriterFactory.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/io/storage/row/HoodieInternalRowFileWriterFactory.java
@@ -105,7 +105,7 @@ public class HoodieInternalRowFileWriterFactory {
         .storage(table.getStorage())
         .populateMetaFields(writeConfig.populateMetaFields())
         .maxFileSize(writeConfig.getLongOrDefault(HoodieStorageConfig.LANCE_MAX_FILE_SIZE))
-        .bloomFilter(tryInstantiateBloomFilter(writeConfig))
+        .bloomFilterOpt(tryInstantiateBloomFilter(writeConfig))
         .build();
   }
 

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/io/storage/row/HoodieInternalRowFileWriterFactory.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/io/storage/row/HoodieInternalRowFileWriterFactory.java
@@ -64,8 +64,7 @@ public class HoodieInternalRowFileWriterFactory {
     if (PARQUET.getFileExtension().equals(extension)) {
       return newParquetInternalRowFileWriter(path, hoodieTable, writeConfig, schema, tryInstantiateBloomFilter(writeConfig));
     } else if (LANCE.getFileExtension().equals(extension)) {
-      long maxFileSize = writeConfig.getLongOrDefault(HoodieStorageConfig.LANCE_MAX_FILE_SIZE);
-      return newLanceInternalRowFileWriter(path, hoodieTable, schema, maxFileSize);
+      return newLanceInternalRowFileWriter(path, hoodieTable, schema, writeConfig);
     }
     throw new UnsupportedOperationException(extension + " format not supported yet.");
   }
@@ -97,14 +96,16 @@ public class HoodieInternalRowFileWriterFactory {
   private static HoodieInternalRowFileWriter newLanceInternalRowFileWriter(StoragePath path,
                                                                            HoodieTable table,
                                                                            StructType structType,
-                                                                           long maxFileSize)
+                                                                           HoodieWriteConfig writeConfig)
       throws IOException {
     return HoodieSparkLanceWriter.builder()
         .file(path)
         .sparkSchema(structType)
         .taskContextSupplier(new LocalTaskContextSupplier())
         .storage(table.getStorage())
-        .maxFileSize(maxFileSize)
+        .populateMetaFields(writeConfig.populateMetaFields())
+        .maxFileSize(writeConfig.getLongOrDefault(HoodieStorageConfig.LANCE_MAX_FILE_SIZE))
+        .bloomFilter(tryInstantiateBloomFilter(writeConfig))
         .build();
   }
 

--- a/hudi-client/hudi-spark-client/src/main/scala/org/apache/hudi/SparkFileFormatInternalRecordContext.scala
+++ b/hudi-client/hudi-spark-client/src/main/scala/org/apache/hudi/SparkFileFormatInternalRecordContext.scala
@@ -21,13 +21,17 @@ package org.apache.hudi
 
 import org.apache.avro.generic.{GenericRecord, IndexedRecord}
 import org.apache.hudi.common.engine.RecordContext
+import org.apache.hudi.common.model.HoodieRecord
 import org.apache.hudi.common.schema.HoodieSchema
 import org.apache.hudi.common.table.HoodieTableConfig
+import org.apache.hudi.exception.HoodieException
 import org.apache.spark.sql.HoodieInternalRowUtils
 import org.apache.spark.sql.avro.{HoodieAvroDeserializer, HoodieAvroSerializer}
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.hudi.SparkAdapter
 
+import java.io.IOException
+import java.util.Properties
 import scala.collection.mutable
 
 trait SparkFileFormatInternalRecordContext extends BaseSparkInternalRecordContext {
@@ -35,9 +39,53 @@ trait SparkFileFormatInternalRecordContext extends BaseSparkInternalRecordContex
   lazy val sparkAdapter: SparkAdapter = SparkAdapterSupport.sparkAdapter
   private val deserializerMap: mutable.Map[HoodieSchema, HoodieAvroDeserializer] = mutable.Map()
   private val serializerMap: mutable.Map[HoodieSchema, HoodieAvroSerializer] = mutable.Map()
+  // Maps InternalRow instances (by identity) to their original Avro records when the Avro record's
+  // schema differs from the BufferedRecord schema. This handles ExpressionPayload records whose
+  // getInsertValue result carries the data schema (no meta fields) while the BufferedRecord
+  // stores writeSchemaWithMetaFields. Returning the original Avro record from convertToAvroRecord
+  // lets ExpressionPayload.combineAndGetUpdateValue decode bytes with the correct data schema.
+  private val avroRecordByRow: java.util.IdentityHashMap[InternalRow, GenericRecord] =
+    new java.util.IdentityHashMap[InternalRow, GenericRecord]()
 
   override def supportsParquetRowIndex: Boolean = {
     HoodieSparkUtils.gteqSpark3_5
+  }
+
+  /**
+   * Extracts the engine-native record data from a [[HoodieRecord]].
+   *
+   * For Spark records the data is already an [[InternalRow]]. For records coming from
+   * Avro-payload-based paths (e.g. [[org.apache.spark.sql.hudi.command.payload.ExpressionPayload]]
+   * used in SQL MERGE INTO operations), the Avro representation is extracted via
+   * [[HoodieRecord#toIndexedRecord]] and then deserialized to [[InternalRow]].
+   */
+  override def extractDataFromRecord(record: HoodieRecord[_], schema: HoodieSchema, properties: Properties): InternalRow = {
+    val data = record.getData
+    if (data == null || data.isInstanceOf[InternalRow]) {
+      data.asInstanceOf[InternalRow]
+    } else {
+      // For records with non-InternalRow payloads (e.g. ExpressionPayload from SQL MERGE INTO),
+      // extract the raw Avro record and convert it to InternalRow.
+      try {
+        val avroRecordOpt = record.toIndexedRecord(schema, properties)
+        if (avroRecordOpt.isPresent) {
+          val avroRecord = avroRecordOpt.get().getData.asInstanceOf[GenericRecord]
+          val row = convertAvroRecord(avroRecord)
+          // When the Avro record's schema differs from the BufferedRecord schema (e.g. ExpressionPayload
+          // getInsertValue returns a data-schema record while schema is writeSchemaWithMetaFields),
+          // cache the original Avro record keyed by the InternalRow identity. convertToAvroRecord will
+          // return it directly, preserving the data schema so ExpressionPayload.combineAndGetUpdateValue
+          // can decode the payload bytes with the correct PAYLOAD_RECORD_AVRO_SCHEMA.
+          if (!avroRecord.getSchema.equals(schema.toAvroSchema)) {
+            avroRecordByRow.put(row, avroRecord)
+          }
+          row
+        } else null
+      } catch {
+        case e: IOException =>
+          throw new HoodieException("Failed to extract data from record: " + record, e)
+      }
+    }
   }
 
   /**
@@ -56,6 +104,14 @@ trait SparkFileFormatInternalRecordContext extends BaseSparkInternalRecordContex
   }
 
   override def convertToAvroRecord(record: InternalRow, schema: HoodieSchema): GenericRecord = {
+    // If the InternalRow was produced from a payload (e.g. ExpressionPayload) whose Avro schema
+    // differs from the BufferedRecord schema, return the original Avro record directly. This avoids
+    // trying to serialize an InternalRow with the wrong schema and preserves the schema expected
+    // by ExpressionPayload.combineAndGetUpdateValue (i.e., PAYLOAD_RECORD_AVRO_SCHEMA / data schema).
+    val cached = avroRecordByRow.remove(record)
+    if (cached != null) {
+      return cached
+    }
     val structType = HoodieInternalRowUtils.getCachedSchema(schema)
     val serializer = serializerMap.getOrElseUpdate(schema, {
       sparkAdapter.createAvroSerializer(structType, schema, schema.isNullable)

--- a/hudi-client/hudi-spark-client/src/main/scala/org/apache/hudi/SparkFileFormatInternalRecordContext.scala
+++ b/hudi-client/hudi-spark-client/src/main/scala/org/apache/hudi/SparkFileFormatInternalRecordContext.scala
@@ -64,9 +64,12 @@ trait SparkFileFormatInternalRecordContext extends BaseSparkInternalRecordContex
       try {
         val avroRecordOpt = record.toIndexedRecord(schema, properties)
         if (avroRecordOpt.isPresent) {
-          val avroRecord = avroRecordOpt.get().getData.asInstanceOf[GenericRecord]
-          val row = convertAvroRecord(avroRecord)
-          val originalAvro = if (!avroRecord.getSchema.equals(schema.toAvroSchema)) avroRecord else null
+          val indexedRecord = avroRecordOpt.get().getData
+          val row = convertAvroRecord(indexedRecord)
+          val originalAvro = indexedRecord match {
+            case g: GenericRecord if !g.getSchema.equals(schema.toAvroSchema) => g
+            case _ => null
+          }
           ExtractedData.of(row, originalAvro)
         } else {
           ExtractedData.of(null.asInstanceOf[InternalRow])

--- a/hudi-client/hudi-spark-client/src/main/scala/org/apache/hudi/SparkFileFormatInternalRecordContext.scala
+++ b/hudi-client/hudi-spark-client/src/main/scala/org/apache/hudi/SparkFileFormatInternalRecordContext.scala
@@ -62,6 +62,11 @@ trait SparkFileFormatInternalRecordContext extends BaseSparkInternalRecordContex
   private val avroRecordByRow: java.util.IdentityHashMap[InternalRow, GenericRecord] =
     new java.util.IdentityHashMap[InternalRow, GenericRecord]()
 
+  // Single-shot flag set by convertToAvroRecord when it returned a cached record,
+  // consumed by consumeLastAvroRecordFromCache. Avoids relying on schema-inequality
+  // heuristics in downstream code (UpdateProcessor).
+  private var lastAvroFromCache: Boolean = false
+
   override def supportsParquetRowIndex: Boolean = {
     HoodieSparkUtils.gteqSpark3_5
   }
@@ -125,13 +130,21 @@ trait SparkFileFormatInternalRecordContext extends BaseSparkInternalRecordContex
     // by ExpressionPayload.combineAndGetUpdateValue (i.e., PAYLOAD_RECORD_AVRO_SCHEMA / data schema).
     val cached = avroRecordByRow.remove(record)
     if (cached != null) {
+      lastAvroFromCache = true
       return cached
     }
+    lastAvroFromCache = false
     val structType = HoodieInternalRowUtils.getCachedSchema(schema)
     val serializer = serializerMap.getOrElseUpdate(schema, {
       sparkAdapter.createAvroSerializer(structType, schema, schema.isNullable)
     })
     serializer.serialize(record).asInstanceOf[GenericRecord]
+  }
+
+  override def consumeLastAvroRecordFromCache(): Boolean = {
+    val flag = lastAvroFromCache
+    lastAvroFromCache = false
+    flag
   }
 }
 

--- a/hudi-client/hudi-spark-client/src/main/scala/org/apache/hudi/SparkFileFormatInternalRecordContext.scala
+++ b/hudi-client/hudi-spark-client/src/main/scala/org/apache/hudi/SparkFileFormatInternalRecordContext.scala
@@ -20,7 +20,7 @@
 package org.apache.hudi
 
 import org.apache.avro.generic.{GenericRecord, IndexedRecord}
-import org.apache.hudi.common.engine.RecordContext
+import org.apache.hudi.common.engine.{ExtractedData, RecordContext}
 import org.apache.hudi.common.model.HoodieRecord
 import org.apache.hudi.common.schema.HoodieSchema
 import org.apache.hudi.common.table.HoodieTableConfig
@@ -39,33 +39,6 @@ trait SparkFileFormatInternalRecordContext extends BaseSparkInternalRecordContex
   lazy val sparkAdapter: SparkAdapter = SparkAdapterSupport.sparkAdapter
   private val deserializerMap: mutable.Map[HoodieSchema, HoodieAvroDeserializer] = mutable.Map()
   private val serializerMap: mutable.Map[HoodieSchema, HoodieAvroSerializer] = mutable.Map()
-  // Maps InternalRow instances (by identity) to their original Avro records when the Avro record's
-  // schema differs from the BufferedRecord schema. This handles ExpressionPayload records whose
-  // getInsertValue result carries the data schema (no meta fields) while the BufferedRecord
-  // stores writeSchemaWithMetaFields. Returning the original Avro record from convertToAvroRecord
-  // lets ExpressionPayload.combineAndGetUpdateValue decode bytes with the correct data schema.
-  //
-  // IMPORTANT INVARIANT: The identity link between InternalRow and GenericRecord must survive
-  // from extractDataFromRecord (where the cache is populated) to convertToAvroRecord (where
-  // it is consumed via remove()). Any operation that replaces the InternalRow object in between
-  // — such as BufferedRecord.seal() (which calls InternalRow.copy()), replaceRecord(), or
-  // project() — would break this link and cause fallback to schema-based serialization.
-  //
-  // Current safety: In the MOR read path (UpdateProcessor.handleNonDeletes), convertToAvroRecord
-  // is called on the original InternalRow BEFORE seal() runs in super.handleNonDeletes().
-  // In the COW write path (HoodieIndexUtils.inferPartitionPath), convertToAvroRecord is similarly
-  // called before any record transformation.
-  // LIFECYCLE: Entries are added in extractDataFromRecord and removed in convertToAvroRecord.
-  // If a record is cached but never reaches convertToAvroRecord (e.g., SENTINEL records that
-  // are filtered out), the entry leaks. This is bounded because: (1) SENTINEL records are rare,
-  // and (2) this instance is scoped to a single FileGroup read and is GC'd afterwards.
-  private val avroRecordByRow: java.util.IdentityHashMap[InternalRow, GenericRecord] =
-    new java.util.IdentityHashMap[InternalRow, GenericRecord]()
-
-  // Single-shot flag set by convertToAvroRecord when it returned a cached record,
-  // consumed by consumeLastAvroRecordFromCache. Avoids relying on schema-inequality
-  // heuristics in downstream code (UpdateProcessor).
-  private var lastAvroFromCache: Boolean = false
 
   override def supportsParquetRowIndex: Boolean = {
     HoodieSparkUtils.gteqSpark3_5
@@ -77,30 +50,27 @@ trait SparkFileFormatInternalRecordContext extends BaseSparkInternalRecordContex
    * For Spark records the data is already an [[InternalRow]]. For records coming from
    * Avro-payload-based paths (e.g. [[org.apache.spark.sql.hudi.command.payload.ExpressionPayload]]
    * used in SQL MERGE INTO operations), the Avro representation is extracted via
-   * [[HoodieRecord#toIndexedRecord]] and then deserialized to [[InternalRow]].
+   * [[HoodieRecord#toIndexedRecord]] and then deserialized to [[InternalRow]]. When the Avro
+   * record's schema differs from the BufferedRecord schema (e.g. ExpressionPayload's
+   * getInsertValue returns a data-schema record while the buffered schema is
+   * writeSchemaWithMetaFields), the original Avro record is propagated through
+   * [[ExtractedData]] so downstream code can decode it with the correct source schema.
    */
-  override def extractDataFromRecord(record: HoodieRecord[_], schema: HoodieSchema, properties: Properties): InternalRow = {
+  override def extractDataFromRecord(record: HoodieRecord[_], schema: HoodieSchema, properties: Properties): ExtractedData[InternalRow] = {
     val data = record.getData
     if (data == null || data.isInstanceOf[InternalRow]) {
-      data.asInstanceOf[InternalRow]
+      ExtractedData.of(data.asInstanceOf[InternalRow])
     } else {
-      // For records with non-InternalRow payloads (e.g. ExpressionPayload from SQL MERGE INTO),
-      // extract the raw Avro record and convert it to InternalRow.
       try {
         val avroRecordOpt = record.toIndexedRecord(schema, properties)
         if (avroRecordOpt.isPresent) {
           val avroRecord = avroRecordOpt.get().getData.asInstanceOf[GenericRecord]
           val row = convertAvroRecord(avroRecord)
-          // When the Avro record's schema differs from the BufferedRecord schema (e.g. ExpressionPayload
-          // getInsertValue returns a data-schema record while schema is writeSchemaWithMetaFields),
-          // cache the original Avro record keyed by the InternalRow identity. convertToAvroRecord will
-          // return it directly, preserving the data schema so ExpressionPayload.combineAndGetUpdateValue
-          // can decode the payload bytes with the correct PAYLOAD_RECORD_AVRO_SCHEMA.
-          if (!avroRecord.getSchema.equals(schema.toAvroSchema)) {
-            avroRecordByRow.put(row, avroRecord)
-          }
-          row
-        } else null
+          val originalAvro = if (!avroRecord.getSchema.equals(schema.toAvroSchema)) avroRecord else null
+          ExtractedData.of(row, originalAvro)
+        } else {
+          ExtractedData.of(null.asInstanceOf[InternalRow])
+        }
       } catch {
         case e: IOException =>
           throw new HoodieException("Failed to extract data from record: " + record, e)
@@ -124,37 +94,15 @@ trait SparkFileFormatInternalRecordContext extends BaseSparkInternalRecordContex
   }
 
   override def convertToAvroRecord(record: InternalRow, schema: HoodieSchema): GenericRecord = {
-    // If the InternalRow was produced from a payload (e.g. ExpressionPayload) whose Avro schema
-    // differs from the BufferedRecord schema, return the original Avro record directly. This avoids
-    // trying to serialize an InternalRow with the wrong schema and preserves the schema expected
-    // by ExpressionPayload.combineAndGetUpdateValue (i.e., PAYLOAD_RECORD_AVRO_SCHEMA / data schema).
-    val cached = avroRecordByRow.remove(record)
-    if (cached != null) {
-      lastAvroFromCache = true
-      return cached
-    }
-    lastAvroFromCache = false
     val structType = HoodieInternalRowUtils.getCachedSchema(schema)
     val serializer = serializerMap.getOrElseUpdate(schema, {
       sparkAdapter.createAvroSerializer(structType, schema, schema.isNullable)
     })
     serializer.serialize(record).asInstanceOf[GenericRecord]
   }
-
-  override def consumeLastAvroRecordFromCache(): Boolean = {
-    val flag = lastAvroFromCache
-    lastAvroFromCache = false
-    flag
-  }
 }
 
 object SparkFileFormatInternalRecordContext {
-  // THREAD SAFETY NOTE: FIELD_ACCESSOR_INSTANCE is a static singleton used ONLY via
-  // HoodieSparkRecord.isDeleteRecord(), which calls getFieldVal/getSealedRecord but
-  // NEVER calls extractDataFromRecord or convertToAvroRecord. Therefore the singleton's
-  // avroRecordByRow cache is always empty, and no thread-safety or memory-leak concern
-  // applies. Per-task instances created via apply(tableConfig) are not shared across threads.
-  // If new call sites are added for the singleton, this invariant must be re-evaluated.
   private val FIELD_ACCESSOR_INSTANCE = SparkFileFormatInternalRecordContext.apply()
   def getFieldAccessorInstance: RecordContext[InternalRow] = FIELD_ACCESSOR_INSTANCE
   def apply(): SparkFileFormatInternalRecordContext = new BaseSparkInternalRecordContext() with SparkFileFormatInternalRecordContext

--- a/hudi-client/hudi-spark-client/src/main/scala/org/apache/hudi/SparkFileFormatInternalRecordContext.scala
+++ b/hudi-client/hudi-spark-client/src/main/scala/org/apache/hudi/SparkFileFormatInternalRecordContext.scala
@@ -55,6 +55,10 @@ trait SparkFileFormatInternalRecordContext extends BaseSparkInternalRecordContex
   // is called on the original InternalRow BEFORE seal() runs in super.handleNonDeletes().
   // In the COW write path (HoodieIndexUtils.inferPartitionPath), convertToAvroRecord is similarly
   // called before any record transformation.
+  // LIFECYCLE: Entries are added in extractDataFromRecord and removed in convertToAvroRecord.
+  // If a record is cached but never reaches convertToAvroRecord (e.g., SENTINEL records that
+  // are filtered out), the entry leaks. This is bounded because: (1) SENTINEL records are rare,
+  // and (2) this instance is scoped to a single FileGroup read and is GC'd afterwards.
   private val avroRecordByRow: java.util.IdentityHashMap[InternalRow, GenericRecord] =
     new java.util.IdentityHashMap[InternalRow, GenericRecord]()
 
@@ -132,6 +136,12 @@ trait SparkFileFormatInternalRecordContext extends BaseSparkInternalRecordContex
 }
 
 object SparkFileFormatInternalRecordContext {
+  // THREAD SAFETY NOTE: FIELD_ACCESSOR_INSTANCE is a static singleton used ONLY via
+  // HoodieSparkRecord.isDeleteRecord(), which calls getFieldVal/getSealedRecord but
+  // NEVER calls extractDataFromRecord or convertToAvroRecord. Therefore the singleton's
+  // avroRecordByRow cache is always empty, and no thread-safety or memory-leak concern
+  // applies. Per-task instances created via apply(tableConfig) are not shared across threads.
+  // If new call sites are added for the singleton, this invariant must be re-evaluated.
   private val FIELD_ACCESSOR_INSTANCE = SparkFileFormatInternalRecordContext.apply()
   def getFieldAccessorInstance: RecordContext[InternalRow] = FIELD_ACCESSOR_INSTANCE
   def apply(): SparkFileFormatInternalRecordContext = new BaseSparkInternalRecordContext() with SparkFileFormatInternalRecordContext

--- a/hudi-client/hudi-spark-client/src/main/scala/org/apache/hudi/SparkFileFormatInternalRecordContext.scala
+++ b/hudi-client/hudi-spark-client/src/main/scala/org/apache/hudi/SparkFileFormatInternalRecordContext.scala
@@ -44,6 +44,17 @@ trait SparkFileFormatInternalRecordContext extends BaseSparkInternalRecordContex
   // getInsertValue result carries the data schema (no meta fields) while the BufferedRecord
   // stores writeSchemaWithMetaFields. Returning the original Avro record from convertToAvroRecord
   // lets ExpressionPayload.combineAndGetUpdateValue decode bytes with the correct data schema.
+  //
+  // IMPORTANT INVARIANT: The identity link between InternalRow and GenericRecord must survive
+  // from extractDataFromRecord (where the cache is populated) to convertToAvroRecord (where
+  // it is consumed via remove()). Any operation that replaces the InternalRow object in between
+  // — such as BufferedRecord.seal() (which calls InternalRow.copy()), replaceRecord(), or
+  // project() — would break this link and cause fallback to schema-based serialization.
+  //
+  // Current safety: In the MOR read path (UpdateProcessor.handleNonDeletes), convertToAvroRecord
+  // is called on the original InternalRow BEFORE seal() runs in super.handleNonDeletes().
+  // In the COW write path (HoodieIndexUtils.inferPartitionPath), convertToAvroRecord is similarly
+  // called before any record transformation.
   private val avroRecordByRow: java.util.IdentityHashMap[InternalRow, GenericRecord] =
     new java.util.IdentityHashMap[InternalRow, GenericRecord]()
 

--- a/hudi-common/src/main/java/org/apache/hudi/avro/AvroRecordContext.java
+++ b/hudi-common/src/main/java/org/apache/hudi/avro/AvroRecordContext.java
@@ -19,6 +19,7 @@
 
 package org.apache.hudi.avro;
 
+import org.apache.hudi.common.engine.ExtractedData;
 import org.apache.hudi.common.engine.RecordContext;
 import org.apache.hudi.common.model.HoodieAvroIndexedRecord;
 import org.apache.hudi.common.model.HoodieEmptyRecord;
@@ -128,9 +129,10 @@ public class AvroRecordContext extends RecordContext<IndexedRecord> {
   }
 
   @Override
-  public IndexedRecord extractDataFromRecord(HoodieRecord record, HoodieSchema schema, Properties properties) {
+  public ExtractedData<IndexedRecord> extractDataFromRecord(HoodieRecord record, HoodieSchema schema, Properties properties) {
     try {
-      return record.toIndexedRecord(schema, properties).map(HoodieAvroIndexedRecord::getData).orElse(null);
+      IndexedRecord data = record.toIndexedRecord(schema, properties).map(HoodieAvroIndexedRecord::getData).orElse(null);
+      return ExtractedData.of(data);
     } catch (IOException e) {
       throw new HoodieException("Failed to extract data from record: " + record, e);
     }

--- a/hudi-common/src/main/java/org/apache/hudi/common/engine/ExtractedData.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/engine/ExtractedData.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.hudi.common.engine;
+
+import org.apache.avro.generic.GenericRecord;
+
+import javax.annotation.Nullable;
+
+/**
+ * Result of {@link RecordContext#extractDataFromRecord} carrying the engine-native row plus,
+ * when extraction went through an Avro payload (e.g. {@code ExpressionPayload} in SQL MERGE INTO),
+ * the original Avro record produced by {@code HoodieRecord#toIndexedRecord}.
+ *
+ * <p>The original Avro record is propagated to {@link org.apache.hudi.common.table.read.BufferedRecord}
+ * so downstream code (e.g. {@code UpdateProcessor}) can decode the payload bytes with the correct
+ * source schema instead of re-serializing the engine-native row through a possibly-mismatched schema.
+ */
+public final class ExtractedData<T> {
+
+  private final T data;
+  @Nullable
+  private final GenericRecord originalAvroRecord;
+
+  private ExtractedData(T data, @Nullable GenericRecord originalAvroRecord) {
+    this.data = data;
+    this.originalAvroRecord = originalAvroRecord;
+  }
+
+  public static <T> ExtractedData<T> of(T data) {
+    return new ExtractedData<>(data, null);
+  }
+
+  public static <T> ExtractedData<T> of(T data, @Nullable GenericRecord originalAvroRecord) {
+    return new ExtractedData<>(data, originalAvroRecord);
+  }
+
+  public T getData() {
+    return data;
+  }
+
+  @Nullable
+  public GenericRecord getOriginalAvroRecord() {
+    return originalAvroRecord;
+  }
+}

--- a/hudi-common/src/main/java/org/apache/hudi/common/engine/RecordContext.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/engine/RecordContext.java
@@ -88,8 +88,16 @@ public abstract class RecordContext<T> implements Serializable {
     this.partitionPath = partitionPath;
   }
 
-  public T extractDataFromRecord(HoodieRecord record, HoodieSchema schema, Properties properties) {
-    return (T) record.getData();
+  /**
+   * Extracts the engine-native record data from a {@link HoodieRecord}.
+   *
+   * <p>Returns an {@link ExtractedData} so engines whose extraction path goes through an Avro
+   * payload (e.g. {@code ExpressionPayload} in SQL MERGE INTO on Spark) can hand the original
+   * Avro record back to downstream callers without losing its source schema. The default
+   * implementation returns the record's data with no Avro hint.
+   */
+  public ExtractedData<T> extractDataFromRecord(HoodieRecord record, HoodieSchema schema, Properties properties) {
+    return ExtractedData.of((T) record.getData());
   }
 
   /**
@@ -136,6 +144,30 @@ public abstract class RecordContext<T> implements Serializable {
    */
   public HoodieRecord<T> constructHoodieRecord(BufferedRecord<T> bufferedRecord) {
     return constructHoodieRecord(bufferedRecord, partitionPath);
+  }
+
+  /**
+   * Schema-aware variant of {@link #constructHoodieRecord(BufferedRecord, String)}.
+   *
+   * <p>Use this when the {@link BufferedRecord} was produced against a different
+   * {@link RecordContext} (e.g. after an Avro-merger created a new BufferedRecord and encoded
+   * its schemaId into the {@code incoming} context), so that this context can resolve the schema
+   * by registering it locally and constructing a thin wrapper with a locally-valid schemaId.
+   * If the schema is already encoded with the same id, the call is forwarded directly.
+   */
+  public HoodieRecord<T> constructHoodieRecord(BufferedRecord<T> bufferedRecord, String partitionPath, HoodieSchema schema) {
+    Integer localSchemaId = encodeSchema(schema);
+    if (localSchemaId.equals(bufferedRecord.getSchemaId())) {
+      return constructHoodieRecord(bufferedRecord, partitionPath);
+    }
+    BufferedRecord<T> rewrapped = new BufferedRecord<>(
+        bufferedRecord.getRecordKey(),
+        bufferedRecord.getOrderingValue(),
+        bufferedRecord.getRecord(),
+        localSchemaId,
+        bufferedRecord.getHoodieOperation(),
+        bufferedRecord.getOriginalAvroRecord());
+    return constructHoodieRecord(rewrapped, partitionPath);
   }
 
   /**
@@ -245,20 +277,18 @@ public abstract class RecordContext<T> implements Serializable {
   public abstract GenericRecord convertToAvroRecord(T record, HoodieSchema schema);
 
   /**
-   * Reports whether the most recent {@link #convertToAvroRecord} call returned an Avro
-   * record produced upstream (e.g. cached by {@link #extractDataFromRecord} for
-   * ExpressionPayload) rather than one freshly serialized from the engine-native record.
-   *
-   * <p>This is an explicit signal intended to disambiguate the "came from cache" case from
-   * a legitimate schema-evolution skew between writer and reader schemas. Callers that need
-   * to branch on this distinction should invoke this method immediately after the
-   * corresponding {@code convertToAvroRecord} call; the flag is single-shot and resets on read.
-   *
-   * <p>Default implementation returns {@code false} for engines/contexts that do not
-   * maintain such a cache.
+   * Returns the Avro representation of the given buffered record. If the record was extracted
+   * from an Avro payload (e.g. {@code ExpressionPayload}) and still carries the original Avro
+   * record on the {@link BufferedRecord}, that record is returned directly so its source schema
+   * is preserved. Otherwise the engine-native row is serialized to Avro via
+   * {@link #convertToAvroRecord(Object, HoodieSchema)}.
    */
-  public boolean consumeLastAvroRecordFromCache() {
-    return false;
+  public GenericRecord convertToAvroRecord(BufferedRecord<T> bufferedRecord, HoodieSchema schema) {
+    GenericRecord original = bufferedRecord.getOriginalAvroRecord();
+    if (original != null) {
+      return original;
+    }
+    return convertToAvroRecord(bufferedRecord.getRecord(), schema);
   }
 
   /**

--- a/hudi-common/src/main/java/org/apache/hudi/common/engine/RecordContext.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/engine/RecordContext.java
@@ -245,6 +245,23 @@ public abstract class RecordContext<T> implements Serializable {
   public abstract GenericRecord convertToAvroRecord(T record, HoodieSchema schema);
 
   /**
+   * Reports whether the most recent {@link #convertToAvroRecord} call returned an Avro
+   * record produced upstream (e.g. cached by {@link #extractDataFromRecord} for
+   * ExpressionPayload) rather than one freshly serialized from the engine-native record.
+   *
+   * <p>This is an explicit signal intended to disambiguate the "came from cache" case from
+   * a legitimate schema-evolution skew between writer and reader schemas. Callers that need
+   * to branch on this distinction should invoke this method immediately after the
+   * corresponding {@code convertToAvroRecord} call; the flag is single-shot and resets on read.
+   *
+   * <p>Default implementation returns {@code false} for engines/contexts that do not
+   * maintain such a cache.
+   */
+  public boolean consumeLastAvroRecordFromCache() {
+    return false;
+  }
+
+  /**
    * Fills an empty row with record key fields and returns.
    *
    * <p>When `emitDelete` is true for FileGroup reader and payload for DELETE record is empty,

--- a/hudi-common/src/main/java/org/apache/hudi/common/model/HoodieAvroRecordMerger.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/model/HoodieAvroRecordMerger.java
@@ -55,9 +55,9 @@ public class HoodieAvroRecordMerger implements HoodieRecordMerger, OperationMode
       return newer;
     }
     init(props);
-    IndexedRecord previousAvroData = older.getRecord() == null ? null : recordContext.convertToAvroRecord(older.getRecord(), recordContext.getSchemaFromBufferRecord(older));
+    IndexedRecord previousAvroData = older.getRecord() == null ? null : recordContext.convertToAvroRecord(older, recordContext.getSchemaFromBufferRecord(older));
     HoodieSchema newerSchema = recordContext.getSchemaFromBufferRecord(newer);
-    GenericRecord newerAvroRecord = newer.getRecord() == null ? null : recordContext.convertToAvroRecord(newer.getRecord(), recordContext.getSchemaFromBufferRecord(newer));
+    GenericRecord newerAvroRecord = newer.getRecord() == null ? null : recordContext.convertToAvroRecord(newer, newerSchema);
     HoodieRecordPayload payload = HoodieRecordUtils.loadPayload(payloadClass, newerAvroRecord, newer.getOrderingValue());
 
     if (previousAvroData == null) {

--- a/hudi-common/src/main/java/org/apache/hudi/common/model/HoodieFileFormat.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/model/HoodieFileFormat.java
@@ -78,6 +78,14 @@ public enum HoodieFileFormat {
     return this == LANCE;
   }
 
+  /**
+   * Resolves the record type to use for this file format: returns SPARK if this format
+   * requires it, otherwise returns the given fallback type.
+   */
+  public HoodieRecord.HoodieRecordType resolveRecordType(HoodieRecord.HoodieRecordType fallback) {
+    return requiresSparkRecordType() ? HoodieRecord.HoodieRecordType.SPARK : fallback;
+  }
+
   public static HoodieFileFormat fromFileExtension(String extension) {
     for (HoodieFileFormat format : HoodieFileFormat.values()) {
       if (format.getFileExtension().equals(extension)) {

--- a/hudi-common/src/main/java/org/apache/hudi/common/model/HoodieFileFormat.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/model/HoodieFileFormat.java
@@ -87,6 +87,20 @@ public enum HoodieFileFormat {
     throw new IllegalArgumentException("Unknown file extension :" + extension);
   }
 
+  /**
+   * Returns the {@link HoodieFileFormat} matching the given file extension, or {@code null}
+   * if no match is found. Useful when the caller wants to handle unknown extensions without
+   * exception-based control flow.
+   */
+  public static HoodieFileFormat fromFileExtensionOrNull(String extension) {
+    for (HoodieFileFormat format : HoodieFileFormat.values()) {
+      if (format.getFileExtension().equals(extension)) {
+        return format;
+      }
+    }
+    return null;
+  }
+
   public static HoodieFileFormat getValue(String fileFormat) {
     if (StringUtils.isNullOrEmpty(fileFormat)) {
       return null;

--- a/hudi-common/src/main/java/org/apache/hudi/common/model/HoodieFileFormat.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/model/HoodieFileFormat.java
@@ -70,6 +70,14 @@ public enum HoodieFileFormat {
     return extension;
   }
 
+  /**
+   * Returns true if this file format requires the SPARK record type for reading/writing.
+   * Lance only supports the Spark-native InternalRow representation, not Avro.
+   */
+  public boolean requiresSparkRecordType() {
+    return this == LANCE;
+  }
+
   public static HoodieFileFormat fromFileExtension(String extension) {
     for (HoodieFileFormat format : HoodieFileFormat.values()) {
       if (format.getFileExtension().equals(extension)) {

--- a/hudi-common/src/main/java/org/apache/hudi/common/model/HoodiePreCombineAvroRecordMerger.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/model/HoodiePreCombineAvroRecordMerger.java
@@ -50,8 +50,8 @@ public class HoodiePreCombineAvroRecordMerger extends HoodieAvroRecordMerger {
 
   @SuppressWarnings("rawtypes, unchecked")
   private <T> BufferedRecord<T> preCombine(BufferedRecord<T> older, BufferedRecord<T> newer, RecordContext<T> recordContext, HoodieSchema newSchema, TypedProperties props) {
-    GenericRecord newerAvroRecord = recordContext.convertToAvroRecord(newer.getRecord(), recordContext.getSchemaFromBufferRecord(newer));
-    GenericRecord olderAvroRecord = recordContext.convertToAvroRecord(older.getRecord(), recordContext.getSchemaFromBufferRecord(older));
+    GenericRecord newerAvroRecord = recordContext.convertToAvroRecord(newer, recordContext.getSchemaFromBufferRecord(newer));
+    GenericRecord olderAvroRecord = recordContext.convertToAvroRecord(older, recordContext.getSchemaFromBufferRecord(older));
     HoodieRecordPayload newerPayload = HoodieRecordUtils.loadPayload(payloadClass, newerAvroRecord, newer.getOrderingValue());
     HoodieRecordPayload olderPayload = HoodieRecordUtils.loadPayload(payloadClass, olderAvroRecord, older.getOrderingValue());
     HoodieRecordPayload payload = newerPayload.preCombine(olderPayload, newSchema.toAvroSchema(), props);

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/read/BufferedRecord.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/read/BufferedRecord.java
@@ -23,6 +23,8 @@ import org.apache.hudi.common.model.HoodieOperation;
 import org.apache.hudi.common.schema.HoodieSchema;
 import org.apache.hudi.common.util.OrderingValues;
 
+import org.apache.avro.generic.GenericRecord;
+
 import javax.annotation.Nullable;
 
 import java.io.Serializable;
@@ -40,17 +42,27 @@ public class BufferedRecord<T> implements Serializable {
   private final Comparable orderingValue;
   private final Integer schemaId;
   @Nullable private HoodieOperation hoodieOperation;
+  // Original Avro record from the source payload (e.g. ExpressionPayload), kept alongside
+  // the engine-native row so downstream code can recover the source schema without re-serializing.
+  // Transient: this hint is only useful in-memory and must not survive spill or shuffle.
+  @Nullable private transient GenericRecord originalAvroRecord;
 
   public BufferedRecord() {
     this(null, null, null, null, null);
   }
 
   public BufferedRecord(String recordKey, Comparable orderingValue, T record, Integer schemaId, @Nullable HoodieOperation hoodieOperation) {
+    this(recordKey, orderingValue, record, schemaId, hoodieOperation, null);
+  }
+
+  public BufferedRecord(String recordKey, Comparable orderingValue, T record, Integer schemaId, @Nullable HoodieOperation hoodieOperation,
+                        @Nullable GenericRecord originalAvroRecord) {
     this.recordKey = recordKey;
     this.orderingValue = orderingValue;
     this.record = record;
     this.schemaId = schemaId;
     this.hoodieOperation = hoodieOperation;
+    this.originalAvroRecord = originalAvroRecord;
   }
 
   public String getRecordKey() {
@@ -110,13 +122,22 @@ public class BufferedRecord<T> implements Serializable {
   public BufferedRecord<T> project(UnaryOperator<T> converter) {
     if (record != null) {
       this.record = converter.apply(record);
+      // Projection produces a new row whose schema differs from the original Avro record.
+      this.originalAvroRecord = null;
     }
     return this;
   }
 
   public BufferedRecord<T> replaceRecord(T record) {
     this.record = record;
+    // The new record no longer corresponds to the previously-cached Avro hint.
+    this.originalAvroRecord = null;
     return this;
+  }
+
+  @Nullable
+  public GenericRecord getOriginalAvroRecord() {
+    return originalAvroRecord;
   }
 
   public BufferedRecord<T> replaceRecordKey(String recordKey) {

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/read/BufferedRecords.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/read/BufferedRecords.java
@@ -18,6 +18,7 @@
 
 package org.apache.hudi.common.table.read;
 
+import org.apache.hudi.common.engine.ExtractedData;
 import org.apache.hudi.common.engine.RecordContext;
 import org.apache.hudi.common.model.DeleteRecord;
 import org.apache.hudi.common.model.HoodieKey;
@@ -41,11 +42,12 @@ public class BufferedRecords {
 
   public static <T> BufferedRecord<T> fromHoodieRecord(HoodieRecord record, HoodieSchema schema, RecordContext<T> recordContext, Properties props, String[] orderingFields, boolean isDelete) {
     HoodieKey hoodieKey = record.getKey();
-    T data = recordContext.extractDataFromRecord(record, schema, props);
+    ExtractedData<T> extracted = recordContext.extractDataFromRecord(record, schema, props);
+    T data = extracted.getData();
     String recordKey = hoodieKey == null ? recordContext.getRecordKey(data, schema) : hoodieKey.getRecordKey();
     Integer schemaId = recordContext.encodeSchema(schema);
     Comparable orderingValue = record.getOrderingValue(schema, props, orderingFields);
-    return new BufferedRecord<>(recordKey, orderingValue, data, schemaId, inferOperation(isDelete, record.getOperation()));
+    return new BufferedRecord<>(recordKey, orderingValue, data, schemaId, inferOperation(isDelete, record.getOperation()), extracted.getOriginalAvroRecord());
   }
 
   public static <T> BufferedRecord<T> fromEngineRecord(T record, HoodieSchema schema, RecordContext<T> recordContext, List<String> orderingFieldNames, boolean isDelete) {

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/read/UpdateProcessor.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/read/UpdateProcessor.java
@@ -142,13 +142,13 @@ public interface UpdateProcessor<T> {
         GenericRecord record = readerContext.getRecordContext().convertToAvroRecord(mergedRecord.getRecord(), recordSchema);
         Schema recordAvroSchema = recordSchema.toAvroSchema();
 
-        // If convertToAvroRecord returned a cached record with a different schema (e.g., from
-        // extractDataFromRecord caching for ExpressionPayload in the COW write path), the record
-        // is already in write-schema format with correctly evaluated expressions. Convert directly.
-        // Note: SENTINEL records (used by ExpressionPayload to signal "skip this record") always
-        // have null schema (HoodieRecord.EmptyRecord.getSchema() returns null), so they cannot
-        // enter this branch and will always go through the payload path where shouldIgnore handles them.
-        if (record.getSchema() != null && !record.getSchema().equals(recordAvroSchema)) {
+        // If convertToAvroRecord returned an Avro record previously cached by extractDataFromRecord
+        // (ExpressionPayload in the COW write path), the record is already in write-schema format
+        // with correctly evaluated expressions. Convert directly and skip the payload path.
+        // Using the explicit RecordContext flag instead of comparing schemas: schema inequality
+        // can also arise from legitimate reader/writer schema evolution, which is unrelated to
+        // the cache hit we want to detect here.
+        if (readerContext.getRecordContext().consumeLastAvroRecordFromCache()) {
           // NOTE: After replaceRecord(), mergedRecord.getSchemaId() still references the original schema.
           // This is safe because the record is emitted immediately via super.handleNonDeletes() below,
           // which calls seal() and produces the output row. The record is not spilled to disk (via

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/read/UpdateProcessor.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/read/UpdateProcessor.java
@@ -145,7 +145,9 @@ public interface UpdateProcessor<T> {
         // If convertToAvroRecord returned a cached record with a different schema (e.g., from
         // extractDataFromRecord caching for ExpressionPayload in the COW write path), the record
         // is already in write-schema format with correctly evaluated expressions. Convert directly.
-        // Note: SENTINEL records have null schema and must go through the payload path for shouldIgnore.
+        // Note: SENTINEL records (used by ExpressionPayload to signal "skip this record") always
+        // have null schema (HoodieRecord.EmptyRecord.getSchema() returns null), so they cannot
+        // enter this branch and will always go through the payload path where shouldIgnore handles them.
         if (record.getSchema() != null && !record.getSchema().equals(recordAvroSchema)) {
           mergedRecord.replaceRecord(readerContext.getRecordContext().convertAvroRecord(record));
         } else {
@@ -173,6 +175,10 @@ public interface UpdateProcessor<T> {
                 finalRecord = HoodieAvroUtils.rewriteRecordWithNewSchema(insertRecord, dataSchema.toAvroSchema());
               }
               mergedRecord.replaceRecord(readerContext.getRecordContext().convertAvroRecord(finalRecord));
+            } else {
+              // Payload returned empty (e.g., soft-deleted record in DefaultHoodieRecordPayload).
+              // Suppress the record — do not emit it as an insert.
+              return null;
             }
           } catch (IOException e) {
             throw new HoodieIOException("Error processing record with payload class: " + payloadClass, e);

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/read/UpdateProcessor.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/read/UpdateProcessor.java
@@ -168,7 +168,7 @@ public interface UpdateProcessor<T> {
             // Evaluate the payload to get the insert value
             Option<IndexedRecord> insertValueOpt = hoodieRecord.getData().getInsertValue(recordAvroSchema, properties);
             if (insertValueOpt.isPresent()) {
-              GenericRecord insertRecord = (GenericRecord) insertValueOpt.get();
+              IndexedRecord insertRecord = insertValueOpt.get();
               HoodieSchema readerSchema = readerContext.getSchemaHandler().getRequestedSchema();
               GenericRecord finalRecord;
               if (insertRecord.getSchema().equals(recordAvroSchema)) {

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/read/UpdateProcessor.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/read/UpdateProcessor.java
@@ -18,6 +18,7 @@
 
 package org.apache.hudi.common.table.read;
 
+import org.apache.hudi.avro.HoodieAvroUtils;
 import org.apache.hudi.common.config.RecordMergeMode;
 import org.apache.hudi.common.config.TypedProperties;
 import org.apache.hudi.common.engine.HoodieReaderContext;
@@ -31,7 +32,9 @@ import org.apache.hudi.common.util.collection.Pair;
 import org.apache.hudi.exception.HoodieIOException;
 import org.apache.hudi.metadata.HoodieMetadataPayload;
 
+import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericRecord;
+import org.apache.avro.generic.IndexedRecord;
 
 import java.io.IOException;
 import java.util.Properties;
@@ -137,23 +140,43 @@ public interface UpdateProcessor<T> {
         // special case for payloads when there is no previous record
         HoodieSchema recordSchema = readerContext.getRecordContext().decodeAvroSchema(mergedRecord.getSchemaId());
         GenericRecord record = readerContext.getRecordContext().convertToAvroRecord(mergedRecord.getRecord(), recordSchema);
-        HoodieAvroRecord hoodieRecord = new HoodieAvroRecord<>(null, HoodieRecordUtils.loadPayload(payloadClass, record, mergedRecord.getOrderingValue()));
-        try {
-          if (hoodieRecord.shouldIgnore(recordSchema, properties)) {
-            return null;
-          } else {
-            HoodieSchema readerSchema = readerContext.getSchemaHandler().getRequestedSchema();
-            // Strip meta fields: the payload evaluates INSERT expressions against data fields only.
-            // Meta fields are populated separately by prependMetaFields/writeWithMetadata downstream,
-            // so rewriting to a schema that already includes meta fields would cause double-wrapping
-            // of meta fields in HoodieInternalRow, resulting in data fields being read from the
-            // inner meta positions (all null) instead of the actual data positions.
-            HoodieSchema dataSchema = HoodieSchemaUtils.removeMetadataFields(readerSchema);
-            hoodieRecord.rewriteRecordWithNewSchema(recordSchema, properties, dataSchema).toIndexedRecord(dataSchema, properties)
-                .ifPresent(rewrittenRecord -> mergedRecord.replaceRecord(readerContext.getRecordContext().convertAvroRecord(rewrittenRecord.getData())));
+        Schema recordAvroSchema = recordSchema.toAvroSchema();
+
+        // If convertToAvroRecord returned a cached record with a different schema (e.g., from
+        // extractDataFromRecord caching for ExpressionPayload in the COW write path), the record
+        // is already in write-schema format with correctly evaluated expressions. Convert directly.
+        // Note: SENTINEL records have null schema and must go through the payload path for shouldIgnore.
+        if (record.getSchema() != null && !record.getSchema().equals(recordAvroSchema)) {
+          mergedRecord.replaceRecord(readerContext.getRecordContext().convertAvroRecord(record));
+        } else {
+          HoodieAvroRecord hoodieRecord = new HoodieAvroRecord<>(null, HoodieRecordUtils.loadPayload(payloadClass, record, mergedRecord.getOrderingValue()));
+          try {
+            if (hoodieRecord.shouldIgnore(recordSchema, properties)) {
+              return null;
+            }
+            // Evaluate the payload to get the insert value
+            Option<IndexedRecord> insertValueOpt = hoodieRecord.getData().getInsertValue(recordAvroSchema, properties);
+            if (insertValueOpt.isPresent()) {
+              GenericRecord insertRecord = (GenericRecord) insertValueOpt.get();
+              HoodieSchema readerSchema = readerContext.getSchemaHandler().getRequestedSchema();
+              GenericRecord finalRecord;
+              if (insertRecord.getSchema().equals(recordAvroSchema)) {
+                // Payload preserved the schema (e.g., OverwriteWithLatestAvroPayload).
+                // Rewrite to full reader schema including meta fields.
+                finalRecord = HoodieAvroUtils.rewriteRecordWithNewSchema(insertRecord, readerSchema.toAvroSchema());
+              } else {
+                // Payload transformed the schema (e.g., ExpressionPayload maps source→target fields).
+                // The result has different field names than recordSchema. Use data-only schema as
+                // the rewrite target to maintain arity consistency with BufferedRecord's schemaId,
+                // which is immutable and corresponds to the data-only recordSchema.
+                HoodieSchema dataSchema = HoodieSchemaUtils.removeMetadataFields(readerSchema);
+                finalRecord = HoodieAvroUtils.rewriteRecordWithNewSchema(insertRecord, dataSchema.toAvroSchema());
+              }
+              mergedRecord.replaceRecord(readerContext.getRecordContext().convertAvroRecord(finalRecord));
+            }
+          } catch (IOException e) {
+            throw new HoodieIOException("Error processing record with payload class: " + payloadClass, e);
           }
-        } catch (IOException e) {
-          throw new HoodieIOException("Error processing record with payload class: " + payloadClass, e);
         }
       }
       return super.handleNonDeletes(previousRecord, mergedRecord);

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/read/UpdateProcessor.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/read/UpdateProcessor.java
@@ -139,23 +139,27 @@ public interface UpdateProcessor<T> {
       if (previousRecord == null) {
         // special case for payloads when there is no previous record
         HoodieSchema recordSchema = readerContext.getRecordContext().decodeAvroSchema(mergedRecord.getSchemaId());
-        GenericRecord record = readerContext.getRecordContext().convertToAvroRecord(mergedRecord.getRecord(), recordSchema);
+        GenericRecord originalAvro = mergedRecord.getOriginalAvroRecord();
         Schema recordAvroSchema = recordSchema.toAvroSchema();
 
-        // If convertToAvroRecord returned an Avro record previously cached by extractDataFromRecord
-        // (ExpressionPayload in the COW write path), the record is already in write-schema format
-        // with correctly evaluated expressions. Convert directly and skip the payload path.
-        // Using the explicit RecordContext flag instead of comparing schemas: schema inequality
-        // can also arise from legitimate reader/writer schema evolution, which is unrelated to
-        // the cache hit we want to detect here.
-        if (readerContext.getRecordContext().consumeLastAvroRecordFromCache()) {
-          // NOTE: After replaceRecord(), mergedRecord.getSchemaId() still references the original schema.
+        // When the merged record carries an originalAvroRecord (populated by extractDataFromRecord
+        // for ExpressionPayload in the COW write path via ExtractedData), the record is already in
+        // write-schema format with correctly evaluated expressions. Convert directly and skip the
+        // payload path.
+        //
+        // NOTE: this branch bypasses shouldIgnore. That is safe today because the only payload that
+        // populates originalAvroRecord is ExpressionPayload, which never returns shouldIgnore=true.
+        // If a future payload starts producing an originalAvroRecord, it must add a shouldIgnore
+        // check here.
+        if (originalAvro != null) {
+          // After replaceRecord(), mergedRecord.getSchemaId() still references the original schema.
           // This is safe because the record is emitted immediately via super.handleNonDeletes() below,
-          // which calls seal() and produces the output row. The record is not spilled to disk (via
-          // toBinary()) between replaceRecord and emit in this single-record path. If this assumption
-          // changes, the schemaId must be updated after replaceRecord.
-          mergedRecord.replaceRecord(readerContext.getRecordContext().convertAvroRecord(record));
+          // which calls seal() and produces the output row — the record is not spilled to disk
+          // (via toBinary()) between replaceRecord and emit in this single-record path. If this
+          // assumption changes, the schemaId must be updated after replaceRecord.
+          mergedRecord.replaceRecord(readerContext.getRecordContext().convertAvroRecord(originalAvro));
         } else {
+          GenericRecord record = readerContext.getRecordContext().convertToAvroRecord(mergedRecord.getRecord(), recordSchema);
           HoodieAvroRecord hoodieRecord = new HoodieAvroRecord<>(null, HoodieRecordUtils.loadPayload(payloadClass, record, mergedRecord.getOrderingValue()));
           try {
             if (hoodieRecord.shouldIgnore(recordSchema, properties)) {

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/read/UpdateProcessor.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/read/UpdateProcessor.java
@@ -149,6 +149,11 @@ public interface UpdateProcessor<T> {
         // have null schema (HoodieRecord.EmptyRecord.getSchema() returns null), so they cannot
         // enter this branch and will always go through the payload path where shouldIgnore handles them.
         if (record.getSchema() != null && !record.getSchema().equals(recordAvroSchema)) {
+          // NOTE: After replaceRecord(), mergedRecord.getSchemaId() still references the original schema.
+          // This is safe because the record is emitted immediately via super.handleNonDeletes() below,
+          // which calls seal() and produces the output row. The record is not spilled to disk (via
+          // toBinary()) between replaceRecord and emit in this single-record path. If this assumption
+          // changes, the schemaId must be updated after replaceRecord.
           mergedRecord.replaceRecord(readerContext.getRecordContext().convertAvroRecord(record));
         } else {
           HoodieAvroRecord hoodieRecord = new HoodieAvroRecord<>(null, HoodieRecordUtils.loadPayload(payloadClass, record, mergedRecord.getOrderingValue()));

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/read/UpdateProcessor.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/read/UpdateProcessor.java
@@ -24,6 +24,7 @@ import org.apache.hudi.common.engine.HoodieReaderContext;
 import org.apache.hudi.common.model.HoodieAvroRecord;
 import org.apache.hudi.common.model.HoodieOperation;
 import org.apache.hudi.common.schema.HoodieSchema;
+import org.apache.hudi.common.schema.HoodieSchemaUtils;
 import org.apache.hudi.common.util.HoodieRecordUtils;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.common.util.collection.Pair;
@@ -142,8 +143,13 @@ public interface UpdateProcessor<T> {
             return null;
           } else {
             HoodieSchema readerSchema = readerContext.getSchemaHandler().getRequestedSchema();
-            // If the record schema is different from the reader schema, rewrite the record using the payload methods to ensure consistency with legacy writer paths
-            hoodieRecord.rewriteRecordWithNewSchema(recordSchema, properties, readerSchema).toIndexedRecord(readerSchema, properties)
+            // Strip meta fields: the payload evaluates INSERT expressions against data fields only.
+            // Meta fields are populated separately by prependMetaFields/writeWithMetadata downstream,
+            // so rewriting to a schema that already includes meta fields would cause double-wrapping
+            // of meta fields in HoodieInternalRow, resulting in data fields being read from the
+            // inner meta positions (all null) instead of the actual data positions.
+            HoodieSchema dataSchema = HoodieSchemaUtils.removeMetadataFields(readerSchema);
+            hoodieRecord.rewriteRecordWithNewSchema(recordSchema, properties, dataSchema).toIndexedRecord(dataSchema, properties)
                 .ifPresent(rewrittenRecord -> mergedRecord.replaceRecord(readerContext.getRecordContext().convertAvroRecord(rewrittenRecord.getData())));
           }
         } catch (IOException e) {

--- a/hudi-common/src/main/java/org/apache/hudi/io/storage/HoodieFileWriterFactory.java
+++ b/hudi-common/src/main/java/org/apache/hudi/io/storage/HoodieFileWriterFactory.java
@@ -49,7 +49,13 @@ public class HoodieFileWriterFactory {
       String instantTime, StoragePath path, HoodieStorage storage, HoodieConfig config, HoodieSchema schema,
       TaskContextSupplier taskContextSupplier, HoodieRecordType recordType) throws IOException {
     final String extension = FSUtils.getFileExtension(path.getName());
-    HoodieFileWriterFactory factory = HoodieIOFactory.getIOFactory(storage).getWriterFactory(recordType);
+    HoodieRecordType fixedType;
+    try {
+      fixedType = HoodieFileFormat.fromFileExtension(extension).requiresSparkRecordType() ? HoodieRecordType.SPARK : recordType;
+    } catch (IllegalArgumentException e) {
+      fixedType = recordType;
+    }
+    HoodieFileWriterFactory factory = HoodieIOFactory.getIOFactory(storage).getWriterFactory(fixedType);
     return factory.getFileWriterByFormat(extension, instantTime, path, config, schema, taskContextSupplier);
   }
 

--- a/hudi-common/src/main/java/org/apache/hudi/io/storage/HoodieFileWriterFactory.java
+++ b/hudi-common/src/main/java/org/apache/hudi/io/storage/HoodieFileWriterFactory.java
@@ -50,9 +50,8 @@ public class HoodieFileWriterFactory {
       TaskContextSupplier taskContextSupplier, HoodieRecordType recordType) throws IOException {
     final String extension = FSUtils.getFileExtension(path.getName());
     HoodieFileFormat format = HoodieFileFormat.fromFileExtensionOrNull(extension);
-    HoodieRecordType fixedType = (format != null && format.requiresSparkRecordType())
-        ? HoodieRecordType.SPARK : recordType;
-    HoodieFileWriterFactory factory = HoodieIOFactory.getIOFactory(storage).getWriterFactory(fixedType);
+    HoodieRecordType resolvedRecordType = format != null ? format.resolveRecordType(recordType) : recordType;
+    HoodieFileWriterFactory factory = HoodieIOFactory.getIOFactory(storage).getWriterFactory(resolvedRecordType);
     return factory.getFileWriterByFormat(extension, instantTime, path, config, schema, taskContextSupplier);
   }
 

--- a/hudi-common/src/main/java/org/apache/hudi/io/storage/HoodieFileWriterFactory.java
+++ b/hudi-common/src/main/java/org/apache/hudi/io/storage/HoodieFileWriterFactory.java
@@ -49,12 +49,9 @@ public class HoodieFileWriterFactory {
       String instantTime, StoragePath path, HoodieStorage storage, HoodieConfig config, HoodieSchema schema,
       TaskContextSupplier taskContextSupplier, HoodieRecordType recordType) throws IOException {
     final String extension = FSUtils.getFileExtension(path.getName());
-    HoodieRecordType fixedType;
-    try {
-      fixedType = HoodieFileFormat.fromFileExtension(extension).requiresSparkRecordType() ? HoodieRecordType.SPARK : recordType;
-    } catch (IllegalArgumentException e) {
-      fixedType = recordType;
-    }
+    HoodieFileFormat format = HoodieFileFormat.fromFileExtensionOrNull(extension);
+    HoodieRecordType fixedType = (format != null && format.requiresSparkRecordType())
+        ? HoodieRecordType.SPARK : recordType;
     HoodieFileWriterFactory factory = HoodieIOFactory.getIOFactory(storage).getWriterFactory(fixedType);
     return factory.getFileWriterByFormat(extension, instantTime, path, config, schema, taskContextSupplier);
   }

--- a/hudi-common/src/test/java/org/apache/hudi/common/table/read/TestHoodieFileGroupReaderBase.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/table/read/TestHoodieFileGroupReaderBase.java
@@ -1163,7 +1163,7 @@ public abstract class TestHoodieFileGroupReaderBase<T> {
     props.setProperty(HoodieTableConfig.ORDERING_FIELDS.key(), String.join(",", orderingFields));
     return records.stream()
         .map(record -> {
-          T data = readerContext.getRecordContext().extractDataFromRecord(record, schema, props);
+          T data = readerContext.getRecordContext().extractDataFromRecord(record, schema, props).getData();
           return new HoodieTestDataGenerator.RecordIdentifier(
               record.getRecordKey(),
               removeHiveStylePartition(record.getPartitionPath()),

--- a/hudi-hadoop-common/src/main/java/org/apache/hudi/io/lance/HoodieBaseLanceWriter.java
+++ b/hudi-hadoop-common/src/main/java/org/apache/hudi/io/lance/HoodieBaseLanceWriter.java
@@ -258,7 +258,7 @@ public abstract class HoodieBaseLanceWriter<R, K extends Comparable<K>> implemen
    * Initialize LanceFileWriter (lazy initialization).
    */
   private void initializeWriter() throws IOException {
-    writer = LanceFileWriter.open(path.toString(), allocator, null);
+    writer = LanceFileWriter.open(path.toUri().toString(), allocator, null);
   }
 
   /**

--- a/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/HoodieHFileRecordReader.java
+++ b/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/HoodieHFileRecordReader.java
@@ -102,18 +102,22 @@ public class HoodieHFileRecordReader implements RecordReader<NullWritable, Array
 
   @Override
   public void close() throws IOException {
-    if (reader != null) {
-      reader.close();
-      reader = null;
-    }
+    // Close the iterator before the reader: the iterator holds references to
+    // resources owned by the reader, so closing the reader first may cause
+    // the iterator's close to fail or leak resources.
     if (recordIterator != null) {
       recordIterator.close();
       recordIterator = null;
+    }
+    if (reader != null) {
+      reader.close();
+      reader = null;
     }
   }
 
   @Override
   public float getProgress() throws IOException {
-    return 1.0f * count / reader.getTotalRecords();
+    return (reader == null || reader.getTotalRecords() == 0)
+        ? 0f : 1.0f * count / reader.getTotalRecords();
   }
 }

--- a/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/HoodieLanceInputFormat.java
+++ b/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/HoodieLanceInputFormat.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.hadoop;
+
+import org.apache.hudi.common.table.timeline.HoodieTimeline;
+import org.apache.hudi.hadoop.utils.HoodieInputFormatUtils;
+
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.io.ArrayWritable;
+import org.apache.hadoop.io.NullWritable;
+import org.apache.hadoop.mapred.InputSplit;
+import org.apache.hadoop.mapred.JobConf;
+import org.apache.hadoop.mapred.RecordReader;
+import org.apache.hadoop.mapred.Reporter;
+
+import java.io.IOException;
+
+/**
+ * HoodieInputFormat for HUDI datasets which store data in Lance base file format.
+ */
+@UseFileSplitsFromInputFormat
+public class HoodieLanceInputFormat extends HoodieCopyOnWriteTableInputFormat {
+
+  protected HoodieTimeline filterInstantsTimeline(HoodieTimeline timeline) {
+    return HoodieInputFormatUtils.filterInstantsTimeline(timeline);
+  }
+
+  @Override
+  public RecordReader<NullWritable, ArrayWritable> getRecordReader(final InputSplit split, final JobConf job,
+      final Reporter reporter) throws IOException {
+    return new HoodieLanceRecordReader(conf, split, job);
+  }
+
+  @Override
+  protected boolean isSplitable(FileSystem fs, Path filename) {
+    // This file isn't splittable.
+    return false;
+  }
+}

--- a/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/HoodieLanceInputFormat.java
+++ b/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/HoodieLanceInputFormat.java
@@ -45,7 +45,7 @@ public class HoodieLanceInputFormat extends HoodieCopyOnWriteTableInputFormat {
   @Override
   public RecordReader<NullWritable, ArrayWritable> getRecordReader(final InputSplit split, final JobConf job,
       final Reporter reporter) throws IOException {
-    return new HoodieLanceRecordReader(conf, split, job);
+    return new HoodieLanceRecordReader(job, split, job);
   }
 
   @Override

--- a/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/HoodieLanceRecordReader.java
+++ b/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/HoodieLanceRecordReader.java
@@ -1,0 +1,119 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.hadoop;
+
+import org.apache.hudi.common.config.HoodieConfig;
+import org.apache.hudi.common.model.HoodieFileFormat;
+import org.apache.hudi.common.model.HoodieRecord;
+import org.apache.hudi.common.schema.HoodieSchema;
+import org.apache.hudi.common.util.Option;
+import org.apache.hudi.common.util.collection.ClosableIterator;
+import org.apache.hudi.hadoop.fs.HadoopFSUtils;
+import org.apache.hudi.hadoop.utils.HoodieRealtimeRecordReaderUtils;
+import org.apache.hudi.io.storage.HoodieFileReader;
+import org.apache.hudi.io.storage.HoodieIOFactory;
+import org.apache.hudi.storage.HoodieStorageUtils;
+import org.apache.hudi.storage.StorageConfiguration;
+import org.apache.hudi.storage.StoragePath;
+
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.io.ArrayWritable;
+import org.apache.hadoop.io.NullWritable;
+import org.apache.hadoop.io.Writable;
+import org.apache.hadoop.mapred.FileSplit;
+import org.apache.hadoop.mapred.InputSplit;
+import org.apache.hadoop.mapred.JobConf;
+import org.apache.hadoop.mapred.RecordReader;
+
+import java.io.IOException;
+
+import static org.apache.hudi.common.util.ConfigUtils.getReaderConfigs;
+import static org.apache.hudi.hadoop.fs.HadoopFSUtils.convertToStoragePath;
+
+public class HoodieLanceRecordReader implements RecordReader<NullWritable, ArrayWritable> {
+
+  private long count = 0;
+  private final ArrayWritable valueObj;
+  private HoodieFileReader reader;
+  private ClosableIterator<HoodieRecord<IndexedRecord>> recordIterator;
+  private final HoodieSchema schema;
+
+  public HoodieLanceRecordReader(Configuration conf, InputSplit split, JobConf job) throws IOException {
+    FileSplit fileSplit = (FileSplit) split;
+    StoragePath path = convertToStoragePath(fileSplit.getPath());
+    StorageConfiguration<?> storageConf = HadoopFSUtils.getStorageConf(conf);
+    HoodieConfig hoodieConfig = getReaderConfigs(storageConf);
+    reader = HoodieIOFactory.getIOFactory(HoodieStorageUtils.getStorage(path, storageConf)).getReaderFactory(HoodieRecord.HoodieRecordType.AVRO)
+        .getFileReader(hoodieConfig, path, HoodieFileFormat.LANCE, Option.empty());
+
+    schema = reader.getSchema();
+    valueObj = new ArrayWritable(Writable.class, new Writable[schema.getFields().size()]);
+  }
+
+  @Override
+  public boolean next(NullWritable key, ArrayWritable value) throws IOException {
+    if (recordIterator == null) {
+      recordIterator = reader.getRecordIterator(schema);
+    }
+
+    if (!recordIterator.hasNext()) {
+      return false;
+    }
+
+    IndexedRecord record = recordIterator.next().getData();
+    ArrayWritable aWritable = (ArrayWritable) HoodieRealtimeRecordReaderUtils.avroToArrayWritable(record, schema.toAvroSchema());
+    value.set(aWritable.get());
+    count++;
+    return true;
+  }
+
+  @Override
+  public NullWritable createKey() {
+    return null;
+  }
+
+  @Override
+  public ArrayWritable createValue() {
+    return valueObj;
+  }
+
+  @Override
+  public long getPos() throws IOException {
+    // TODO Auto-generated method stub
+    return 0;
+  }
+
+  @Override
+  public void close() throws IOException {
+    if (reader != null) {
+      reader.close();
+      reader = null;
+    }
+    if (recordIterator != null) {
+      recordIterator.close();
+      recordIterator = null;
+    }
+  }
+
+  @Override
+  public float getProgress() throws IOException {
+    return 1.0f * count / reader.getTotalRecords();
+  }
+}

--- a/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/HoodieLanceRecordReader.java
+++ b/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/HoodieLanceRecordReader.java
@@ -60,7 +60,8 @@ public class HoodieLanceRecordReader implements RecordReader<NullWritable, Array
     StoragePath path = convertToStoragePath(fileSplit.getPath());
     StorageConfiguration<?> storageConf = HadoopFSUtils.getStorageConf(conf);
     HoodieConfig hoodieConfig = getReaderConfigs(storageConf);
-    reader = HoodieIOFactory.getIOFactory(HoodieStorageUtils.getStorage(path, storageConf)).getReaderFactory(HoodieRecord.HoodieRecordType.AVRO)
+    HoodieIOFactory ioFactory = HoodieIOFactory.getIOFactory(HoodieStorageUtils.getStorage(path, storageConf));
+    reader = ioFactory.getReaderFactory(HoodieRecord.HoodieRecordType.AVRO)
         .getFileReader(hoodieConfig, path, HoodieFileFormat.LANCE, Option.empty());
 
     schema = reader.getSchema();
@@ -96,7 +97,6 @@ public class HoodieLanceRecordReader implements RecordReader<NullWritable, Array
 
   @Override
   public long getPos() throws IOException {
-    // TODO Auto-generated method stub
     return 0;
   }
 

--- a/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/HoodieLanceRecordReader.java
+++ b/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/HoodieLanceRecordReader.java
@@ -87,7 +87,7 @@ public class HoodieLanceRecordReader implements RecordReader<NullWritable, Array
 
   @Override
   public NullWritable createKey() {
-    return null;
+    return NullWritable.get();
   }
 
   @Override

--- a/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/HoodieLanceRecordReader.java
+++ b/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/HoodieLanceRecordReader.java
@@ -102,18 +102,22 @@ public class HoodieLanceRecordReader implements RecordReader<NullWritable, Array
 
   @Override
   public void close() throws IOException {
-    if (reader != null) {
-      reader.close();
-      reader = null;
-    }
+    // Close the iterator before the reader: the iterator holds references to
+    // resources owned by the reader, so closing the reader first may cause
+    // the iterator's close to fail or leak resources.
     if (recordIterator != null) {
       recordIterator.close();
       recordIterator = null;
+    }
+    if (reader != null) {
+      reader.close();
+      reader = null;
     }
   }
 
   @Override
   public float getProgress() throws IOException {
-    return 1.0f * count / reader.getTotalRecords();
+    return (reader == null || reader.getTotalRecords() == 0)
+        ? 0f : 1.0f * count / reader.getTotalRecords();
   }
 }

--- a/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/realtime/HoodieLanceRealtimeInputFormat.java
+++ b/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/realtime/HoodieLanceRealtimeInputFormat.java
@@ -1,0 +1,100 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.hadoop.realtime;
+
+import org.apache.hudi.common.util.Option;
+import org.apache.hudi.common.util.ValidationUtils;
+import org.apache.hudi.hadoop.HoodieLanceInputFormat;
+import org.apache.hudi.hadoop.UseFileSplitsFromInputFormat;
+import org.apache.hudi.hadoop.UseRecordReaderFromInputFormat;
+import org.apache.hudi.hadoop.utils.HoodieInputFormatUtils;
+import org.apache.hudi.hadoop.utils.HoodieRealtimeInputFormatUtils;
+
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hive.serde2.ColumnProjectionUtils;
+import org.apache.hadoop.io.ArrayWritable;
+import org.apache.hadoop.io.NullWritable;
+import org.apache.hadoop.mapred.InputSplit;
+import org.apache.hadoop.mapred.JobConf;
+import org.apache.hadoop.mapred.RecordReader;
+import org.apache.hadoop.mapred.Reporter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+
+/**
+ * HoodieRealtimeInputFormat for HUDI datasets which store data in Lance base file format.
+ */
+@UseRecordReaderFromInputFormat
+@UseFileSplitsFromInputFormat
+public class HoodieLanceRealtimeInputFormat extends HoodieMergeOnReadTableInputFormat {
+
+  private static final Logger LOG = LoggerFactory.getLogger(HoodieLanceRealtimeInputFormat.class);
+
+  // NOTE: We're only using {@code HoodieLanceInputFormat} to compose {@code RecordReader}
+  private final HoodieLanceInputFormat lanceInputFormat = new HoodieLanceInputFormat();
+
+  @Override
+  public RecordReader<NullWritable, ArrayWritable> getRecordReader(final InputSplit split, final JobConf jobConf,
+      final Reporter reporter) throws IOException {
+    // Hive on Spark invokes multiple getRecordReaders from different threads in the same spark task (and hence the
+    // same JVM) unlike Hive on MR. Due to this, accesses to JobConf, which is shared across all threads, is at the
+    // risk of experiencing race conditions. Hence, we synchronize on the JobConf object here. There is negligible
+    // latency incurred here due to the synchronization since get record reader is called once per spilt before the
+    // actual heavy lifting of reading the parquet files happen.
+    if (jobConf.get(HoodieInputFormatUtils.HOODIE_READ_COLUMNS_PROP) == null) {
+      synchronized (jobConf) {
+        LOG.info(
+            "Before adding Hoodie columns, Projections :" + jobConf.get(ColumnProjectionUtils.READ_COLUMN_NAMES_CONF_STR)
+                + ", Ids :" + jobConf.get(ColumnProjectionUtils.READ_COLUMN_IDS_CONF_STR));
+        if (jobConf.get(HoodieInputFormatUtils.HOODIE_READ_COLUMNS_PROP) == null) {
+          // Hive (across all versions) fails for queries like select count(`_hoodie_commit_time`) from table;
+          // In this case, the projection fields gets removed. Looking at HiveInputFormat implementation, in some cases
+          // hoodie additional projection columns are reset after calling setConf and only natural projections
+          // (one found in select queries) are set. things would break because of this.
+          // For e:g _hoodie_record_key would be missing and merge step would throw exceptions.
+          // TO fix this, hoodie columns are appended late at the time record-reader gets built instead of construction
+          // time.
+          HoodieRealtimeInputFormatUtils.addVirtualKeysProjection(jobConf, Option.empty());
+
+          this.conf = jobConf;
+          this.conf.set(HoodieInputFormatUtils.HOODIE_READ_COLUMNS_PROP, "true");
+        }
+      }
+    }
+    HoodieRealtimeInputFormatUtils.cleanProjectionColumnIds(jobConf);
+
+    LOG.info("Creating record reader with readCols :" + jobConf.get(ColumnProjectionUtils.READ_COLUMN_NAMES_CONF_STR)
+        + ", Ids :" + jobConf.get(ColumnProjectionUtils.READ_COLUMN_IDS_CONF_STR));
+    // sanity check
+    ValidationUtils.checkArgument(split instanceof HoodieRealtimeFileSplit,
+        "HoodieRealtimeRecordReader can only work on HoodieRealtimeFileSplit and not with " + split);
+
+    return new HoodieRealtimeRecordReader((HoodieRealtimeFileSplit) split, jobConf,
+        lanceInputFormat.getRecordReader(split, jobConf, reporter));
+  }
+
+  @Override
+  protected boolean isSplitable(FileSystem fs, Path filename) {
+    // This file isn't splittable.
+    return false;
+  }
+}

--- a/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/realtime/HoodieLanceRealtimeInputFormat.java
+++ b/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/realtime/HoodieLanceRealtimeInputFormat.java
@@ -58,8 +58,8 @@ public class HoodieLanceRealtimeInputFormat extends HoodieMergeOnReadTableInputF
     // Hive on Spark invokes multiple getRecordReaders from different threads in the same spark task (and hence the
     // same JVM) unlike Hive on MR. Due to this, accesses to JobConf, which is shared across all threads, is at the
     // risk of experiencing race conditions. Hence, we synchronize on the JobConf object here. There is negligible
-    // latency incurred here due to the synchronization since get record reader is called once per spilt before the
-    // actual heavy lifting of reading the parquet files happen.
+    // latency incurred here due to the synchronization since get record reader is called once per split before the
+    // actual heavy lifting of reading the Lance files happen.
     if (jobConf.get(HoodieInputFormatUtils.HOODIE_READ_COLUMNS_PROP) == null) {
       synchronized (jobConf) {
         LOG.info(

--- a/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/utils/HoodieInputFormatUtils.java
+++ b/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/utils/HoodieInputFormatUtils.java
@@ -176,6 +176,8 @@ public class HoodieInputFormatUtils {
       case PARQUET:
       case HFILE:
       case LANCE:
+        // Lance uses Parquet output format for Hive metastore registration only.
+        // Actual writes go through Spark-native Lance writers; Hive never writes Lance files directly.
         return MapredParquetOutputFormat.class.getName();
       case ORC:
         return OrcOutputFormat.class.getName();
@@ -189,6 +191,8 @@ public class HoodieInputFormatUtils {
       case PARQUET:
       case HFILE:
       case LANCE:
+        // Lance uses Parquet SerDe for Hive metastore registration only.
+        // Actual reads go through Spark-native Lance readers.
         return ParquetHiveSerDe.class.getName();
       case ORC:
         return OrcSerde.class.getName();

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/execution/datasources/lance/SparkLanceReaderBase.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/execution/datasources/lance/SparkLanceReaderBase.scala
@@ -76,8 +76,21 @@ class SparkLanceReaderBase(enableVectorizedReader: Boolean) extends SparkColumna
     val filePath = file.filePath.toString
 
     if (requiredSchema.isEmpty && partitionSchema.isEmpty) {
-      // No columns requested - return empty iterator
-      Iterator.empty
+      // No column data needed (e.g. count() on a non-partitioned table). Open the Lance file to
+      // get the actual row count and return that many empty rows, so Spark computes the correct count.
+      val countAllocator = HoodieArrowAllocator.newChildAllocator(
+        getClass.getSimpleName + "-count-" + file.filePath, HoodieSparkLanceReader.LANCE_DATA_ALLOCATOR_SIZE)
+      try {
+        val lanceReader = LanceFileReader.open(file.filePath.toString, countAllocator)
+        try {
+          val rowCount = lanceReader.numRows()
+          Iterator.fill(rowCount.toInt)(InternalRow.empty)
+        } finally {
+          lanceReader.close()
+        }
+      } finally {
+        countAllocator.close()
+      }
     } else {
       // Track iterator for cleanup
       var lanceIterator: LanceRecordIterator = null

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/execution/datasources/lance/SparkLanceReaderBase.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/execution/datasources/lance/SparkLanceReaderBase.scala
@@ -83,8 +83,8 @@ class SparkLanceReaderBase(enableVectorizedReader: Boolean) extends SparkColumna
       try {
         val lanceReader = LanceFileReader.open(file.filePath.toString, countAllocator)
         try {
-          val rowCount = lanceReader.numRows()
-          Iterator.fill(rowCount.toInt)(InternalRow.empty)
+          val rowCount = Math.toIntExact(lanceReader.numRows())
+          Iterator.fill(rowCount)(InternalRow.empty)
         } finally {
           lanceReader.close()
         }

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/execution/datasources/lance/SparkLanceReaderBase.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/execution/datasources/lance/SparkLanceReaderBase.scala
@@ -40,6 +40,7 @@ import org.apache.spark.sql.util.LanceArrowUtils
 import org.lance.file.LanceFileReader
 
 import java.io.IOException
+import java.util.NoSuchElementException
 
 import scala.collection.JavaConverters._
 
@@ -83,8 +84,18 @@ class SparkLanceReaderBase(enableVectorizedReader: Boolean) extends SparkColumna
       try {
         val lanceReader = LanceFileReader.open(file.filePath.toString, countAllocator)
         try {
-          val rowCount = Math.toIntExact(lanceReader.numRows())
-          Iterator.fill(rowCount)(InternalRow.empty)
+          val rowCount: Long = lanceReader.numRows()
+          // Lazy Long-backed iterator: Iterator.fill/take require Int, which caps at ~2.1B rows.
+          // This custom iterator counts with Long so the count(*) path is not bounded by Int.MaxValue.
+          new Iterator[InternalRow] {
+            private var remaining: Long = rowCount
+            override def hasNext: Boolean = remaining > 0L
+            override def next(): InternalRow = {
+              if (remaining <= 0L) throw new NoSuchElementException
+              remaining -= 1L
+              InternalRow.empty
+            }
+          }
         } finally {
           lanceReader.close()
         }

--- a/hudi-spark-datasource/hudi-spark/src/test/resources/sql-statements.sql
+++ b/hudi-spark-datasource/hudi-spark/src/test/resources/sql-statements.sql
@@ -33,7 +33,7 @@ set hoodie.delete.shuffle.parallelism = 1;
 
 # CTAS
 
-create table h0 using hudi options(type = '${tableType}', primaryKey = 'id', ${recordMergerImpl} hoodie.table.base.file.format = '${baseFileFormat}')
+create table h0 using hudi options(type = '${tableType}', primaryKey = 'id', hoodie.table.base.file.format = '${baseFileFormat}')
 location '${tmpDir}/h0'
 as select 1 as id, 'a1' as name, 10 as price;
 +----------+
@@ -46,7 +46,7 @@ select id, name, price from h0;
 +-----------+
 
 create table h0_p using hudi partitioned by(dt)
-options(type = '${tableType}', primaryKey = 'id', ${recordMergerImpl} hoodie.table.base.file.format = '${baseFileFormat}')
+options(type = '${tableType}', primaryKey = 'id', hoodie.table.base.file.format = '${baseFileFormat}')
 location '${tmpDir}/h0_p'
 as select cast('2021-05-07 00:00:00' as timestamp) as dt,
  1 as id, 'a1' as name, 10 as price;
@@ -72,7 +72,6 @@ options (
   type = '${tableType}',
   primaryKey = 'id',
   orderingFields = 'ts',
-  ${recordMergerImpl}
   hoodie.table.base.file.format = '${baseFileFormat}'
 )
 location '${tmpDir}/h1';
@@ -92,7 +91,6 @@ options (
   type = '${tableType}',
   primaryKey = 'id',
   orderingFields = 'ts',
-  ${recordMergerImpl}
   hoodie.table.base.file.format = '${baseFileFormat}'
 )
 location '${tmpDir}/h1_p';

--- a/hudi-spark-datasource/hudi-spark/src/test/resources/sql-statements.sql
+++ b/hudi-spark-datasource/hudi-spark/src/test/resources/sql-statements.sql
@@ -33,7 +33,7 @@ set hoodie.delete.shuffle.parallelism = 1;
 
 # CTAS
 
-create table h0 using hudi options(type = '${tableType}', primaryKey = 'id')
+create table h0 using hudi options(type = '${tableType}', primaryKey = 'id', ${recordMergerImpl} hoodie.table.base.file.format = '${baseFileFormat}')
 location '${tmpDir}/h0'
 as select 1 as id, 'a1' as name, 10 as price;
 +----------+
@@ -46,7 +46,7 @@ select id, name, price from h0;
 +-----------+
 
 create table h0_p using hudi partitioned by(dt)
-options(type = '${tableType}', primaryKey = 'id')
+options(type = '${tableType}', primaryKey = 'id', ${recordMergerImpl} hoodie.table.base.file.format = '${baseFileFormat}')
 location '${tmpDir}/h0_p'
 as select cast('2021-05-07 00:00:00' as timestamp) as dt,
  1 as id, 'a1' as name, 10 as price;
@@ -71,7 +71,9 @@ create table h1 (
 options (
   type = '${tableType}',
   primaryKey = 'id',
-  orderingFields = 'ts'
+  orderingFields = 'ts',
+  ${recordMergerImpl}
+  hoodie.table.base.file.format = '${baseFileFormat}'
 )
 location '${tmpDir}/h1';
 +----------+
@@ -89,7 +91,9 @@ partitioned by (dt)
 options (
   type = '${tableType}',
   primaryKey = 'id',
-  orderingFields = 'ts'
+  orderingFields = 'ts',
+  ${recordMergerImpl}
+  hoodie.table.base.file.format = '${baseFileFormat}'
 )
 location '${tmpDir}/h1_p';
 +----------+

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestLanceDataSource.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestLanceDataSource.scala
@@ -21,7 +21,7 @@ import org.apache.hudi.DataSourceWriteOptions._
 import org.apache.hudi.DefaultSparkRecordMerger
 import org.apache.hudi.common.config.{HoodieCommonConfig, HoodieMetadataConfig}
 import org.apache.hudi.common.engine.HoodieLocalEngineContext
-import org.apache.hudi.common.model.HoodieTableType
+import org.apache.hudi.common.model.{HoodieFileFormat, HoodieTableType}
 import org.apache.hudi.common.table.{HoodieTableConfig, HoodieTableMetaClient}
 import org.apache.hudi.common.table.view.{FileSystemViewManager, FileSystemViewStorageConfig}
 import org.apache.hudi.common.testutils.HoodieTestUtils
@@ -30,13 +30,14 @@ import org.apache.hudi.io.storage.HoodieSparkLanceReader
 import org.apache.hudi.storage.StoragePath
 import org.apache.hudi.testutils.HoodieSparkClientTestBase
 
-import org.apache.spark.sql.{DataFrame, SaveMode, SparkSession}
+import org.apache.spark.sql.{DataFrame, Row, SaveMode, SparkSession}
 import org.junit.jupiter.api.{AfterEach, BeforeEach}
 import org.junit.jupiter.api.Assertions.{assertEquals, assertFalse, assertNotNull, assertTrue}
 import org.junit.jupiter.api.condition.DisabledIfSystemProperty
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.EnumSource
 
+import java.util.concurrent.atomic.AtomicInteger
 import java.util.stream.Collectors
 
 import scala.collection.JavaConverters._
@@ -59,6 +60,21 @@ class TestLanceDataSource extends HoodieSparkClientTestBase {
   override def tearDown(): Unit = {
     super.tearDown()
     spark = null
+  }
+
+  private val tableId = new AtomicInteger(0)
+
+  private def generateTableName: String = {
+    s"lance_sql_${tableId.incrementAndGet()}"
+  }
+
+  private def checkAnswer(sql: String)(expects: Seq[Any]*): Unit = {
+    val result = spark.sql(sql).collect()
+    val expectedRows = expects.map(row => Row(row: _*)).toArray
+    assertEquals(expectedRows.length, result.length, "Row count mismatch")
+    expectedRows.zip(result).foreach { case (expected, actual) =>
+      assertEquals(expected, actual)
+    }
   }
 
   @ParameterizedTest
@@ -782,6 +798,106 @@ class TestLanceDataSource extends HoodieSparkClientTestBase {
       }
     }
     fsView.close()
+  }
+
+  @ParameterizedTest
+  @EnumSource(value = classOf[HoodieTableType])
+  def testBasicSqlInsertOperations(tableType: HoodieTableType): Unit = {
+    Seq(true, false).foreach { isPartitioned =>
+      val tableName = generateTableName
+      val tablePath = s"$basePath/$tableName"
+      testSqlInsertWithSubsetOfColumns(tableType, tableName, tablePath, isPartitioned)
+    }
+  }
+
+  private def testSqlInsertWithSubsetOfColumns(tableType: HoodieTableType,
+                                               tableName: String,
+                                               tablePath: String,
+                                               isPartitioned: Boolean): Unit = {
+    val createTablePartitionClause = if (isPartitioned) "partitioned by (dt)" else ""
+
+    // CREATE TABLE with Lance configuration
+    // Lance format requires Spark record merger for writing
+    spark.sql(s"""
+      create table $tableName (
+        id int,
+        dt string,
+        name string,
+        age int,
+        score double
+      ) using hudi
+      tblproperties (
+        hoodie.table.base.file.format = 'LANCE',
+        type = '${tableType.name()}',
+        primaryKey = 'id',
+        hoodie.write.record.merge.custom.implementation.classes = '${classOf[DefaultSparkRecordMerger].getName}'
+      )
+      $createTablePartitionClause
+      location '$tablePath'
+    """.stripMargin)
+
+    // Test 1: INSERT with all columns in schema order
+    spark.sql(s"""
+      insert into $tableName (id, name, age, score, dt)
+      values (1, 'Alice', 30, 95.5, '2025-01-01'),
+             (2, 'Bob', 25, 87.3, '2025-01-02')
+    """.stripMargin)
+
+    checkAnswer(s"select id, name, age, score, dt from $tableName order by id")(
+      Seq(1, "Alice", 30, 95.5, "2025-01-01"),
+      Seq(2, "Bob", 25, 87.3, "2025-01-02")
+    )
+
+    // Test 2: INSERT with reordered columns
+    spark.sql(s"""
+      insert into $tableName (dt, name, id, age, score)
+      values ('2025-01-03', 'Charlie', 3, 35, 92.1)
+    """.stripMargin)
+
+    checkAnswer(s"select id, name, age, score, dt from $tableName order by id")(
+      Seq(1, "Alice", 30, 95.5, "2025-01-01"),
+      Seq(2, "Bob", 25, 87.3, "2025-01-02"),
+      Seq(3, "Charlie", 35, 92.1, "2025-01-03")
+    )
+
+    // Test 3: INSERT with subset of columns (null handling)
+    spark.sql(s"""
+      insert into $tableName (dt, age, name, id)
+      values ('2025-01-04', 40, 'Diana', 4)
+    """.stripMargin)
+
+    checkAnswer(s"select id, name, age, score, dt from $tableName order by id")(
+      Seq(1, "Alice", 30, 95.5, "2025-01-01"),
+      Seq(2, "Bob", 25, 87.3, "2025-01-02"),
+      Seq(3, "Charlie", 35, 92.1, "2025-01-03"),
+      Seq(4, "Diana", 40, null, "2025-01-04")
+    )
+
+    // Test 4: INSERT with static partition (only for partitioned tables)
+    if (isPartitioned) {
+      spark.sql(s"""
+        insert into $tableName partition(dt='2025-01-05') (age, id, name)
+        values (28, 5, 'Eve')
+      """.stripMargin)
+
+      checkAnswer(s"select id, name, age, score, dt from $tableName order by id")(
+        Seq(1, "Alice", 30, 95.5, "2025-01-01"),
+        Seq(2, "Bob", 25, 87.3, "2025-01-02"),
+        Seq(3, "Charlie", 35, 92.1, "2025-01-03"),
+        Seq(4, "Diana", 40, null, "2025-01-04"),
+        Seq(5, "Eve", 28, null, "2025-01-05")
+      )
+    }
+
+    // Verify Lance files were created
+    val metaClient = HoodieTableMetaClient.builder()
+      .setConf(HoodieTestUtils.getDefaultStorageConf)
+      .setBasePath(tablePath)
+      .build()
+
+    val baseFileFormat = metaClient.getTableConfig.getBaseFileFormat
+    assertEquals(HoodieFileFormat.LANCE, baseFileFormat,
+                 "Table should use Lance base file format")
   }
 
   private def createDataFrame(records: Seq[(Int, String, Int, Double)]) = {

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestLanceDataSource.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestLanceDataSource.scala
@@ -103,6 +103,14 @@ class TestLanceDataSource extends HoodieSparkClientTestBase {
 
     assertTrue(expectedDf.except(actual).isEmpty)
     assertTrue(actual.except(expectedDf).isEmpty)
+
+    // Verify SELECT count(*) returns the correct row count. This exercises the column-less
+    // scan path in SparkLanceReaderBase (requiredSchema.isEmpty && partitionSchema.isEmpty),
+    // which opens the Lance file solely to read its row count via the footer/manifest.
+    readDf.createOrReplaceTempView(tableName)
+    val countResult = spark.sql(s"SELECT count(*) FROM $tableName").collect()
+    assertEquals(records.length.toLong, countResult(0).getLong(0))
+    assertEquals(records.length.toLong, readDf.count())
   }
 
   @ParameterizedTest
@@ -816,8 +824,7 @@ class TestLanceDataSource extends HoodieSparkClientTestBase {
                                                isPartitioned: Boolean): Unit = {
     val createTablePartitionClause = if (isPartitioned) "partitioned by (dt)" else ""
 
-    // CREATE TABLE with Lance configuration
-    // Lance format requires Spark record merger for writing
+    // CREATE TABLE with Lance configuration.
     spark.sql(s"""
       create table $tableName (
         id int,
@@ -829,8 +836,7 @@ class TestLanceDataSource extends HoodieSparkClientTestBase {
       tblproperties (
         hoodie.table.base.file.format = 'LANCE',
         type = '${tableType.name()}',
-        primaryKey = 'id',
-        hoodie.write.record.merge.custom.implementation.classes = '${classOf[DefaultSparkRecordMerger].getName}'
+        primaryKey = 'id'
       )
       $createTablePartitionClause
       location '$tablePath'

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestSparkSqlCoreFlow.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestSparkSqlCoreFlow.scala
@@ -19,8 +19,8 @@
 
 package org.apache.hudi.functional
 
+import org.apache.hudi.{DefaultSparkRecordMerger, HoodieSparkUtils}
 import org.apache.hudi.DataSourceReadOptions.{QUERY_TYPE, QUERY_TYPE_READ_OPTIMIZED_OPT_VAL, QUERY_TYPE_SNAPSHOT_OPT_VAL}
-import org.apache.hudi.DefaultSparkRecordMerger
 import org.apache.hudi.HoodieDataSourceHelpers.{hasNewCommits, latestCompletedCommit, listCommitsSince, streamCompletedInstantSince}
 import org.apache.hudi.common.config.HoodieMetadataConfig
 import org.apache.hudi.common.model.{HoodieRecord, WriteOperationType}
@@ -48,40 +48,47 @@ class TestSparkSqlCoreFlow extends HoodieSparkSqlTestBase {
   val colsToCompare = "timestamp, _row_key, partition_path, rider, driver, begin_lat, begin_lon, end_lat, end_lon, fare.amount, fare.currency, _hoodie_is_deleted"
 
   //params for core flow tests
-  val params: List[String] = List(
-    "COPY_ON_WRITE|false|org.apache.hudi.keygen.SimpleKeyGenerator|GLOBAL_BLOOM|parquet",
-    "COPY_ON_WRITE|true|org.apache.hudi.keygen.SimpleKeyGenerator|GLOBAL_BLOOM|parquet",
-    "COPY_ON_WRITE|false|org.apache.hudi.keygen.SimpleKeyGenerator|GLOBAL_SIMPLE|parquet",
-    "COPY_ON_WRITE|true|org.apache.hudi.keygen.SimpleKeyGenerator|GLOBAL_SIMPLE|parquet",
-    "COPY_ON_WRITE|false|org.apache.hudi.keygen.NonpartitionedKeyGenerator|BLOOM|parquet",
-    "COPY_ON_WRITE|true|org.apache.hudi.keygen.NonpartitionedKeyGenerator|BLOOM|parquet",
-    "COPY_ON_WRITE|false|org.apache.hudi.keygen.NonpartitionedKeyGenerator|SIMPLE|parquet",
-    "COPY_ON_WRITE|true|org.apache.hudi.keygen.NonpartitionedKeyGenerator|SIMPLE|parquet",
-    "MERGE_ON_READ|false|org.apache.hudi.keygen.SimpleKeyGenerator|GLOBAL_BLOOM|parquet",
-    "MERGE_ON_READ|true|org.apache.hudi.keygen.SimpleKeyGenerator|GLOBAL_BLOOM|parquet",
-    "MERGE_ON_READ|false|org.apache.hudi.keygen.SimpleKeyGenerator|GLOBAL_SIMPLE|parquet",
-    "MERGE_ON_READ|true|org.apache.hudi.keygen.SimpleKeyGenerator|GLOBAL_SIMPLE|parquet",
-    "MERGE_ON_READ|false|org.apache.hudi.keygen.NonpartitionedKeyGenerator|BLOOM|parquet",
-    "MERGE_ON_READ|true|org.apache.hudi.keygen.NonpartitionedKeyGenerator|BLOOM|parquet",
-    "MERGE_ON_READ|false|org.apache.hudi.keygen.NonpartitionedKeyGenerator|SIMPLE|parquet",
-    "MERGE_ON_READ|true|org.apache.hudi.keygen.NonpartitionedKeyGenerator|SIMPLE|parquet",
-    "COPY_ON_WRITE|false|org.apache.hudi.keygen.SimpleKeyGenerator|GLOBAL_BLOOM|lance",
-    "COPY_ON_WRITE|true|org.apache.hudi.keygen.SimpleKeyGenerator|GLOBAL_BLOOM|lance",
-    "COPY_ON_WRITE|false|org.apache.hudi.keygen.SimpleKeyGenerator|GLOBAL_SIMPLE|lance",
-    "COPY_ON_WRITE|true|org.apache.hudi.keygen.SimpleKeyGenerator|GLOBAL_SIMPLE|lance",
-    "COPY_ON_WRITE|false|org.apache.hudi.keygen.NonpartitionedKeyGenerator|BLOOM|lance",
-    "COPY_ON_WRITE|true|org.apache.hudi.keygen.NonpartitionedKeyGenerator|BLOOM|lance",
-    "COPY_ON_WRITE|false|org.apache.hudi.keygen.NonpartitionedKeyGenerator|SIMPLE|lance",
-    "COPY_ON_WRITE|true|org.apache.hudi.keygen.NonpartitionedKeyGenerator|SIMPLE|lance",
-    "MERGE_ON_READ|false|org.apache.hudi.keygen.SimpleKeyGenerator|GLOBAL_BLOOM|lance",
-    "MERGE_ON_READ|true|org.apache.hudi.keygen.SimpleKeyGenerator|GLOBAL_BLOOM|lance",
-    "MERGE_ON_READ|false|org.apache.hudi.keygen.SimpleKeyGenerator|GLOBAL_SIMPLE|lance",
-    "MERGE_ON_READ|true|org.apache.hudi.keygen.SimpleKeyGenerator|GLOBAL_SIMPLE|lance",
-    "MERGE_ON_READ|false|org.apache.hudi.keygen.NonpartitionedKeyGenerator|BLOOM|lance",
-    "MERGE_ON_READ|true|org.apache.hudi.keygen.NonpartitionedKeyGenerator|BLOOM|lance",
-    "MERGE_ON_READ|false|org.apache.hudi.keygen.NonpartitionedKeyGenerator|SIMPLE|lance",
-    "MERGE_ON_READ|true|org.apache.hudi.keygen.NonpartitionedKeyGenerator|SIMPLE|lance"
-  )
+  val params: List[String] = {
+    val allParams: List[String] = List(
+      "COPY_ON_WRITE|false|org.apache.hudi.keygen.SimpleKeyGenerator|GLOBAL_BLOOM|parquet",
+      "COPY_ON_WRITE|true|org.apache.hudi.keygen.SimpleKeyGenerator|GLOBAL_BLOOM|parquet",
+      "COPY_ON_WRITE|false|org.apache.hudi.keygen.SimpleKeyGenerator|GLOBAL_SIMPLE|parquet",
+      "COPY_ON_WRITE|true|org.apache.hudi.keygen.SimpleKeyGenerator|GLOBAL_SIMPLE|parquet",
+      "COPY_ON_WRITE|false|org.apache.hudi.keygen.NonpartitionedKeyGenerator|BLOOM|parquet",
+      "COPY_ON_WRITE|true|org.apache.hudi.keygen.NonpartitionedKeyGenerator|BLOOM|parquet",
+      "COPY_ON_WRITE|false|org.apache.hudi.keygen.NonpartitionedKeyGenerator|SIMPLE|parquet",
+      "COPY_ON_WRITE|true|org.apache.hudi.keygen.NonpartitionedKeyGenerator|SIMPLE|parquet",
+      "MERGE_ON_READ|false|org.apache.hudi.keygen.SimpleKeyGenerator|GLOBAL_BLOOM|parquet",
+      "MERGE_ON_READ|true|org.apache.hudi.keygen.SimpleKeyGenerator|GLOBAL_BLOOM|parquet",
+      "MERGE_ON_READ|false|org.apache.hudi.keygen.SimpleKeyGenerator|GLOBAL_SIMPLE|parquet",
+      "MERGE_ON_READ|true|org.apache.hudi.keygen.SimpleKeyGenerator|GLOBAL_SIMPLE|parquet",
+      "MERGE_ON_READ|false|org.apache.hudi.keygen.NonpartitionedKeyGenerator|BLOOM|parquet",
+      "MERGE_ON_READ|true|org.apache.hudi.keygen.NonpartitionedKeyGenerator|BLOOM|parquet",
+      "MERGE_ON_READ|false|org.apache.hudi.keygen.NonpartitionedKeyGenerator|SIMPLE|parquet",
+      "MERGE_ON_READ|true|org.apache.hudi.keygen.NonpartitionedKeyGenerator|SIMPLE|parquet",
+      "COPY_ON_WRITE|false|org.apache.hudi.keygen.SimpleKeyGenerator|GLOBAL_BLOOM|lance",
+      "COPY_ON_WRITE|true|org.apache.hudi.keygen.SimpleKeyGenerator|GLOBAL_BLOOM|lance",
+      "COPY_ON_WRITE|false|org.apache.hudi.keygen.SimpleKeyGenerator|GLOBAL_SIMPLE|lance",
+      "COPY_ON_WRITE|true|org.apache.hudi.keygen.SimpleKeyGenerator|GLOBAL_SIMPLE|lance",
+      "COPY_ON_WRITE|false|org.apache.hudi.keygen.NonpartitionedKeyGenerator|BLOOM|lance",
+      "COPY_ON_WRITE|true|org.apache.hudi.keygen.NonpartitionedKeyGenerator|BLOOM|lance",
+      "COPY_ON_WRITE|false|org.apache.hudi.keygen.NonpartitionedKeyGenerator|SIMPLE|lance",
+      "COPY_ON_WRITE|true|org.apache.hudi.keygen.NonpartitionedKeyGenerator|SIMPLE|lance",
+      "MERGE_ON_READ|false|org.apache.hudi.keygen.SimpleKeyGenerator|GLOBAL_BLOOM|lance",
+      "MERGE_ON_READ|true|org.apache.hudi.keygen.SimpleKeyGenerator|GLOBAL_BLOOM|lance",
+      "MERGE_ON_READ|false|org.apache.hudi.keygen.SimpleKeyGenerator|GLOBAL_SIMPLE|lance",
+      "MERGE_ON_READ|true|org.apache.hudi.keygen.SimpleKeyGenerator|GLOBAL_SIMPLE|lance",
+      "MERGE_ON_READ|false|org.apache.hudi.keygen.NonpartitionedKeyGenerator|BLOOM|lance",
+      "MERGE_ON_READ|true|org.apache.hudi.keygen.NonpartitionedKeyGenerator|BLOOM|lance",
+      "MERGE_ON_READ|false|org.apache.hudi.keygen.NonpartitionedKeyGenerator|SIMPLE|lance",
+      "MERGE_ON_READ|true|org.apache.hudi.keygen.NonpartitionedKeyGenerator|SIMPLE|lance"
+    )
+    if (HoodieSparkUtils.gteqSpark3_4) {
+      allParams
+    } else {
+      allParams.filterNot(_.endsWith("|lance"))
+    }
+  }
 
   //extracts the params and runs each core flow test
   forAll(params) { (paramStr: String) =>
@@ -436,72 +443,79 @@ class TestSparkSqlCoreFlow extends HoodieSparkSqlTestBase {
   }
 
   //params for immutable user flow
-  val paramsForImmutable: List[String] = List(
-    "COPY_ON_WRITE|insert|false|org.apache.hudi.keygen.SimpleKeyGenerator|GLOBAL_BLOOM|parquet",
-    "COPY_ON_WRITE|insert|true|org.apache.hudi.keygen.SimpleKeyGenerator|GLOBAL_BLOOM|parquet",
-    "COPY_ON_WRITE|insert|false|org.apache.hudi.keygen.SimpleKeyGenerator|GLOBAL_SIMPLE|parquet",
-    "COPY_ON_WRITE|insert|true|org.apache.hudi.keygen.SimpleKeyGenerator|GLOBAL_SIMPLE|parquet",
-    "COPY_ON_WRITE|insert|false|org.apache.hudi.keygen.NonpartitionedKeyGenerator|BLOOM|parquet",
-    "COPY_ON_WRITE|insert|true|org.apache.hudi.keygen.NonpartitionedKeyGenerator|BLOOM|parquet",
-    "COPY_ON_WRITE|insert|false|org.apache.hudi.keygen.NonpartitionedKeyGenerator|SIMPLE|parquet",
-    "COPY_ON_WRITE|insert|true|org.apache.hudi.keygen.NonpartitionedKeyGenerator|SIMPLE|parquet",
-    "MERGE_ON_READ|insert|false|org.apache.hudi.keygen.SimpleKeyGenerator|GLOBAL_BLOOM|parquet",
-    "MERGE_ON_READ|insert|true|org.apache.hudi.keygen.SimpleKeyGenerator|GLOBAL_BLOOM|parquet",
-    "MERGE_ON_READ|insert|false|org.apache.hudi.keygen.SimpleKeyGenerator|GLOBAL_SIMPLE|parquet",
-    "MERGE_ON_READ|insert|true|org.apache.hudi.keygen.SimpleKeyGenerator|GLOBAL_SIMPLE|parquet",
-    "MERGE_ON_READ|insert|false|org.apache.hudi.keygen.NonpartitionedKeyGenerator|BLOOM|parquet",
-    "MERGE_ON_READ|insert|true|org.apache.hudi.keygen.NonpartitionedKeyGenerator|BLOOM|parquet",
-    "MERGE_ON_READ|insert|false|org.apache.hudi.keygen.NonpartitionedKeyGenerator|SIMPLE|parquet",
-    "MERGE_ON_READ|insert|true|org.apache.hudi.keygen.NonpartitionedKeyGenerator|SIMPLE|parquet",
-    "COPY_ON_WRITE|bulk_insert|false|org.apache.hudi.keygen.SimpleKeyGenerator|GLOBAL_BLOOM|parquet",
-    "COPY_ON_WRITE|bulk_insert|true|org.apache.hudi.keygen.SimpleKeyGenerator|GLOBAL_BLOOM|parquet",
-    "COPY_ON_WRITE|bulk_insert|false|org.apache.hudi.keygen.SimpleKeyGenerator|GLOBAL_SIMPLE|parquet",
-    "COPY_ON_WRITE|bulk_insert|true|org.apache.hudi.keygen.SimpleKeyGenerator|GLOBAL_SIMPLE|parquet",
-    "COPY_ON_WRITE|bulk_insert|false|org.apache.hudi.keygen.NonpartitionedKeyGenerator|BLOOM|parquet",
-    "COPY_ON_WRITE|bulk_insert|true|org.apache.hudi.keygen.NonpartitionedKeyGenerator|BLOOM|parquet",
-    "COPY_ON_WRITE|bulk_insert|false|org.apache.hudi.keygen.NonpartitionedKeyGenerator|SIMPLE|parquet",
-    "COPY_ON_WRITE|bulk_insert|true|org.apache.hudi.keygen.NonpartitionedKeyGenerator|SIMPLE|parquet",
-    "MERGE_ON_READ|bulk_insert|false|org.apache.hudi.keygen.SimpleKeyGenerator|GLOBAL_BLOOM|parquet",
-    "MERGE_ON_READ|bulk_insert|true|org.apache.hudi.keygen.SimpleKeyGenerator|GLOBAL_BLOOM|parquet",
-    "MERGE_ON_READ|bulk_insert|false|org.apache.hudi.keygen.SimpleKeyGenerator|GLOBAL_SIMPLE|parquet",
-    "MERGE_ON_READ|bulk_insert|true|org.apache.hudi.keygen.SimpleKeyGenerator|GLOBAL_SIMPLE|parquet",
-    "MERGE_ON_READ|bulk_insert|false|org.apache.hudi.keygen.NonpartitionedKeyGenerator|BLOOM|parquet",
-    "MERGE_ON_READ|bulk_insert|true|org.apache.hudi.keygen.NonpartitionedKeyGenerator|BLOOM|parquet",
-    "MERGE_ON_READ|bulk_insert|false|org.apache.hudi.keygen.NonpartitionedKeyGenerator|SIMPLE|parquet",
-    "MERGE_ON_READ|bulk_insert|true|org.apache.hudi.keygen.NonpartitionedKeyGenerator|SIMPLE|parquet",
-    "COPY_ON_WRITE|insert|false|org.apache.hudi.keygen.SimpleKeyGenerator|GLOBAL_BLOOM|lance",
-    "COPY_ON_WRITE|insert|true|org.apache.hudi.keygen.SimpleKeyGenerator|GLOBAL_BLOOM|lance",
-    "COPY_ON_WRITE|insert|false|org.apache.hudi.keygen.SimpleKeyGenerator|GLOBAL_SIMPLE|lance",
-    "COPY_ON_WRITE|insert|true|org.apache.hudi.keygen.SimpleKeyGenerator|GLOBAL_SIMPLE|lance",
-    "COPY_ON_WRITE|insert|false|org.apache.hudi.keygen.NonpartitionedKeyGenerator|BLOOM|lance",
-    "COPY_ON_WRITE|insert|true|org.apache.hudi.keygen.NonpartitionedKeyGenerator|BLOOM|lance",
-    "COPY_ON_WRITE|insert|false|org.apache.hudi.keygen.NonpartitionedKeyGenerator|SIMPLE|lance",
-    "COPY_ON_WRITE|insert|true|org.apache.hudi.keygen.NonpartitionedKeyGenerator|SIMPLE|lance",
-    "MERGE_ON_READ|insert|false|org.apache.hudi.keygen.SimpleKeyGenerator|GLOBAL_BLOOM|lance",
-    "MERGE_ON_READ|insert|true|org.apache.hudi.keygen.SimpleKeyGenerator|GLOBAL_BLOOM|lance",
-    "MERGE_ON_READ|insert|false|org.apache.hudi.keygen.SimpleKeyGenerator|GLOBAL_SIMPLE|lance",
-    "MERGE_ON_READ|insert|true|org.apache.hudi.keygen.SimpleKeyGenerator|GLOBAL_SIMPLE|lance",
-    "MERGE_ON_READ|insert|false|org.apache.hudi.keygen.NonpartitionedKeyGenerator|BLOOM|lance",
-    "MERGE_ON_READ|insert|true|org.apache.hudi.keygen.NonpartitionedKeyGenerator|BLOOM|lance",
-    "MERGE_ON_READ|insert|false|org.apache.hudi.keygen.NonpartitionedKeyGenerator|SIMPLE|lance",
-    "MERGE_ON_READ|insert|true|org.apache.hudi.keygen.NonpartitionedKeyGenerator|SIMPLE|lance",
-    "COPY_ON_WRITE|bulk_insert|false|org.apache.hudi.keygen.SimpleKeyGenerator|GLOBAL_BLOOM|lance",
-    "COPY_ON_WRITE|bulk_insert|true|org.apache.hudi.keygen.SimpleKeyGenerator|GLOBAL_BLOOM|lance",
-    "COPY_ON_WRITE|bulk_insert|false|org.apache.hudi.keygen.SimpleKeyGenerator|GLOBAL_SIMPLE|lance",
-    "COPY_ON_WRITE|bulk_insert|true|org.apache.hudi.keygen.SimpleKeyGenerator|GLOBAL_SIMPLE|lance",
-    "COPY_ON_WRITE|bulk_insert|false|org.apache.hudi.keygen.NonpartitionedKeyGenerator|BLOOM|lance",
-    "COPY_ON_WRITE|bulk_insert|true|org.apache.hudi.keygen.NonpartitionedKeyGenerator|BLOOM|lance",
-    "COPY_ON_WRITE|bulk_insert|false|org.apache.hudi.keygen.NonpartitionedKeyGenerator|SIMPLE|lance",
-    "COPY_ON_WRITE|bulk_insert|true|org.apache.hudi.keygen.NonpartitionedKeyGenerator|SIMPLE|lance",
-    "MERGE_ON_READ|bulk_insert|false|org.apache.hudi.keygen.SimpleKeyGenerator|GLOBAL_BLOOM|lance",
-    "MERGE_ON_READ|bulk_insert|true|org.apache.hudi.keygen.SimpleKeyGenerator|GLOBAL_BLOOM|lance",
-    "MERGE_ON_READ|bulk_insert|false|org.apache.hudi.keygen.SimpleKeyGenerator|GLOBAL_SIMPLE|lance",
-    "MERGE_ON_READ|bulk_insert|true|org.apache.hudi.keygen.SimpleKeyGenerator|GLOBAL_SIMPLE|lance",
-    "MERGE_ON_READ|bulk_insert|false|org.apache.hudi.keygen.NonpartitionedKeyGenerator|BLOOM|lance",
-    "MERGE_ON_READ|bulk_insert|true|org.apache.hudi.keygen.NonpartitionedKeyGenerator|BLOOM|lance",
-    "MERGE_ON_READ|bulk_insert|false|org.apache.hudi.keygen.NonpartitionedKeyGenerator|SIMPLE|lance",
-    "MERGE_ON_READ|bulk_insert|true|org.apache.hudi.keygen.NonpartitionedKeyGenerator|SIMPLE|lance"
-  )
+  val paramsForImmutable: List[String] = {
+    val allParamsForImmutable: List[String] = List(
+      "COPY_ON_WRITE|insert|false|org.apache.hudi.keygen.SimpleKeyGenerator|GLOBAL_BLOOM|parquet",
+      "COPY_ON_WRITE|insert|true|org.apache.hudi.keygen.SimpleKeyGenerator|GLOBAL_BLOOM|parquet",
+      "COPY_ON_WRITE|insert|false|org.apache.hudi.keygen.SimpleKeyGenerator|GLOBAL_SIMPLE|parquet",
+      "COPY_ON_WRITE|insert|true|org.apache.hudi.keygen.SimpleKeyGenerator|GLOBAL_SIMPLE|parquet",
+      "COPY_ON_WRITE|insert|false|org.apache.hudi.keygen.NonpartitionedKeyGenerator|BLOOM|parquet",
+      "COPY_ON_WRITE|insert|true|org.apache.hudi.keygen.NonpartitionedKeyGenerator|BLOOM|parquet",
+      "COPY_ON_WRITE|insert|false|org.apache.hudi.keygen.NonpartitionedKeyGenerator|SIMPLE|parquet",
+      "COPY_ON_WRITE|insert|true|org.apache.hudi.keygen.NonpartitionedKeyGenerator|SIMPLE|parquet",
+      "MERGE_ON_READ|insert|false|org.apache.hudi.keygen.SimpleKeyGenerator|GLOBAL_BLOOM|parquet",
+      "MERGE_ON_READ|insert|true|org.apache.hudi.keygen.SimpleKeyGenerator|GLOBAL_BLOOM|parquet",
+      "MERGE_ON_READ|insert|false|org.apache.hudi.keygen.SimpleKeyGenerator|GLOBAL_SIMPLE|parquet",
+      "MERGE_ON_READ|insert|true|org.apache.hudi.keygen.SimpleKeyGenerator|GLOBAL_SIMPLE|parquet",
+      "MERGE_ON_READ|insert|false|org.apache.hudi.keygen.NonpartitionedKeyGenerator|BLOOM|parquet",
+      "MERGE_ON_READ|insert|true|org.apache.hudi.keygen.NonpartitionedKeyGenerator|BLOOM|parquet",
+      "MERGE_ON_READ|insert|false|org.apache.hudi.keygen.NonpartitionedKeyGenerator|SIMPLE|parquet",
+      "MERGE_ON_READ|insert|true|org.apache.hudi.keygen.NonpartitionedKeyGenerator|SIMPLE|parquet",
+      "COPY_ON_WRITE|bulk_insert|false|org.apache.hudi.keygen.SimpleKeyGenerator|GLOBAL_BLOOM|parquet",
+      "COPY_ON_WRITE|bulk_insert|true|org.apache.hudi.keygen.SimpleKeyGenerator|GLOBAL_BLOOM|parquet",
+      "COPY_ON_WRITE|bulk_insert|false|org.apache.hudi.keygen.SimpleKeyGenerator|GLOBAL_SIMPLE|parquet",
+      "COPY_ON_WRITE|bulk_insert|true|org.apache.hudi.keygen.SimpleKeyGenerator|GLOBAL_SIMPLE|parquet",
+      "COPY_ON_WRITE|bulk_insert|false|org.apache.hudi.keygen.NonpartitionedKeyGenerator|BLOOM|parquet",
+      "COPY_ON_WRITE|bulk_insert|true|org.apache.hudi.keygen.NonpartitionedKeyGenerator|BLOOM|parquet",
+      "COPY_ON_WRITE|bulk_insert|false|org.apache.hudi.keygen.NonpartitionedKeyGenerator|SIMPLE|parquet",
+      "COPY_ON_WRITE|bulk_insert|true|org.apache.hudi.keygen.NonpartitionedKeyGenerator|SIMPLE|parquet",
+      "MERGE_ON_READ|bulk_insert|false|org.apache.hudi.keygen.SimpleKeyGenerator|GLOBAL_BLOOM|parquet",
+      "MERGE_ON_READ|bulk_insert|true|org.apache.hudi.keygen.SimpleKeyGenerator|GLOBAL_BLOOM|parquet",
+      "MERGE_ON_READ|bulk_insert|false|org.apache.hudi.keygen.SimpleKeyGenerator|GLOBAL_SIMPLE|parquet",
+      "MERGE_ON_READ|bulk_insert|true|org.apache.hudi.keygen.SimpleKeyGenerator|GLOBAL_SIMPLE|parquet",
+      "MERGE_ON_READ|bulk_insert|false|org.apache.hudi.keygen.NonpartitionedKeyGenerator|BLOOM|parquet",
+      "MERGE_ON_READ|bulk_insert|true|org.apache.hudi.keygen.NonpartitionedKeyGenerator|BLOOM|parquet",
+      "MERGE_ON_READ|bulk_insert|false|org.apache.hudi.keygen.NonpartitionedKeyGenerator|SIMPLE|parquet",
+      "MERGE_ON_READ|bulk_insert|true|org.apache.hudi.keygen.NonpartitionedKeyGenerator|SIMPLE|parquet",
+      "COPY_ON_WRITE|insert|false|org.apache.hudi.keygen.SimpleKeyGenerator|GLOBAL_BLOOM|lance",
+      "COPY_ON_WRITE|insert|true|org.apache.hudi.keygen.SimpleKeyGenerator|GLOBAL_BLOOM|lance",
+      "COPY_ON_WRITE|insert|false|org.apache.hudi.keygen.SimpleKeyGenerator|GLOBAL_SIMPLE|lance",
+      "COPY_ON_WRITE|insert|true|org.apache.hudi.keygen.SimpleKeyGenerator|GLOBAL_SIMPLE|lance",
+      "COPY_ON_WRITE|insert|false|org.apache.hudi.keygen.NonpartitionedKeyGenerator|BLOOM|lance",
+      "COPY_ON_WRITE|insert|true|org.apache.hudi.keygen.NonpartitionedKeyGenerator|BLOOM|lance",
+      "COPY_ON_WRITE|insert|false|org.apache.hudi.keygen.NonpartitionedKeyGenerator|SIMPLE|lance",
+      "COPY_ON_WRITE|insert|true|org.apache.hudi.keygen.NonpartitionedKeyGenerator|SIMPLE|lance",
+      "MERGE_ON_READ|insert|false|org.apache.hudi.keygen.SimpleKeyGenerator|GLOBAL_BLOOM|lance",
+      "MERGE_ON_READ|insert|true|org.apache.hudi.keygen.SimpleKeyGenerator|GLOBAL_BLOOM|lance",
+      "MERGE_ON_READ|insert|false|org.apache.hudi.keygen.SimpleKeyGenerator|GLOBAL_SIMPLE|lance",
+      "MERGE_ON_READ|insert|true|org.apache.hudi.keygen.SimpleKeyGenerator|GLOBAL_SIMPLE|lance",
+      "MERGE_ON_READ|insert|false|org.apache.hudi.keygen.NonpartitionedKeyGenerator|BLOOM|lance",
+      "MERGE_ON_READ|insert|true|org.apache.hudi.keygen.NonpartitionedKeyGenerator|BLOOM|lance",
+      "MERGE_ON_READ|insert|false|org.apache.hudi.keygen.NonpartitionedKeyGenerator|SIMPLE|lance",
+      "MERGE_ON_READ|insert|true|org.apache.hudi.keygen.NonpartitionedKeyGenerator|SIMPLE|lance",
+      "COPY_ON_WRITE|bulk_insert|false|org.apache.hudi.keygen.SimpleKeyGenerator|GLOBAL_BLOOM|lance",
+      "COPY_ON_WRITE|bulk_insert|true|org.apache.hudi.keygen.SimpleKeyGenerator|GLOBAL_BLOOM|lance",
+      "COPY_ON_WRITE|bulk_insert|false|org.apache.hudi.keygen.SimpleKeyGenerator|GLOBAL_SIMPLE|lance",
+      "COPY_ON_WRITE|bulk_insert|true|org.apache.hudi.keygen.SimpleKeyGenerator|GLOBAL_SIMPLE|lance",
+      "COPY_ON_WRITE|bulk_insert|false|org.apache.hudi.keygen.NonpartitionedKeyGenerator|BLOOM|lance",
+      "COPY_ON_WRITE|bulk_insert|true|org.apache.hudi.keygen.NonpartitionedKeyGenerator|BLOOM|lance",
+      "COPY_ON_WRITE|bulk_insert|false|org.apache.hudi.keygen.NonpartitionedKeyGenerator|SIMPLE|lance",
+      "COPY_ON_WRITE|bulk_insert|true|org.apache.hudi.keygen.NonpartitionedKeyGenerator|SIMPLE|lance",
+      "MERGE_ON_READ|bulk_insert|false|org.apache.hudi.keygen.SimpleKeyGenerator|GLOBAL_BLOOM|lance",
+      "MERGE_ON_READ|bulk_insert|true|org.apache.hudi.keygen.SimpleKeyGenerator|GLOBAL_BLOOM|lance",
+      "MERGE_ON_READ|bulk_insert|false|org.apache.hudi.keygen.SimpleKeyGenerator|GLOBAL_SIMPLE|lance",
+      "MERGE_ON_READ|bulk_insert|true|org.apache.hudi.keygen.SimpleKeyGenerator|GLOBAL_SIMPLE|lance",
+      "MERGE_ON_READ|bulk_insert|false|org.apache.hudi.keygen.NonpartitionedKeyGenerator|BLOOM|lance",
+      "MERGE_ON_READ|bulk_insert|true|org.apache.hudi.keygen.NonpartitionedKeyGenerator|BLOOM|lance",
+      "MERGE_ON_READ|bulk_insert|false|org.apache.hudi.keygen.NonpartitionedKeyGenerator|SIMPLE|lance",
+      "MERGE_ON_READ|bulk_insert|true|org.apache.hudi.keygen.NonpartitionedKeyGenerator|SIMPLE|lance"
+    )
+    if (HoodieSparkUtils.gteqSpark3_4) {
+      allParamsForImmutable
+    } else {
+      allParamsForImmutable.filterNot(_.endsWith("|lance"))
+    }
+  }
 
   //extracts the params and runs each immutable user flow test
   forAll(paramsForImmutable) { (paramStr: String) =>

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestSparkSqlCoreFlow.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestSparkSqlCoreFlow.scala
@@ -19,9 +19,9 @@
 
 package org.apache.hudi.functional
 
-import org.apache.hudi.{DefaultSparkRecordMerger, HoodieSparkUtils}
 import org.apache.hudi.DataSourceReadOptions.{QUERY_TYPE, QUERY_TYPE_READ_OPTIMIZED_OPT_VAL, QUERY_TYPE_SNAPSHOT_OPT_VAL}
 import org.apache.hudi.HoodieDataSourceHelpers.{hasNewCommits, latestCompletedCommit, listCommitsSince, streamCompletedInstantSince}
+import org.apache.hudi.HoodieSparkUtils
 import org.apache.hudi.common.config.HoodieMetadataConfig
 import org.apache.hudi.common.model.{HoodieRecord, WriteOperationType}
 import org.apache.hudi.common.model.WriteOperationType.{BULK_INSERT, INSERT, UPSERT}
@@ -66,22 +66,13 @@ class TestSparkSqlCoreFlow extends HoodieSparkSqlTestBase {
       "MERGE_ON_READ|true|org.apache.hudi.keygen.NonpartitionedKeyGenerator|BLOOM|parquet",
       "MERGE_ON_READ|false|org.apache.hudi.keygen.NonpartitionedKeyGenerator|SIMPLE|parquet",
       "MERGE_ON_READ|true|org.apache.hudi.keygen.NonpartitionedKeyGenerator|SIMPLE|parquet",
-      "COPY_ON_WRITE|false|org.apache.hudi.keygen.SimpleKeyGenerator|GLOBAL_BLOOM|lance",
+      // Representative Lance subset: COW/MOR x partitioned/non-partitioned x global/local index.
+      // Lance format is orthogonal to keygen/index/metadata — full cartesian adds ~60 runs with
+      // minimal extra signal. Edge cases belong in TestLanceDataSource.
       "COPY_ON_WRITE|true|org.apache.hudi.keygen.SimpleKeyGenerator|GLOBAL_BLOOM|lance",
-      "COPY_ON_WRITE|false|org.apache.hudi.keygen.SimpleKeyGenerator|GLOBAL_SIMPLE|lance",
-      "COPY_ON_WRITE|true|org.apache.hudi.keygen.SimpleKeyGenerator|GLOBAL_SIMPLE|lance",
-      "COPY_ON_WRITE|false|org.apache.hudi.keygen.NonpartitionedKeyGenerator|BLOOM|lance",
-      "COPY_ON_WRITE|true|org.apache.hudi.keygen.NonpartitionedKeyGenerator|BLOOM|lance",
       "COPY_ON_WRITE|false|org.apache.hudi.keygen.NonpartitionedKeyGenerator|SIMPLE|lance",
-      "COPY_ON_WRITE|true|org.apache.hudi.keygen.NonpartitionedKeyGenerator|SIMPLE|lance",
-      "MERGE_ON_READ|false|org.apache.hudi.keygen.SimpleKeyGenerator|GLOBAL_BLOOM|lance",
       "MERGE_ON_READ|true|org.apache.hudi.keygen.SimpleKeyGenerator|GLOBAL_BLOOM|lance",
-      "MERGE_ON_READ|false|org.apache.hudi.keygen.SimpleKeyGenerator|GLOBAL_SIMPLE|lance",
-      "MERGE_ON_READ|true|org.apache.hudi.keygen.SimpleKeyGenerator|GLOBAL_SIMPLE|lance",
-      "MERGE_ON_READ|false|org.apache.hudi.keygen.NonpartitionedKeyGenerator|BLOOM|lance",
-      "MERGE_ON_READ|true|org.apache.hudi.keygen.NonpartitionedKeyGenerator|BLOOM|lance",
-      "MERGE_ON_READ|false|org.apache.hudi.keygen.NonpartitionedKeyGenerator|SIMPLE|lance",
-      "MERGE_ON_READ|true|org.apache.hudi.keygen.NonpartitionedKeyGenerator|SIMPLE|lance"
+      "MERGE_ON_READ|false|org.apache.hudi.keygen.NonpartitionedKeyGenerator|SIMPLE|lance"
     )
     withLanceIfSupported(allParams)
   }
@@ -237,19 +228,12 @@ class TestSparkSqlCoreFlow extends HoodieSparkSqlTestBase {
       tableType
     }
 
-    val recordMergerImpl = if (baseFileFormat == "lance") {
-      s"hoodie.write.record.merge.custom.implementation.classes = '${classOf[DefaultSparkRecordMerger].getName}',"
-    } else {
-      ""
-    }
-
     s"""
        |tblproperties (
        |  type = '$typeString',
        |  primaryKey = '_row_key',
        |  orderingFields = 'timestamp',
        |  hoodie.table.base.file.format = '$baseFileFormat',
-       |  $recordMergerImpl
        |  hoodie.bulkinsert.shuffle.parallelism = 4,
        |  hoodie.database.name = "databaseName",
        |  hoodie.table.keygenerator.class = '$keyGenClass',
@@ -473,38 +457,13 @@ class TestSparkSqlCoreFlow extends HoodieSparkSqlTestBase {
       "MERGE_ON_READ|bulk_insert|true|org.apache.hudi.keygen.NonpartitionedKeyGenerator|BLOOM|parquet",
       "MERGE_ON_READ|bulk_insert|false|org.apache.hudi.keygen.NonpartitionedKeyGenerator|SIMPLE|parquet",
       "MERGE_ON_READ|bulk_insert|true|org.apache.hudi.keygen.NonpartitionedKeyGenerator|SIMPLE|parquet",
-      "COPY_ON_WRITE|insert|false|org.apache.hudi.keygen.SimpleKeyGenerator|GLOBAL_BLOOM|lance",
+      // Representative Lance subset: COW/MOR x insert/bulk_insert x partitioned/non-partitioned.
+      // Keeps coverage of write-operation axis (which was the motivation for this list) while
+      // avoiding a 32-row cartesian over keygen/index/metadata dimensions.
       "COPY_ON_WRITE|insert|true|org.apache.hudi.keygen.SimpleKeyGenerator|GLOBAL_BLOOM|lance",
-      "COPY_ON_WRITE|insert|false|org.apache.hudi.keygen.SimpleKeyGenerator|GLOBAL_SIMPLE|lance",
-      "COPY_ON_WRITE|insert|true|org.apache.hudi.keygen.SimpleKeyGenerator|GLOBAL_SIMPLE|lance",
-      "COPY_ON_WRITE|insert|false|org.apache.hudi.keygen.NonpartitionedKeyGenerator|BLOOM|lance",
-      "COPY_ON_WRITE|insert|true|org.apache.hudi.keygen.NonpartitionedKeyGenerator|BLOOM|lance",
-      "COPY_ON_WRITE|insert|false|org.apache.hudi.keygen.NonpartitionedKeyGenerator|SIMPLE|lance",
-      "COPY_ON_WRITE|insert|true|org.apache.hudi.keygen.NonpartitionedKeyGenerator|SIMPLE|lance",
-      "MERGE_ON_READ|insert|false|org.apache.hudi.keygen.SimpleKeyGenerator|GLOBAL_BLOOM|lance",
-      "MERGE_ON_READ|insert|true|org.apache.hudi.keygen.SimpleKeyGenerator|GLOBAL_BLOOM|lance",
-      "MERGE_ON_READ|insert|false|org.apache.hudi.keygen.SimpleKeyGenerator|GLOBAL_SIMPLE|lance",
-      "MERGE_ON_READ|insert|true|org.apache.hudi.keygen.SimpleKeyGenerator|GLOBAL_SIMPLE|lance",
-      "MERGE_ON_READ|insert|false|org.apache.hudi.keygen.NonpartitionedKeyGenerator|BLOOM|lance",
-      "MERGE_ON_READ|insert|true|org.apache.hudi.keygen.NonpartitionedKeyGenerator|BLOOM|lance",
       "MERGE_ON_READ|insert|false|org.apache.hudi.keygen.NonpartitionedKeyGenerator|SIMPLE|lance",
-      "MERGE_ON_READ|insert|true|org.apache.hudi.keygen.NonpartitionedKeyGenerator|SIMPLE|lance",
-      "COPY_ON_WRITE|bulk_insert|false|org.apache.hudi.keygen.SimpleKeyGenerator|GLOBAL_BLOOM|lance",
       "COPY_ON_WRITE|bulk_insert|true|org.apache.hudi.keygen.SimpleKeyGenerator|GLOBAL_BLOOM|lance",
-      "COPY_ON_WRITE|bulk_insert|false|org.apache.hudi.keygen.SimpleKeyGenerator|GLOBAL_SIMPLE|lance",
-      "COPY_ON_WRITE|bulk_insert|true|org.apache.hudi.keygen.SimpleKeyGenerator|GLOBAL_SIMPLE|lance",
-      "COPY_ON_WRITE|bulk_insert|false|org.apache.hudi.keygen.NonpartitionedKeyGenerator|BLOOM|lance",
-      "COPY_ON_WRITE|bulk_insert|true|org.apache.hudi.keygen.NonpartitionedKeyGenerator|BLOOM|lance",
-      "COPY_ON_WRITE|bulk_insert|false|org.apache.hudi.keygen.NonpartitionedKeyGenerator|SIMPLE|lance",
-      "COPY_ON_WRITE|bulk_insert|true|org.apache.hudi.keygen.NonpartitionedKeyGenerator|SIMPLE|lance",
-      "MERGE_ON_READ|bulk_insert|false|org.apache.hudi.keygen.SimpleKeyGenerator|GLOBAL_BLOOM|lance",
-      "MERGE_ON_READ|bulk_insert|true|org.apache.hudi.keygen.SimpleKeyGenerator|GLOBAL_BLOOM|lance",
-      "MERGE_ON_READ|bulk_insert|false|org.apache.hudi.keygen.SimpleKeyGenerator|GLOBAL_SIMPLE|lance",
-      "MERGE_ON_READ|bulk_insert|true|org.apache.hudi.keygen.SimpleKeyGenerator|GLOBAL_SIMPLE|lance",
-      "MERGE_ON_READ|bulk_insert|false|org.apache.hudi.keygen.NonpartitionedKeyGenerator|BLOOM|lance",
-      "MERGE_ON_READ|bulk_insert|true|org.apache.hudi.keygen.NonpartitionedKeyGenerator|BLOOM|lance",
-      "MERGE_ON_READ|bulk_insert|false|org.apache.hudi.keygen.NonpartitionedKeyGenerator|SIMPLE|lance",
-      "MERGE_ON_READ|bulk_insert|true|org.apache.hudi.keygen.NonpartitionedKeyGenerator|SIMPLE|lance"
+      "MERGE_ON_READ|bulk_insert|false|org.apache.hudi.keygen.NonpartitionedKeyGenerator|SIMPLE|lance"
     )
     withLanceIfSupported(allParamsForImmutable)
   }

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestSparkSqlCoreFlow.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestSparkSqlCoreFlow.scala
@@ -20,6 +20,7 @@
 package org.apache.hudi.functional
 
 import org.apache.hudi.DataSourceReadOptions.{QUERY_TYPE, QUERY_TYPE_READ_OPTIMIZED_OPT_VAL, QUERY_TYPE_SNAPSHOT_OPT_VAL}
+import org.apache.hudi.DefaultSparkRecordMerger
 import org.apache.hudi.HoodieDataSourceHelpers.{hasNewCommits, latestCompletedCommit, listCommitsSince, streamCompletedInstantSince}
 import org.apache.hudi.common.config.HoodieMetadataConfig
 import org.apache.hudi.common.model.{HoodieRecord, WriteOperationType}
@@ -48,22 +49,38 @@ class TestSparkSqlCoreFlow extends HoodieSparkSqlTestBase {
 
   //params for core flow tests
   val params: List[String] = List(
-    "COPY_ON_WRITE|false|org.apache.hudi.keygen.SimpleKeyGenerator|GLOBAL_BLOOM",
-    "COPY_ON_WRITE|true|org.apache.hudi.keygen.SimpleKeyGenerator|GLOBAL_BLOOM",
-    "COPY_ON_WRITE|false|org.apache.hudi.keygen.SimpleKeyGenerator|GLOBAL_SIMPLE",
-    "COPY_ON_WRITE|true|org.apache.hudi.keygen.SimpleKeyGenerator|GLOBAL_SIMPLE",
-    "COPY_ON_WRITE|false|org.apache.hudi.keygen.NonpartitionedKeyGenerator|BLOOM",
-    "COPY_ON_WRITE|true|org.apache.hudi.keygen.NonpartitionedKeyGenerator|BLOOM",
-    "COPY_ON_WRITE|false|org.apache.hudi.keygen.NonpartitionedKeyGenerator|SIMPLE",
-    "COPY_ON_WRITE|true|org.apache.hudi.keygen.NonpartitionedKeyGenerator|SIMPLE",
-    "MERGE_ON_READ|false|org.apache.hudi.keygen.SimpleKeyGenerator|GLOBAL_BLOOM",
-    "MERGE_ON_READ|true|org.apache.hudi.keygen.SimpleKeyGenerator|GLOBAL_BLOOM",
-    "MERGE_ON_READ|false|org.apache.hudi.keygen.SimpleKeyGenerator|GLOBAL_SIMPLE",
-    "MERGE_ON_READ|true|org.apache.hudi.keygen.SimpleKeyGenerator|GLOBAL_SIMPLE",
-    "MERGE_ON_READ|false|org.apache.hudi.keygen.NonpartitionedKeyGenerator|BLOOM",
-    "MERGE_ON_READ|true|org.apache.hudi.keygen.NonpartitionedKeyGenerator|BLOOM",
-    "MERGE_ON_READ|false|org.apache.hudi.keygen.NonpartitionedKeyGenerator|SIMPLE",
-    "MERGE_ON_READ|true|org.apache.hudi.keygen.NonpartitionedKeyGenerator|SIMPLE"
+    "COPY_ON_WRITE|false|org.apache.hudi.keygen.SimpleKeyGenerator|GLOBAL_BLOOM|parquet",
+    "COPY_ON_WRITE|true|org.apache.hudi.keygen.SimpleKeyGenerator|GLOBAL_BLOOM|parquet",
+    "COPY_ON_WRITE|false|org.apache.hudi.keygen.SimpleKeyGenerator|GLOBAL_SIMPLE|parquet",
+    "COPY_ON_WRITE|true|org.apache.hudi.keygen.SimpleKeyGenerator|GLOBAL_SIMPLE|parquet",
+    "COPY_ON_WRITE|false|org.apache.hudi.keygen.NonpartitionedKeyGenerator|BLOOM|parquet",
+    "COPY_ON_WRITE|true|org.apache.hudi.keygen.NonpartitionedKeyGenerator|BLOOM|parquet",
+    "COPY_ON_WRITE|false|org.apache.hudi.keygen.NonpartitionedKeyGenerator|SIMPLE|parquet",
+    "COPY_ON_WRITE|true|org.apache.hudi.keygen.NonpartitionedKeyGenerator|SIMPLE|parquet",
+    "MERGE_ON_READ|false|org.apache.hudi.keygen.SimpleKeyGenerator|GLOBAL_BLOOM|parquet",
+    "MERGE_ON_READ|true|org.apache.hudi.keygen.SimpleKeyGenerator|GLOBAL_BLOOM|parquet",
+    "MERGE_ON_READ|false|org.apache.hudi.keygen.SimpleKeyGenerator|GLOBAL_SIMPLE|parquet",
+    "MERGE_ON_READ|true|org.apache.hudi.keygen.SimpleKeyGenerator|GLOBAL_SIMPLE|parquet",
+    "MERGE_ON_READ|false|org.apache.hudi.keygen.NonpartitionedKeyGenerator|BLOOM|parquet",
+    "MERGE_ON_READ|true|org.apache.hudi.keygen.NonpartitionedKeyGenerator|BLOOM|parquet",
+    "MERGE_ON_READ|false|org.apache.hudi.keygen.NonpartitionedKeyGenerator|SIMPLE|parquet",
+    "MERGE_ON_READ|true|org.apache.hudi.keygen.NonpartitionedKeyGenerator|SIMPLE|parquet",
+    "COPY_ON_WRITE|false|org.apache.hudi.keygen.SimpleKeyGenerator|GLOBAL_BLOOM|lance",
+    "COPY_ON_WRITE|true|org.apache.hudi.keygen.SimpleKeyGenerator|GLOBAL_BLOOM|lance",
+    "COPY_ON_WRITE|false|org.apache.hudi.keygen.SimpleKeyGenerator|GLOBAL_SIMPLE|lance",
+    "COPY_ON_WRITE|true|org.apache.hudi.keygen.SimpleKeyGenerator|GLOBAL_SIMPLE|lance",
+    "COPY_ON_WRITE|false|org.apache.hudi.keygen.NonpartitionedKeyGenerator|BLOOM|lance",
+    "COPY_ON_WRITE|true|org.apache.hudi.keygen.NonpartitionedKeyGenerator|BLOOM|lance",
+    "COPY_ON_WRITE|false|org.apache.hudi.keygen.NonpartitionedKeyGenerator|SIMPLE|lance",
+    "COPY_ON_WRITE|true|org.apache.hudi.keygen.NonpartitionedKeyGenerator|SIMPLE|lance",
+    "MERGE_ON_READ|false|org.apache.hudi.keygen.SimpleKeyGenerator|GLOBAL_BLOOM|lance",
+    "MERGE_ON_READ|true|org.apache.hudi.keygen.SimpleKeyGenerator|GLOBAL_BLOOM|lance",
+    "MERGE_ON_READ|false|org.apache.hudi.keygen.SimpleKeyGenerator|GLOBAL_SIMPLE|lance",
+    "MERGE_ON_READ|true|org.apache.hudi.keygen.SimpleKeyGenerator|GLOBAL_SIMPLE|lance",
+    "MERGE_ON_READ|false|org.apache.hudi.keygen.NonpartitionedKeyGenerator|BLOOM|lance",
+    "MERGE_ON_READ|true|org.apache.hudi.keygen.NonpartitionedKeyGenerator|BLOOM|lance",
+    "MERGE_ON_READ|false|org.apache.hudi.keygen.NonpartitionedKeyGenerator|SIMPLE|lance",
+    "MERGE_ON_READ|true|org.apache.hudi.keygen.NonpartitionedKeyGenerator|SIMPLE|lance"
   )
 
   //extracts the params and runs each core flow test
@@ -75,17 +92,18 @@ class TestSparkSqlCoreFlow extends HoodieSparkSqlTestBase {
           tableType = splits(0),
           isMetadataEnabled = splits(1).toBoolean,
           keyGenClass = splits(2),
-          indexType = splits(3))
+          indexType = splits(3),
+          baseFileFormat = splits(4))
       }
     }
   }
 
   def testCoreFlows(basePath: File, tableType: String, isMetadataEnabled: Boolean,
-                    keyGenClass: String, indexType: String): Unit = {
+                    keyGenClass: String, indexType: String, baseFileFormat: String): Unit = {
     //Create table and set up for testing
     val tableName = generateTableName
     val tableBasePath = basePath.getCanonicalPath + "/" + tableName
-    val writeOptions = getWriteOptions(tableName, tableType, keyGenClass, indexType)
+    val writeOptions = getWriteOptions(tableName, tableType, keyGenClass, indexType, baseFileFormat)
     createTable(tableName, keyGenClass, writeOptions, tableBasePath)
     val fs = HadoopFSUtils.getFs(tableBasePath, spark.sparkContext.hadoopConfiguration)
     val dataGen = new HoodieTestDataGenerator(HoodieTestDataGenerator.TRIP_NESTED_EXAMPLE_SCHEMA, 0xDEED)
@@ -207,7 +225,7 @@ class TestSparkSqlCoreFlow extends HoodieSparkSqlTestBase {
     }
   }
 
-  def getWriteOptions(tableName: String, tableType: String, keyGenClass: String, indexType: String): String = {
+  def getWriteOptions(tableName: String, tableType: String, keyGenClass: String, indexType: String, baseFileFormat: String): String = {
     val typeString = if (tableType.equals("COPY_ON_WRITE")) {
       "cow"
     } else if (tableType.equals("MERGE_ON_READ")) {
@@ -216,11 +234,19 @@ class TestSparkSqlCoreFlow extends HoodieSparkSqlTestBase {
       tableType
     }
 
+    val recordMergerImpl = if (baseFileFormat.equals("lance")) {
+      s"hoodie.write.record.merge.custom.implementation.classes = '${classOf[DefaultSparkRecordMerger].getName}',"
+    } else {
+      ""
+    }
+
     s"""
        |tblproperties (
        |  type = '$typeString',
        |  primaryKey = '_row_key',
        |  orderingFields = 'timestamp',
+       |  hoodie.table.base.file.format = '$baseFileFormat',
+       |  $recordMergerImpl
        |  hoodie.bulkinsert.shuffle.parallelism = 4,
        |  hoodie.database.name = "databaseName",
        |  hoodie.table.keygenerator.class = '$keyGenClass',
@@ -411,38 +437,70 @@ class TestSparkSqlCoreFlow extends HoodieSparkSqlTestBase {
 
   //params for immutable user flow
   val paramsForImmutable: List[String] = List(
-    "COPY_ON_WRITE|insert|false|org.apache.hudi.keygen.SimpleKeyGenerator|GLOBAL_BLOOM",
-    "COPY_ON_WRITE|insert|true|org.apache.hudi.keygen.SimpleKeyGenerator|GLOBAL_BLOOM",
-    "COPY_ON_WRITE|insert|false|org.apache.hudi.keygen.SimpleKeyGenerator|GLOBAL_SIMPLE",
-    "COPY_ON_WRITE|insert|true|org.apache.hudi.keygen.SimpleKeyGenerator|GLOBAL_SIMPLE",
-    "COPY_ON_WRITE|insert|false|org.apache.hudi.keygen.NonpartitionedKeyGenerator|BLOOM",
-    "COPY_ON_WRITE|insert|true|org.apache.hudi.keygen.NonpartitionedKeyGenerator|BLOOM",
-    "COPY_ON_WRITE|insert|false|org.apache.hudi.keygen.NonpartitionedKeyGenerator|SIMPLE",
-    "COPY_ON_WRITE|insert|true|org.apache.hudi.keygen.NonpartitionedKeyGenerator|SIMPLE",
-    "MERGE_ON_READ|insert|false|org.apache.hudi.keygen.SimpleKeyGenerator|GLOBAL_BLOOM",
-    "MERGE_ON_READ|insert|true|org.apache.hudi.keygen.SimpleKeyGenerator|GLOBAL_BLOOM",
-    "MERGE_ON_READ|insert|false|org.apache.hudi.keygen.SimpleKeyGenerator|GLOBAL_SIMPLE",
-    "MERGE_ON_READ|insert|true|org.apache.hudi.keygen.SimpleKeyGenerator|GLOBAL_SIMPLE",
-    "MERGE_ON_READ|insert|false|org.apache.hudi.keygen.NonpartitionedKeyGenerator|BLOOM",
-    "MERGE_ON_READ|insert|true|org.apache.hudi.keygen.NonpartitionedKeyGenerator|BLOOM",
-    "MERGE_ON_READ|insert|false|org.apache.hudi.keygen.NonpartitionedKeyGenerator|SIMPLE",
-    "MERGE_ON_READ|insert|true|org.apache.hudi.keygen.NonpartitionedKeyGenerator|SIMPLE",
-    "COPY_ON_WRITE|bulk_insert|false|org.apache.hudi.keygen.SimpleKeyGenerator|GLOBAL_BLOOM",
-    "COPY_ON_WRITE|bulk_insert|true|org.apache.hudi.keygen.SimpleKeyGenerator|GLOBAL_BLOOM",
-    "COPY_ON_WRITE|bulk_insert|false|org.apache.hudi.keygen.SimpleKeyGenerator|GLOBAL_SIMPLE",
-    "COPY_ON_WRITE|bulk_insert|true|org.apache.hudi.keygen.SimpleKeyGenerator|GLOBAL_SIMPLE",
-    "COPY_ON_WRITE|bulk_insert|false|org.apache.hudi.keygen.NonpartitionedKeyGenerator|BLOOM",
-    "COPY_ON_WRITE|bulk_insert|true|org.apache.hudi.keygen.NonpartitionedKeyGenerator|BLOOM",
-    "COPY_ON_WRITE|bulk_insert|false|org.apache.hudi.keygen.NonpartitionedKeyGenerator|SIMPLE",
-    "COPY_ON_WRITE|bulk_insert|true|org.apache.hudi.keygen.NonpartitionedKeyGenerator|SIMPLE",
-    "MERGE_ON_READ|bulk_insert|false|org.apache.hudi.keygen.SimpleKeyGenerator|GLOBAL_BLOOM",
-    "MERGE_ON_READ|bulk_insert|true|org.apache.hudi.keygen.SimpleKeyGenerator|GLOBAL_BLOOM",
-    "MERGE_ON_READ|bulk_insert|false|org.apache.hudi.keygen.SimpleKeyGenerator|GLOBAL_SIMPLE",
-    "MERGE_ON_READ|bulk_insert|true|org.apache.hudi.keygen.SimpleKeyGenerator|GLOBAL_SIMPLE",
-    "MERGE_ON_READ|bulk_insert|false|org.apache.hudi.keygen.NonpartitionedKeyGenerator|BLOOM",
-    "MERGE_ON_READ|bulk_insert|true|org.apache.hudi.keygen.NonpartitionedKeyGenerator|BLOOM",
-    "MERGE_ON_READ|bulk_insert|false|org.apache.hudi.keygen.NonpartitionedKeyGenerator|SIMPLE",
-    "MERGE_ON_READ|bulk_insert|true|org.apache.hudi.keygen.NonpartitionedKeyGenerator|SIMPLE"
+    "COPY_ON_WRITE|insert|false|org.apache.hudi.keygen.SimpleKeyGenerator|GLOBAL_BLOOM|parquet",
+    "COPY_ON_WRITE|insert|true|org.apache.hudi.keygen.SimpleKeyGenerator|GLOBAL_BLOOM|parquet",
+    "COPY_ON_WRITE|insert|false|org.apache.hudi.keygen.SimpleKeyGenerator|GLOBAL_SIMPLE|parquet",
+    "COPY_ON_WRITE|insert|true|org.apache.hudi.keygen.SimpleKeyGenerator|GLOBAL_SIMPLE|parquet",
+    "COPY_ON_WRITE|insert|false|org.apache.hudi.keygen.NonpartitionedKeyGenerator|BLOOM|parquet",
+    "COPY_ON_WRITE|insert|true|org.apache.hudi.keygen.NonpartitionedKeyGenerator|BLOOM|parquet",
+    "COPY_ON_WRITE|insert|false|org.apache.hudi.keygen.NonpartitionedKeyGenerator|SIMPLE|parquet",
+    "COPY_ON_WRITE|insert|true|org.apache.hudi.keygen.NonpartitionedKeyGenerator|SIMPLE|parquet",
+    "MERGE_ON_READ|insert|false|org.apache.hudi.keygen.SimpleKeyGenerator|GLOBAL_BLOOM|parquet",
+    "MERGE_ON_READ|insert|true|org.apache.hudi.keygen.SimpleKeyGenerator|GLOBAL_BLOOM|parquet",
+    "MERGE_ON_READ|insert|false|org.apache.hudi.keygen.SimpleKeyGenerator|GLOBAL_SIMPLE|parquet",
+    "MERGE_ON_READ|insert|true|org.apache.hudi.keygen.SimpleKeyGenerator|GLOBAL_SIMPLE|parquet",
+    "MERGE_ON_READ|insert|false|org.apache.hudi.keygen.NonpartitionedKeyGenerator|BLOOM|parquet",
+    "MERGE_ON_READ|insert|true|org.apache.hudi.keygen.NonpartitionedKeyGenerator|BLOOM|parquet",
+    "MERGE_ON_READ|insert|false|org.apache.hudi.keygen.NonpartitionedKeyGenerator|SIMPLE|parquet",
+    "MERGE_ON_READ|insert|true|org.apache.hudi.keygen.NonpartitionedKeyGenerator|SIMPLE|parquet",
+    "COPY_ON_WRITE|bulk_insert|false|org.apache.hudi.keygen.SimpleKeyGenerator|GLOBAL_BLOOM|parquet",
+    "COPY_ON_WRITE|bulk_insert|true|org.apache.hudi.keygen.SimpleKeyGenerator|GLOBAL_BLOOM|parquet",
+    "COPY_ON_WRITE|bulk_insert|false|org.apache.hudi.keygen.SimpleKeyGenerator|GLOBAL_SIMPLE|parquet",
+    "COPY_ON_WRITE|bulk_insert|true|org.apache.hudi.keygen.SimpleKeyGenerator|GLOBAL_SIMPLE|parquet",
+    "COPY_ON_WRITE|bulk_insert|false|org.apache.hudi.keygen.NonpartitionedKeyGenerator|BLOOM|parquet",
+    "COPY_ON_WRITE|bulk_insert|true|org.apache.hudi.keygen.NonpartitionedKeyGenerator|BLOOM|parquet",
+    "COPY_ON_WRITE|bulk_insert|false|org.apache.hudi.keygen.NonpartitionedKeyGenerator|SIMPLE|parquet",
+    "COPY_ON_WRITE|bulk_insert|true|org.apache.hudi.keygen.NonpartitionedKeyGenerator|SIMPLE|parquet",
+    "MERGE_ON_READ|bulk_insert|false|org.apache.hudi.keygen.SimpleKeyGenerator|GLOBAL_BLOOM|parquet",
+    "MERGE_ON_READ|bulk_insert|true|org.apache.hudi.keygen.SimpleKeyGenerator|GLOBAL_BLOOM|parquet",
+    "MERGE_ON_READ|bulk_insert|false|org.apache.hudi.keygen.SimpleKeyGenerator|GLOBAL_SIMPLE|parquet",
+    "MERGE_ON_READ|bulk_insert|true|org.apache.hudi.keygen.SimpleKeyGenerator|GLOBAL_SIMPLE|parquet",
+    "MERGE_ON_READ|bulk_insert|false|org.apache.hudi.keygen.NonpartitionedKeyGenerator|BLOOM|parquet",
+    "MERGE_ON_READ|bulk_insert|true|org.apache.hudi.keygen.NonpartitionedKeyGenerator|BLOOM|parquet",
+    "MERGE_ON_READ|bulk_insert|false|org.apache.hudi.keygen.NonpartitionedKeyGenerator|SIMPLE|parquet",
+    "MERGE_ON_READ|bulk_insert|true|org.apache.hudi.keygen.NonpartitionedKeyGenerator|SIMPLE|parquet",
+    "COPY_ON_WRITE|insert|false|org.apache.hudi.keygen.SimpleKeyGenerator|GLOBAL_BLOOM|lance",
+    "COPY_ON_WRITE|insert|true|org.apache.hudi.keygen.SimpleKeyGenerator|GLOBAL_BLOOM|lance",
+    "COPY_ON_WRITE|insert|false|org.apache.hudi.keygen.SimpleKeyGenerator|GLOBAL_SIMPLE|lance",
+    "COPY_ON_WRITE|insert|true|org.apache.hudi.keygen.SimpleKeyGenerator|GLOBAL_SIMPLE|lance",
+    "COPY_ON_WRITE|insert|false|org.apache.hudi.keygen.NonpartitionedKeyGenerator|BLOOM|lance",
+    "COPY_ON_WRITE|insert|true|org.apache.hudi.keygen.NonpartitionedKeyGenerator|BLOOM|lance",
+    "COPY_ON_WRITE|insert|false|org.apache.hudi.keygen.NonpartitionedKeyGenerator|SIMPLE|lance",
+    "COPY_ON_WRITE|insert|true|org.apache.hudi.keygen.NonpartitionedKeyGenerator|SIMPLE|lance",
+    "MERGE_ON_READ|insert|false|org.apache.hudi.keygen.SimpleKeyGenerator|GLOBAL_BLOOM|lance",
+    "MERGE_ON_READ|insert|true|org.apache.hudi.keygen.SimpleKeyGenerator|GLOBAL_BLOOM|lance",
+    "MERGE_ON_READ|insert|false|org.apache.hudi.keygen.SimpleKeyGenerator|GLOBAL_SIMPLE|lance",
+    "MERGE_ON_READ|insert|true|org.apache.hudi.keygen.SimpleKeyGenerator|GLOBAL_SIMPLE|lance",
+    "MERGE_ON_READ|insert|false|org.apache.hudi.keygen.NonpartitionedKeyGenerator|BLOOM|lance",
+    "MERGE_ON_READ|insert|true|org.apache.hudi.keygen.NonpartitionedKeyGenerator|BLOOM|lance",
+    "MERGE_ON_READ|insert|false|org.apache.hudi.keygen.NonpartitionedKeyGenerator|SIMPLE|lance",
+    "MERGE_ON_READ|insert|true|org.apache.hudi.keygen.NonpartitionedKeyGenerator|SIMPLE|lance",
+    "COPY_ON_WRITE|bulk_insert|false|org.apache.hudi.keygen.SimpleKeyGenerator|GLOBAL_BLOOM|lance",
+    "COPY_ON_WRITE|bulk_insert|true|org.apache.hudi.keygen.SimpleKeyGenerator|GLOBAL_BLOOM|lance",
+    "COPY_ON_WRITE|bulk_insert|false|org.apache.hudi.keygen.SimpleKeyGenerator|GLOBAL_SIMPLE|lance",
+    "COPY_ON_WRITE|bulk_insert|true|org.apache.hudi.keygen.SimpleKeyGenerator|GLOBAL_SIMPLE|lance",
+    "COPY_ON_WRITE|bulk_insert|false|org.apache.hudi.keygen.NonpartitionedKeyGenerator|BLOOM|lance",
+    "COPY_ON_WRITE|bulk_insert|true|org.apache.hudi.keygen.NonpartitionedKeyGenerator|BLOOM|lance",
+    "COPY_ON_WRITE|bulk_insert|false|org.apache.hudi.keygen.NonpartitionedKeyGenerator|SIMPLE|lance",
+    "COPY_ON_WRITE|bulk_insert|true|org.apache.hudi.keygen.NonpartitionedKeyGenerator|SIMPLE|lance",
+    "MERGE_ON_READ|bulk_insert|false|org.apache.hudi.keygen.SimpleKeyGenerator|GLOBAL_BLOOM|lance",
+    "MERGE_ON_READ|bulk_insert|true|org.apache.hudi.keygen.SimpleKeyGenerator|GLOBAL_BLOOM|lance",
+    "MERGE_ON_READ|bulk_insert|false|org.apache.hudi.keygen.SimpleKeyGenerator|GLOBAL_SIMPLE|lance",
+    "MERGE_ON_READ|bulk_insert|true|org.apache.hudi.keygen.SimpleKeyGenerator|GLOBAL_SIMPLE|lance",
+    "MERGE_ON_READ|bulk_insert|false|org.apache.hudi.keygen.NonpartitionedKeyGenerator|BLOOM|lance",
+    "MERGE_ON_READ|bulk_insert|true|org.apache.hudi.keygen.NonpartitionedKeyGenerator|BLOOM|lance",
+    "MERGE_ON_READ|bulk_insert|false|org.apache.hudi.keygen.NonpartitionedKeyGenerator|SIMPLE|lance",
+    "MERGE_ON_READ|bulk_insert|true|org.apache.hudi.keygen.NonpartitionedKeyGenerator|SIMPLE|lance"
   )
 
   //extracts the params and runs each immutable user flow test
@@ -462,17 +520,18 @@ class TestSparkSqlCoreFlow extends HoodieSparkSqlTestBase {
           writeOp = writeOp,
           isMetadataEnabled = splits(2).toBoolean,
           keyGenClass = splits(3),
-          indexType = splits(4))
+          indexType = splits(4),
+          baseFileFormat = splits(5))
       }
     }
   }
 
   def testImmutableUserFlow(basePath: File, tableType: String, writeOp: WriteOperationType,
                             isMetadataEnabled: Boolean, keyGenClass: String,
-                            indexType: String): Unit = {
+                            indexType: String, baseFileFormat: String): Unit = {
     val tableName = generateTableName
     val tableBasePath = basePath.getCanonicalPath + "/" + tableName
-    val writeOptions = getWriteOptions(tableName, tableType, keyGenClass, indexType)
+    val writeOptions = getWriteOptions(tableName, tableType, keyGenClass, indexType, baseFileFormat)
     createTable(tableName, keyGenClass, writeOptions, tableBasePath)
     val fs = HadoopFSUtils.getFs(tableBasePath, spark.sparkContext.hadoopConfiguration)
 

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestSparkSqlCoreFlow.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestSparkSqlCoreFlow.scala
@@ -83,11 +83,7 @@ class TestSparkSqlCoreFlow extends HoodieSparkSqlTestBase {
       "MERGE_ON_READ|false|org.apache.hudi.keygen.NonpartitionedKeyGenerator|SIMPLE|lance",
       "MERGE_ON_READ|true|org.apache.hudi.keygen.NonpartitionedKeyGenerator|SIMPLE|lance"
     )
-    if (HoodieSparkUtils.gteqSpark3_4) {
-      allParams
-    } else {
-      allParams.filterNot(_.endsWith("|lance"))
-    }
+    withLanceIfSupported(allParams)
   }
 
   //extracts the params and runs each core flow test
@@ -241,7 +237,7 @@ class TestSparkSqlCoreFlow extends HoodieSparkSqlTestBase {
       tableType
     }
 
-    val recordMergerImpl = if (baseFileFormat.equals("lance")) {
+    val recordMergerImpl = if (baseFileFormat == "lance") {
       s"hoodie.write.record.merge.custom.implementation.classes = '${classOf[DefaultSparkRecordMerger].getName}',"
     } else {
       ""
@@ -510,11 +506,11 @@ class TestSparkSqlCoreFlow extends HoodieSparkSqlTestBase {
       "MERGE_ON_READ|bulk_insert|false|org.apache.hudi.keygen.NonpartitionedKeyGenerator|SIMPLE|lance",
       "MERGE_ON_READ|bulk_insert|true|org.apache.hudi.keygen.NonpartitionedKeyGenerator|SIMPLE|lance"
     )
-    if (HoodieSparkUtils.gteqSpark3_4) {
-      allParamsForImmutable
-    } else {
-      allParamsForImmutable.filterNot(_.endsWith("|lance"))
-    }
+    withLanceIfSupported(allParamsForImmutable)
+  }
+
+  private def withLanceIfSupported(params: List[String]): List[String] = {
+    if (HoodieSparkUtils.gteqSpark3_4) params else params.filterNot(_.endsWith("|lance"))
   }
 
   //extracts the params and runs each immutable user flow test

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestSqlStatement.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestSqlStatement.scala
@@ -18,6 +18,7 @@
 package org.apache.hudi.functional
 
 import org.apache.hudi.DefaultSparkRecordMerger
+import org.apache.hudi.HoodieSparkUtils
 import org.apache.hudi.io.util.FileIOUtils
 
 import org.apache.spark.sql.hudi.common.HoodieSparkSqlTestBase
@@ -38,7 +39,8 @@ class TestSqlStatement extends HoodieSparkSqlTestBase {
   val STATE_FINISH_ALL = 12
 
   test("Test Sql Statements") {
-    Seq("parquet", "lance").foreach { baseFileFormat =>
+    val baseFileFormats = if (HoodieSparkUtils.gteqSpark3_4) Seq("parquet", "lance") else Seq("parquet")
+    baseFileFormats.foreach { baseFileFormat =>
       Seq("cow", "mor").foreach { tableType =>
         withTempDir { tmp =>
           val params = Map(

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestSqlStatement.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestSqlStatement.scala
@@ -17,7 +17,6 @@
 
 package org.apache.hudi.functional
 
-import org.apache.hudi.DefaultSparkRecordMerger
 import org.apache.hudi.HoodieSparkUtils
 import org.apache.hudi.io.util.FileIOUtils
 
@@ -43,13 +42,9 @@ class TestSqlStatement extends HoodieSparkSqlTestBase {
     baseFileFormats.foreach { baseFileFormat =>
       Seq("cow", "mor").foreach { tableType =>
         withTempDir { tmp =>
-          val recordMergerImpl = if (baseFileFormat == "parquet") "" else {
-            s"hoodie.write.record.merge.custom.implementation.classes = '${classOf[DefaultSparkRecordMerger].getName}',"
-          }
           val params = Map(
             "tableType" -> tableType,
             "baseFileFormat" -> baseFileFormat,
-            "recordMergerImpl" -> recordMergerImpl,
             "tmpDir" -> {
               tmp.getCanonicalPath.replace('\\', '/')
             }

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestSqlStatement.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestSqlStatement.scala
@@ -17,6 +17,7 @@
 
 package org.apache.hudi.functional
 
+import org.apache.hudi.DefaultSparkRecordMerger
 import org.apache.hudi.io.util.FileIOUtils
 
 import org.apache.spark.sql.hudi.common.HoodieSparkSqlTestBase
@@ -37,15 +38,22 @@ class TestSqlStatement extends HoodieSparkSqlTestBase {
   val STATE_FINISH_ALL = 12
 
   test("Test Sql Statements") {
-    Seq("cow", "mor").foreach { tableType =>
-      withTempDir { tmp =>
-        val params = Map(
-          "tableType" -> tableType,
-          "tmpDir" -> {
-            tmp.getCanonicalPath.replace('\\', '/')
-          }
-        )
-        execSqlFile("/sql-statements.sql", params)
+    Seq("parquet", "lance").foreach { baseFileFormat =>
+      Seq("cow", "mor").foreach { tableType =>
+        withTempDir { tmp =>
+          val params = Map(
+            "tableType" -> tableType,
+            "baseFileFormat" -> baseFileFormat,
+            "recordMergerImpl" -> (
+              if (baseFileFormat.equals("parquet")) "" else {
+                s"hoodie.write.record.merge.custom.implementation.classes = '${classOf[DefaultSparkRecordMerger].getName}',"
+              }),
+            "tmpDir" -> {
+              tmp.getCanonicalPath.replace('\\', '/')
+            }
+          )
+          execSqlFile("/sql-statements.sql", params)
+        }
       }
     }
   }

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestSqlStatement.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestSqlStatement.scala
@@ -43,13 +43,13 @@ class TestSqlStatement extends HoodieSparkSqlTestBase {
     baseFileFormats.foreach { baseFileFormat =>
       Seq("cow", "mor").foreach { tableType =>
         withTempDir { tmp =>
+          val recordMergerImpl = if (baseFileFormat == "parquet") "" else {
+            s"hoodie.write.record.merge.custom.implementation.classes = '${classOf[DefaultSparkRecordMerger].getName}',"
+          }
           val params = Map(
             "tableType" -> tableType,
             "baseFileFormat" -> baseFileFormat,
-            "recordMergerImpl" -> (
-              if (baseFileFormat.equals("parquet")) "" else {
-                s"hoodie.write.record.merge.custom.implementation.classes = '${classOf[DefaultSparkRecordMerger].getName}',"
-              }),
+            "recordMergerImpl" -> recordMergerImpl,
             "tmpDir" -> {
               tmp.getCanonicalPath.replace('\\', '/')
             }

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/feature/TestQueryMergeOnReadOptimizedTable.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/feature/TestQueryMergeOnReadOptimizedTable.scala
@@ -19,12 +19,14 @@
 
 package org.apache.spark.sql.hudi.feature
 
+import org.apache.hudi.HoodieSparkUtils
+
 import org.apache.spark.sql.hudi.common.HoodieSparkSqlTestBase
 import org.scalatest.Inspectors.forAll
 
 class TestQueryMergeOnReadOptimizedTable extends HoodieSparkSqlTestBase {
 
-  val baseFileFormats: List[String] = List("parquet", "lance")
+  val baseFileFormats: List[String] = if (HoodieSparkUtils.gteqSpark3_4) List("parquet", "lance") else List("parquet")
 
   forAll(baseFileFormats) { (baseFileFormat: String) =>
     test(s"Test Query Merge_On_Read Read_Optimized table - $baseFileFormat") {

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/feature/TestQueryMergeOnReadOptimizedTable.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/feature/TestQueryMergeOnReadOptimizedTable.scala
@@ -20,62 +20,69 @@
 package org.apache.spark.sql.hudi.feature
 
 import org.apache.spark.sql.hudi.common.HoodieSparkSqlTestBase
+import org.scalatest.Inspectors.forAll
 
 class TestQueryMergeOnReadOptimizedTable extends HoodieSparkSqlTestBase {
-  test("Test Query Merge_On_Read Read_Optimized table") {
-    withTempDir { tmp =>
-      val tableName = generateTableName
-      val tablePath = s"${tmp.getCanonicalPath}/$tableName"
-      // create table
-      spark.sql(
-        s"""
-           |create table $tableName (
-           |  id int,
-           |  name string,
-           |  price double,
-           |  ts long,
-           |  partition long
-           |) using hudi
-           | partitioned by (partition)
-           | location '$tablePath'
-           | tblproperties (
-           |  type = 'mor',
-           |  primaryKey = 'id',
-           |  orderingFields = 'ts'
-           | )
-       """.stripMargin)
-      // insert data to table
-      withSQLConf("hoodie.parquet.max.file.size" -> "10000") {
-        spark.sql(s"insert into $tableName values(1, 'a1', 10, 1000, 1000)")
-        spark.sql(s"insert into $tableName values(2, 'a2', 10, 1000, 1000)")
-        spark.sql(s"insert into $tableName values(3, 'a3', 10, 1000, 1000)")
-        spark.sql(s"insert into $tableName values(4, 'a4', 10, 1000, 1000)")
-        spark.sql(s"update $tableName set price = 11 where id = 1")
-        spark.sql(s"update $tableName set price = 21 where id = 2")
-        spark.sql(s"update $tableName set price = 31 where id = 3")
-        spark.sql(s"update $tableName set price = 41 where id = 4")
 
-        // expect that all complete parquet files can be scanned
-        assertQueryResult(4, tablePath)
+  val baseFileFormats: List[String] = List("parquet", "lance")
 
-        // async schedule compaction job
-        spark.sql(s"call run_compaction(op => 'schedule', table => '$tableName')")
-          .collect()
+  forAll(baseFileFormats) { (baseFileFormat: String) =>
+    test(s"Test Query Merge_On_Read Read_Optimized table - $baseFileFormat") {
+      withTempDir { tmp =>
+        val tableName = generateTableName
+        val tablePath = s"${tmp.getCanonicalPath}/$tableName"
+        // create table
+        spark.sql(
+          s"""
+             |create table $tableName (
+             |  id int,
+             |  name string,
+             |  price double,
+             |  ts long,
+             |  partition long
+             |) using hudi
+             | partitioned by (partition)
+             | location '$tablePath'
+             | tblproperties (
+             |  type = 'mor',
+             |  primaryKey = 'id',
+             |  orderingFields = 'ts',
+             |  hoodie.base.file.format = '$baseFileFormat'
+             | )
+         """.stripMargin)
+        // insert data to table
+        withSQLConf("hoodie.parquet.max.file.size" -> "10000") {
+          spark.sql(s"insert into $tableName values(1, 'a1', 10, 1000, 1000)")
+          spark.sql(s"insert into $tableName values(2, 'a2', 10, 1000, 1000)")
+          spark.sql(s"insert into $tableName values(3, 'a3', 10, 1000, 1000)")
+          spark.sql(s"insert into $tableName values(4, 'a4', 10, 1000, 1000)")
+          spark.sql(s"update $tableName set price = 11 where id = 1")
+          spark.sql(s"update $tableName set price = 21 where id = 2")
+          spark.sql(s"update $tableName set price = 31 where id = 3")
+          spark.sql(s"update $tableName set price = 41 where id = 4")
 
-        // expect that all complete parquet files can be scanned with a pending compaction job
-        assertQueryResult(4, tablePath)
+          // expect that all complete base files can be scanned
+          assertQueryResult(4, tablePath)
 
-        spark.sql(s"insert into $tableName values(5, 'a5', 10, 1000, 1000)")
+          // async schedule compaction job
+          spark.sql(s"call run_compaction(op => 'schedule', table => '$tableName')")
+            .collect()
 
-        // expect that all complete parquet files can be scanned with a pending compaction job
-        assertQueryResult(5, tablePath)
+          // expect that all complete base files can be scanned with a pending compaction job
+          assertQueryResult(4, tablePath)
 
-        // async run compaction job
-        spark.sql(s"call run_compaction(op => 'run', table => '$tableName')")
-          .collect()
+          spark.sql(s"insert into $tableName values(5, 'a5', 10, 1000, 1000)")
 
-        // assert that all complete parquet files can be scanned after compaction
-        assertQueryResult(5, tablePath)
+          // expect that all complete base files can be scanned with a pending compaction job
+          assertQueryResult(5, tablePath)
+
+          // async run compaction job
+          spark.sql(s"call run_compaction(op => 'run', table => '$tableName')")
+            .collect()
+
+          // assert that all complete base files can be scanned after compaction
+          assertQueryResult(5, tablePath)
+        }
       }
     }
   }

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/feature/TestQueryMergeOnReadOptimizedTable.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/feature/TestQueryMergeOnReadOptimizedTable.scala
@@ -19,7 +19,7 @@
 
 package org.apache.spark.sql.hudi.feature
 
-import org.apache.hudi.{DefaultSparkRecordMerger, HoodieSparkUtils}
+import org.apache.hudi.HoodieSparkUtils
 
 import org.apache.spark.sql.hudi.common.HoodieSparkSqlTestBase
 
@@ -32,10 +32,6 @@ class TestQueryMergeOnReadOptimizedTable extends HoodieSparkSqlTestBase {
       withTempDir { tmp =>
         val tableName = generateTableName
         val tablePath = s"${tmp.getCanonicalPath}/$tableName"
-        val recordMergerImpl = if (baseFileFormat == "parquet") "" else {
-          s"hoodie.write.record.merge.custom.implementation.classes = '${classOf[DefaultSparkRecordMerger].getName}',"
-        }
-        // create table
         spark.sql(
           s"""
              |create table $tableName (
@@ -51,7 +47,6 @@ class TestQueryMergeOnReadOptimizedTable extends HoodieSparkSqlTestBase {
              |  type = 'mor',
              |  primaryKey = 'id',
              |  orderingFields = 'ts',
-             |  $recordMergerImpl
              |  hoodie.table.base.file.format = '$baseFileFormat'
              | )
          """.stripMargin)

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/feature/TestQueryMergeOnReadOptimizedTable.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/feature/TestQueryMergeOnReadOptimizedTable.scala
@@ -22,18 +22,20 @@ package org.apache.spark.sql.hudi.feature
 import org.apache.hudi.HoodieSparkUtils
 
 import org.apache.spark.sql.hudi.common.HoodieSparkSqlTestBase
-import org.scalatest.Inspectors.forAll
 
 class TestQueryMergeOnReadOptimizedTable extends HoodieSparkSqlTestBase {
 
   val baseFileFormats: List[String] = if (HoodieSparkUtils.gteqSpark3_4) List("parquet", "lance") else List("parquet")
 
-  forAll(baseFileFormats) { (baseFileFormat: String) =>
+  baseFileFormats.foreach { baseFileFormat =>
     test(s"Test Query Merge_On_Read Read_Optimized table - $baseFileFormat") {
       withTempDir { tmp =>
         val tableName = generateTableName
         val tablePath = s"${tmp.getCanonicalPath}/$tableName"
         // create table
+        // No explicit hoodie.write.record.merge.custom.implementation.classes needed:
+        // orderingFields='ts' triggers EVENT_TIME_ORDERING merge mode, which auto-selects
+        // DefaultSparkRecordMerger for lance (SPARK record type).
         spark.sql(
           s"""
              |create table $tableName (

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/feature/TestQueryMergeOnReadOptimizedTable.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/feature/TestQueryMergeOnReadOptimizedTable.scala
@@ -19,7 +19,7 @@
 
 package org.apache.spark.sql.hudi.feature
 
-import org.apache.hudi.HoodieSparkUtils
+import org.apache.hudi.{DefaultSparkRecordMerger, HoodieSparkUtils}
 
 import org.apache.spark.sql.hudi.common.HoodieSparkSqlTestBase
 
@@ -32,10 +32,10 @@ class TestQueryMergeOnReadOptimizedTable extends HoodieSparkSqlTestBase {
       withTempDir { tmp =>
         val tableName = generateTableName
         val tablePath = s"${tmp.getCanonicalPath}/$tableName"
+        val recordMergerImpl = if (baseFileFormat == "parquet") "" else {
+          s"hoodie.write.record.merge.custom.implementation.classes = '${classOf[DefaultSparkRecordMerger].getName}',"
+        }
         // create table
-        // No explicit hoodie.write.record.merge.custom.implementation.classes needed:
-        // orderingFields='ts' triggers EVENT_TIME_ORDERING merge mode, which auto-selects
-        // DefaultSparkRecordMerger for lance (SPARK record type).
         spark.sql(
           s"""
              |create table $tableName (
@@ -51,7 +51,8 @@ class TestQueryMergeOnReadOptimizedTable extends HoodieSparkSqlTestBase {
              |  type = 'mor',
              |  primaryKey = 'id',
              |  orderingFields = 'ts',
-             |  hoodie.base.file.format = '$baseFileFormat'
+             |  $recordMergerImpl
+             |  hoodie.table.base.file.format = '$baseFileFormat'
              | )
          """.stripMargin)
         // insert data to table


### PR DESCRIPTION
Mirror of https://github.com/apache/hudi/pull/18375 for automated bot review.

**Original author:** @wombatu-kun
**Base branch:** master


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for Apache LANCE columnar file format as an alternative to Parquet for base files
  * Introduced automatic record type selection based on configured base file format
  * Enhanced record buffering to preserve original Avro payloads during reads

* **Bug Fixes**
  * Fixed file readers to derive record types from actual file format instead of relying solely on configuration
  * Improved schema consistency during record merges and conversions

* **Tests**
  * Expanded test coverage across multiple base file formats
  * Added Lance data source integration tests

<!-- end of auto-generated comment: release notes by coderabbit.ai -->