### PR TITLE
[OSS PR #18182] feat(metadata): Support sub-directory bucketing for MDT partitions

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieMetadataConfig.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieMetadataConfig.java
@@ -628,6 +628,16 @@ public final class HoodieMetadataConfig extends HoodieConfig {
     return getLong(MAX_LOG_FILE_SIZE_BYTES_PROP);
   }
 
+  public static final ConfigProperty<Boolean> FILE_GROUP_BUCKETING_ENABLE = ConfigProperty
+          .key(METADATA_PREFIX + ".file.group.bucketing.enable")
+          .defaultValue(false)
+          .withDocumentation("This flag indicates whether there should be intermediate partitions under partitions such as record index and filelisting");
+
+  public static final ConfigProperty<Integer> FILE_GROUP_BUCKET_SIZE = ConfigProperty
+          .key(METADATA_PREFIX + ".file.group.bucket.size")
+          .defaultValue(1000)
+          .withDocumentation("This is paired with " + FILE_GROUP_BUCKETING_ENABLE.key() + ". This represents number of shards under a single bucket");
+
   private HoodieMetadataConfig() {
     super();
   }
@@ -937,6 +947,14 @@ public final class HoodieMetadataConfig extends HoodieConfig {
     return subIndexNameToDrop.contains(indexName);
   }
 
+  public boolean isFileGroupBucketingEnabled() {
+    return getBoolean(FILE_GROUP_BUCKETING_ENABLE);
+  }
+
+  public int getFileGroupBucketSize() {
+    return getInt(FILE_GROUP_BUCKET_SIZE);
+  }
+
   public static class Builder {
 
     private EngineType engineType = EngineType.SPARK;
@@ -1240,6 +1258,16 @@ public final class HoodieMetadataConfig extends HoodieConfig {
       // fix me: disable when schema on read is enabled.
       metadataConfig.setDefaults(HoodieMetadataConfig.class.getName());
       return metadataConfig;
+    }
+
+    public Builder withFileGroupBucketingEnable(boolean fileGroupBucketingEnable) {
+      metadataConfig.setValue(FILE_GROUP_BUCKETING_ENABLE, String.valueOf(fileGroupBucketingEnable));
+      return this;
+    }
+
+    public Builder withFileGroupBucketSize(int bucketSize) {
+      metadataConfig.setValue(FILE_GROUP_BUCKET_SIZE, String.valueOf(bucketSize));
+      return this;
     }
 
     private boolean getDefaultMetadataEnable(EngineType engineType) {

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/HoodieTableConfig.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/HoodieTableConfig.java
@@ -365,6 +365,11 @@ public class HoodieTableConfig extends HoodieConfig {
       .sinceVersion("1.1.0")
       .withDocumentation("This property when set, will define how two versions of the record will be merged together when records are partially formed");
 
+  public static final ConfigProperty<String> METADATA_TABLE_PARTITION_BUCKETING_ENABLE = ConfigProperty
+          .key("hoodie.metadata.partitions.bucketing.enable")
+          .defaultValue("false")
+          .withDocumentation("This flag indicates whether metadata table file groups should be saved within buckets in each partition such as record index and files.");
+
   public static final ConfigProperty<String> URL_ENCODE_PARTITIONING = KeyGeneratorOptions.URL_ENCODE_PARTITIONING;
   public static final ConfigProperty<String> HIVE_STYLE_PARTITIONING_ENABLE = KeyGeneratorOptions.HIVE_STYLE_PARTITIONING_ENABLE;
   public static final ConfigProperty<String> SLASH_SEPARATED_DATE_PARTITIONING = KeyGeneratorOptions.SLASH_SEPARATED_DATE_PARTITIONING;
@@ -1363,6 +1368,22 @@ public class HoodieTableConfig extends HoodieConfig {
       }
     }
     return configs;
+  }
+
+  /**
+   * Enables or disables the bucketing for file groups within the metadata table partitions.
+   *
+   * @param enable Whether to enable or disable bucketing
+   */
+  public void setMetadataTableBucketing(boolean enable) {
+    setValue(METADATA_TABLE_PARTITION_BUCKETING_ENABLE, String.valueOf(enable));
+  }
+
+  /**
+   * @returns true if metadata table partition bucketing is enabled, else returns false.
+   */
+  public boolean isMetadataTablePartitionBucketingEnabled() {
+    return getBooleanOrDefault(METADATA_TABLE_PARTITION_BUCKETING_ENABLE);
   }
 
   public Map<String, String> propsMap() {


### PR DESCRIPTION
Mirror of https://github.com/apache/hudi/pull/18182 for automated bot review.

**Original author:** @prashantwason
**Base branch:** master


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added file group bucketing support for metadata tables with new configuration options: `FILE_GROUP_BUCKETING_ENABLE` and `FILE_GROUP_BUCKET_SIZE` to control intermediate partition organization.
  * Metadata tables can now organize file groups into bucket subdirectories for improved scalability and storage layout optimization.

* **Tests**
  * Updated test utilities to validate bucketed metadata table layouts and partition structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->