### PR TITLE
[OSS PR #18279] perf(core): optimize rollback listing calls on metadata table

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/rollback/MarkerBasedRollbackStrategy.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/rollback/MarkerBasedRollbackStrategy.java
@@ -48,6 +48,7 @@ import java.util.Map;
 import java.util.Objects;
 
 import static org.apache.hudi.common.util.StringUtils.EMPTY_STRING;
+import static org.apache.hudi.common.util.ValidationUtils.checkArgument;
 
 /**
  * Performs rollback using marker files generated during the writes.
@@ -131,76 +132,73 @@ public class MarkerBasedRollbackStrategy<T, I, K, O> implements BaseRollbackPlan
                                                                  StoragePath filePath,
                                                                  HoodieInstant instantToRollback,
                                                                  String filePathToRollback) {
-    if (table.version().greaterThanOrEquals(HoodieTableVersion.EIGHT)) {
-      return new HoodieRollbackRequest(relativePartitionPath, fileId, instantToRollback.requestedTime(), Collections.emptyList(),
-          Collections.singletonMap(filePath.toString(), 1L));
-    } else {
-      StoragePath fullFilePath = new StoragePath(basePath, filePathToRollback);
-      String baseCommitTime;
-      Option<HoodieLogFile> latestLogFileOption;
-      Map<String, Long> logBlocksToBeDeleted = new HashMap<>();
-      // Old marker files may be generated from base file name before HUDI-1517. keep compatible with them.
-      if (FSUtils.isBaseFile(fullFilePath)) {
-        log.info("Found old marker type for log file: {}", filePathToRollback);
-        baseCommitTime = FSUtils.getCommitTime(fullFilePath.getName());
-        StoragePath partitionPath = FSUtils.constructAbsolutePath(config.getBasePath(), relativePartitionPath);
+    checkArgument(table.version().lesserThan(HoodieTableVersion.EIGHT),
+        "V8+ should not have APPEND markers; log files use CREATE markers instead");
+    StoragePath fullFilePath = new StoragePath(basePath, filePathToRollback);
+    String baseCommitTime;
+    Option<HoodieLogFile> latestLogFileOption;
+    Map<String, Long> logBlocksToBeDeleted = new HashMap<>();
+    // Old marker files may be generated from base file name before HUDI-1517. keep compatible with them.
+    if (FSUtils.isBaseFile(fullFilePath)) {
+      log.info("Found old marker type for log file: {}", filePathToRollback);
+      baseCommitTime = FSUtils.getCommitTime(fullFilePath.getName());
+      StoragePath partitionPath = FSUtils.constructAbsolutePath(config.getBasePath(), relativePartitionPath);
 
-        // NOTE: Since we're rolling back incomplete Delta Commit, it only could have appended its
-        //       block to the latest log-file
-        try {
-          latestLogFileOption = FSUtils.getLatestLogFile(table.getMetaClient().getStorage(), partitionPath, fileId,
-              HoodieFileFormat.HOODIE_LOG.getFileExtension(), baseCommitTime);
-          if (latestLogFileOption.isPresent() && baseCommitTime.equals(instantToRollback.requestedTime())) {
-            // Log file can be deleted if the commit to rollback is also the commit that created the fileGroup
-            StoragePath fullDeletePath = new StoragePath(partitionPath, latestLogFileOption.get().getFileName());
+      // NOTE: Since we're rolling back incomplete Delta Commit, it only could have appended its
+      //       block to the latest log-file
+      try {
+        latestLogFileOption = FSUtils.getLatestLogFile(table.getMetaClient().getStorage(), partitionPath, fileId,
+            HoodieFileFormat.HOODIE_LOG.getFileExtension(), baseCommitTime);
+        if (latestLogFileOption.isPresent() && baseCommitTime.equals(instantToRollback.requestedTime())) {
+          // Log file can be deleted if the commit to rollback is also the commit that created the fileGroup
+          StoragePath fullDeletePath = new StoragePath(partitionPath, latestLogFileOption.get().getFileName());
+          return new HoodieRollbackRequest(relativePartitionPath, EMPTY_STRING, EMPTY_STRING,
+              Collections.singletonList(fullDeletePath.toString()),
+              Collections.emptyMap());
+        }
+        if (latestLogFileOption.isPresent()) {
+          HoodieLogFile latestLogFile = latestLogFileOption.get();
+          // NOTE: Markers don't carry information about the cumulative size of the blocks that have been appended,
+          //       therefore we simply stub this value.
+          logBlocksToBeDeleted = Collections.singletonMap(latestLogFile.getPathInfo().getPath().toString(), latestLogFile.getPathInfo().getLength());
+        }
+        return new HoodieRollbackRequest(relativePartitionPath, fileId, baseCommitTime, Collections.emptyList(), logBlocksToBeDeleted);
+      } catch (IOException ioException) {
+        throw new HoodieIOException(
+            "Failed to get latestLogFile for fileId: " + fileId + " in partition: " + partitionPath,
+            ioException);
+      }
+    } else {
+      HoodieLogFile logFileToRollback = new HoodieLogFile(fullFilePath);
+      fileId = logFileToRollback.getFileId();
+      // For tbl version 6, deltaCommitTime is the commit time of the base file for the file slice
+      baseCommitTime = logFileToRollback.getDeltaCommitTime();
+      try {
+        StoragePathInfo pathInfo = table.getMetaClient().getStorage().getPathInfo(logFileToRollback.getPath());
+        if (pathInfo != null) {
+          if (baseCommitTime.equals(instantToRollback.requestedTime())) {
+            // delete the log file that creates a new file group
             return new HoodieRollbackRequest(relativePartitionPath, EMPTY_STRING, EMPTY_STRING,
-                Collections.singletonList(fullDeletePath.toString()),
+                Collections.singletonList(logFileToRollback.getPath().toString()),
                 Collections.emptyMap());
           }
-          if (latestLogFileOption.isPresent()) {
-            HoodieLogFile latestLogFile = latestLogFileOption.get();
-            // NOTE: Markers don't carry information about the cumulative size of the blocks that have been appended,
-            //       therefore we simply stub this value.
-            logBlocksToBeDeleted = Collections.singletonMap(latestLogFile.getPathInfo().getPath().toString(), latestLogFile.getPathInfo().getLength());
-          }
-          return new HoodieRollbackRequest(relativePartitionPath, fileId, baseCommitTime, Collections.emptyList(), logBlocksToBeDeleted);
-        } catch (IOException ioException) {
-          throw new HoodieIOException(
-              "Failed to get latestLogFile for fileId: " + fileId + " in partition: " + partitionPath,
-              ioException);
-        }
-      } else {
-        HoodieLogFile logFileToRollback = new HoodieLogFile(fullFilePath);
-        fileId = logFileToRollback.getFileId();
-        // For tbl version 6, deltaCommitTime is the commit time of the base file for the file slice
-        baseCommitTime = logFileToRollback.getDeltaCommitTime();
-        try {
-          StoragePathInfo pathInfo = table.getMetaClient().getStorage().getPathInfo(logFileToRollback.getPath());
-          if (pathInfo != null) {
-            if (baseCommitTime.equals(instantToRollback.requestedTime())) {
-              // delete the log file that creates a new file group
-              return new HoodieRollbackRequest(relativePartitionPath, EMPTY_STRING, EMPTY_STRING,
-                  Collections.singletonList(logFileToRollback.getPath().toString()),
-                  Collections.emptyMap());
-            }
-            // append a rollback block to the log block that is added to an existing file group
-            logBlocksToBeDeleted = Collections.singletonMap(
-                logFileToRollback.getPath().getName(), pathInfo.getLength());
-          } else {
-            log.debug(
-                "File info of {} is null indicating the file does not exist;"
-                    + " there is no need to include it in the rollback.",
-                fullFilePath);
-          }
-        } catch (FileNotFoundException e) {
+          // append a rollback block to the log block that is added to an existing file group
+          logBlocksToBeDeleted = Collections.singletonMap(
+              logFileToRollback.getPath().getName(), pathInfo.getLength());
+        } else {
           log.debug(
-              "Log file {} is not found so there is no need to include it in the rollback.",
+              "File info of {} is null indicating the file does not exist;"
+                  + " there is no need to include it in the rollback.",
               fullFilePath);
-        } catch (IOException e) {
-          throw new HoodieIOException("Failed to get the file status of " + fullFilePath, e);
         }
+      } catch (FileNotFoundException e) {
+        log.debug(
+            "Log file {} is not found so there is no need to include it in the rollback.",
+            fullFilePath);
+      } catch (IOException e) {
+        throw new HoodieIOException("Failed to get the file status of " + fullFilePath, e);
       }
-      return new HoodieRollbackRequest(relativePartitionPath, fileId, baseCommitTime, Collections.emptyList(), logBlocksToBeDeleted);
     }
+    return new HoodieRollbackRequest(relativePartitionPath, fileId, baseCommitTime, Collections.emptyList(), logBlocksToBeDeleted);
   }
 }

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/rollback/RollbackHelper.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/rollback/RollbackHelper.java
@@ -23,17 +23,12 @@ import org.apache.hudi.common.HoodieRollbackStat;
 import org.apache.hudi.common.engine.HoodieEngineContext;
 import org.apache.hudi.common.fs.FSUtils;
 import org.apache.hudi.common.function.SerializableFunction;
-import org.apache.hudi.common.model.HoodieLogFile;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
-import org.apache.hudi.common.table.log.block.HoodieCommandBlock;
-import org.apache.hudi.common.table.log.block.HoodieLogBlock;
 import org.apache.hudi.common.table.timeline.HoodieInstant;
 import org.apache.hudi.common.util.collection.Pair;
 import org.apache.hudi.config.HoodieWriteConfig;
 import org.apache.hudi.exception.HoodieIOException;
-import org.apache.hudi.exception.InvalidHoodiePathException;
 import org.apache.hudi.storage.StoragePath;
-import org.apache.hudi.storage.StoragePathInfo;
 import org.apache.hudi.table.HoodieTable;
 
 import lombok.extern.slf4j.Slf4j;
@@ -41,11 +36,7 @@ import lombok.extern.slf4j.Slf4j;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.Serializable;
-import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
-import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -134,65 +125,6 @@ public class RollbackHelper implements Serializable {
   }
 
   /**
-   * Builds the lookup key for pre-computed log versions. Used by {@link RollbackHelperV1} for V6 rollback.
-   */
-  protected static String logVersionLookupKey(String partitionPath, String fileId, String commitTime) {
-    return partitionPath + "|" + fileId + "|" + commitTime;
-  }
-
-  /**
-   * Pre-compute the latest log version for each (partition, fileId, deltaCommitTime) tuple
-   * by listing each unique partition directory once. This replaces N per-request listing
-   * calls (one per rollback request) with P per-partition listings (where P is much less than N).
-   *
-   * <p>Used by {@link RollbackHelperV1} for V6 rollback where log blocks are appended.
-   */
-  protected Map<String, Pair<Integer, String>> preComputeLogVersions(
-      List<SerializableHoodieRollbackRequest> rollbackRequests) {
-    Set<String> relativePartitionPaths = rollbackRequests.stream()
-        .filter(req -> !req.getLogBlocksToBeDeleted().isEmpty())
-        .map(SerializableHoodieRollbackRequest::getPartitionPath)
-        .collect(Collectors.toSet());
-
-    if (relativePartitionPaths.isEmpty()) {
-      return Collections.emptyMap();
-    }
-
-    log.info("Pre-computing log versions for {} partition(s) to avoid per-request listStatus calls",
-        relativePartitionPaths.size());
-
-    Map<String, Pair<Integer, String>> logVersionMap = new HashMap<>();
-
-    for (String relPartPath : relativePartitionPaths) {
-      StoragePath absolutePartPath = FSUtils.constructAbsolutePath(metaClient.getBasePath(), relPartPath);
-      try {
-        List<StoragePathInfo> statuses = metaClient.getStorage().listDirectEntries(absolutePartPath,
-            path -> path.getName().contains(HoodieLogFile.DELTA_EXTENSION));
-
-        for (StoragePathInfo status : statuses) {
-          try {
-            HoodieLogFile logFile = new HoodieLogFile(status);
-            String key = logVersionLookupKey(relPartPath, logFile.getFileId(), logFile.getDeltaCommitTime());
-            Pair<Integer, String> existing = logVersionMap.get(key);
-            if (existing == null || logFile.getLogVersion() > existing.getLeft()) {
-              logVersionMap.put(key, Pair.of(logFile.getLogVersion(), logFile.getLogWriteToken()));
-            }
-          } catch (InvalidHoodiePathException e) {
-            log.warn("Skipping non-standard log file during pre-compute: {}", status.getPath(), e);
-          }
-        }
-      } catch (IOException e) {
-        log.warn("Failed to pre-compute log versions for partition {}, will fall back to per-request listing",
-            relPartPath, e);
-      }
-    }
-
-    log.info("Pre-computed log versions for {} file groups across {} partition(s)",
-        logVersionMap.size(), relativePartitionPaths.size());
-    return logVersionMap;
-  }
-
-  /**
    * Common method used for cleaning out files during rollback.
    */
   protected List<HoodieRollbackStat> deleteFiles(HoodieTableMetaClient metaClient, List<String> filesToBeDeleted, boolean doDelete) throws IOException {
@@ -227,16 +159,4 @@ public class RollbackHelper implements Serializable {
     }).collect(Collectors.toList());
   }
 
-  /**
-   * Generates the header for a rollback command block. Used by {@link RollbackHelperV1} for V6 rollback.
-   */
-  protected Map<HoodieLogBlock.HeaderMetadataType, String> generateHeader(String commit) {
-    // generate metadata
-    Map<HoodieLogBlock.HeaderMetadataType, String> header = new HashMap<>(3);
-    header.put(HoodieLogBlock.HeaderMetadataType.INSTANT_TIME, metaClient.getActiveTimeline().lastInstant().get().requestedTime());
-    header.put(HoodieLogBlock.HeaderMetadataType.TARGET_INSTANT_TIME, commit);
-    header.put(HoodieLogBlock.HeaderMetadataType.COMMAND_BLOCK_TYPE,
-        String.valueOf(HoodieCommandBlock.HoodieCommandBlockTypeEnum.ROLLBACK_BLOCK.ordinal()));
-    return header;
-  }
 }

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/rollback/RollbackHelper.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/rollback/RollbackHelper.java
@@ -133,6 +133,9 @@ public class RollbackHelper implements Serializable {
     }, numPartitions);
   }
 
+  /**
+   * Builds the lookup key for pre-computed log versions. Used by {@link RollbackHelperV1} for V6 rollback.
+   */
   protected static String logVersionLookupKey(String partitionPath, String fileId, String commitTime) {
     return partitionPath + "|" + fileId + "|" + commitTime;
   }
@@ -141,6 +144,8 @@ public class RollbackHelper implements Serializable {
    * Pre-compute the latest log version for each (partition, fileId, deltaCommitTime) tuple
    * by listing each unique partition directory once. This replaces N per-request listing
    * calls (one per rollback request) with P per-partition listings (where P is much less than N).
+   *
+   * <p>Used by {@link RollbackHelperV1} for V6 rollback where log blocks are appended.
    */
   protected Map<String, Pair<Integer, String>> preComputeLogVersions(
       List<SerializableHoodieRollbackRequest> rollbackRequests) {
@@ -222,6 +227,9 @@ public class RollbackHelper implements Serializable {
     }).collect(Collectors.toList());
   }
 
+  /**
+   * Generates the header for a rollback command block. Used by {@link RollbackHelperV1} for V6 rollback.
+   */
   protected Map<HoodieLogBlock.HeaderMetadataType, String> generateHeader(String commit) {
     // generate metadata
     Map<HoodieLogBlock.HeaderMetadataType, String> header = new HashMap<>(3);

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/rollback/RollbackHelper.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/rollback/RollbackHelper.java
@@ -21,25 +21,20 @@ package org.apache.hudi.table.action.rollback;
 import org.apache.hudi.avro.model.HoodieRollbackRequest;
 import org.apache.hudi.common.HoodieRollbackStat;
 import org.apache.hudi.common.engine.HoodieEngineContext;
-import org.apache.hudi.common.engine.TaskContextSupplier;
 import org.apache.hudi.common.fs.FSUtils;
 import org.apache.hudi.common.function.SerializableFunction;
 import org.apache.hudi.common.model.HoodieLogFile;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
-import org.apache.hudi.common.table.HoodieTableVersion;
-import org.apache.hudi.common.table.log.HoodieLogFormat;
 import org.apache.hudi.common.table.log.block.HoodieCommandBlock;
 import org.apache.hudi.common.table.log.block.HoodieLogBlock;
 import org.apache.hudi.common.table.timeline.HoodieInstant;
 import org.apache.hudi.common.util.collection.Pair;
 import org.apache.hudi.config.HoodieWriteConfig;
 import org.apache.hudi.exception.HoodieIOException;
-import org.apache.hudi.exception.HoodieRollbackException;
 import org.apache.hudi.exception.InvalidHoodiePathException;
 import org.apache.hudi.storage.StoragePath;
 import org.apache.hudi.storage.StoragePathInfo;
 import org.apache.hudi.table.HoodieTable;
-import org.apache.hudi.util.CommonClientUtils;
 
 import lombok.extern.slf4j.Slf4j;
 
@@ -50,12 +45,11 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import static org.apache.hudi.table.action.rollback.RollbackUtils.groupSerializableRollbackRequestsBasedOnFileGroup;
+import static org.apache.hudi.common.util.ValidationUtils.checkArgument;
 
 /**
  * Contains common methods to be used across engines for rollback operation.
@@ -121,90 +115,15 @@ public class RollbackHelper implements Serializable {
                                                                     HoodieInstant instantToRollback,
                                                                     List<SerializableHoodieRollbackRequest> rollbackRequests,
                                                                     boolean doDelete, int numPartitions) {
-    // The rollback requests for append only exist in table version 6 and below which require groupBy
-    List<SerializableHoodieRollbackRequest> processedRollbackRequests =
-        metaClient.getTableConfig().getTableVersion().greaterThanOrEquals(HoodieTableVersion.EIGHT)
-            ? rollbackRequests
-            : groupSerializableRollbackRequestsBasedOnFileGroup(rollbackRequests);
-    final Map<String, Pair<Integer, String>> logVersionMap = preComputeLogVersions(processedRollbackRequests);
-    final TaskContextSupplier taskContextSupplier = context.getTaskContextSupplier();
-    return context.flatMap(processedRollbackRequests, (SerializableFunction<SerializableHoodieRollbackRequest, Stream<Pair<String, HoodieRollbackStat>>>) rollbackRequest -> {
+    return context.flatMap(rollbackRequests, (SerializableFunction<SerializableHoodieRollbackRequest, Stream<Pair<String, HoodieRollbackStat>>>) rollbackRequest -> {
       List<String> filesToBeDeleted = rollbackRequest.getFilesToBeDeleted();
       if (!filesToBeDeleted.isEmpty()) {
         List<HoodieRollbackStat> rollbackStats = deleteFiles(metaClient, filesToBeDeleted, doDelete);
         return rollbackStats.stream().map(entry -> Pair.of(entry.getPartitionPath(), entry));
-      } else if (!rollbackRequest.getLogBlocksToBeDeleted().isEmpty()) {
-        HoodieLogFormat.Writer writer = null;
-        StoragePath filePath = null;
-        long fileSize = 0L;
-        boolean fileSizeCaptured = false;
-        try {
-          String fileId = rollbackRequest.getFileId();
-          HoodieTableVersion tableVersion = metaClient.getTableConfig().getTableVersion();
-
-          HoodieLogFormat.WriterBuilder writerBuilder = HoodieLogFormat.newWriterBuilder()
-              .onParentPath(FSUtils.constructAbsolutePath(metaClient.getBasePath(), rollbackRequest.getPartitionPath()))
-              .withFileId(fileId)
-              .withLogWriteToken(CommonClientUtils.generateWriteToken(taskContextSupplier))
-              .withInstantTime(tableVersion.greaterThanOrEquals(HoodieTableVersion.EIGHT)
-                      ? instantToRollback.requestedTime() : rollbackRequest.getLatestBaseInstant()
-                  )
-              .withStorage(metaClient.getStorage())
-              .withTableVersion(tableVersion)
-              .withFileExtension(HoodieLogFile.DELTA_EXTENSION);
-
-          String logVersionKey = logVersionLookupKey(rollbackRequest.getPartitionPath(), fileId, rollbackRequest.getLatestBaseInstant());
-          Pair<Integer, String> preComputedVersion = logVersionMap.get(logVersionKey);
-          if (preComputedVersion != null) {
-            writerBuilder.withLogVersion(preComputedVersion.getLeft())
-                .withLogWriteToken(preComputedVersion.getRight());
-          }
-
-          writer = writerBuilder.build();
-
-          // generate metadata
-          if (doDelete) {
-            Map<HoodieLogBlock.HeaderMetadataType, String> header = generateHeader(instantToRollback.requestedTime());
-            // if update belongs to an existing log file
-            // use the log file path from AppendResult in case the file handle may roll over
-            filePath = writer.appendBlock(new HoodieCommandBlock(header)).logFile().getPath();
-            fileSize = writer.getCurrentSize();
-            fileSizeCaptured = true;
-          } else {
-            filePath = writer.getLogFile().getPath();
-          }
-        } catch (IOException | InterruptedException io) {
-          throw new HoodieRollbackException("Failed to rollback for instant " + instantToRollback, io);
-        } finally {
-          try {
-            if (writer != null) {
-              writer.close();
-            }
-          } catch (IOException io) {
-            throw new HoodieIOException("Error appending rollback block", io);
-          }
-        }
-
-        Map<StoragePathInfo, Long> filesToNumBlocksRollback;
-        if (fileSizeCaptured) {
-          filesToNumBlocksRollback = Collections.singletonMap(
-              new StoragePathInfo(Objects.requireNonNull(filePath), fileSize, false, (short) 0, 0, 0), 1L);
-        } else {
-          // This step is intentionally done after writer is closed. Guarantees that
-          // getFileStatus would reflect correct stats and FileNotFoundException is not thrown in
-          // cloud-storage : HUDI-168
-          filesToNumBlocksRollback = Collections.singletonMap(
-              metaClient.getStorage().getPathInfo(Objects.requireNonNull(filePath)), 1L);
-        }
-
-        return Stream.of(
-                Pair.of(rollbackRequest.getPartitionPath(),
-                    HoodieRollbackStat.newBuilder()
-                        .withPartitionPath(rollbackRequest.getPartitionPath())
-                        .withRollbackBlockAppendResults(filesToNumBlocksRollback)
-                        .build()));
       } else {
-        // no action needed.
+        checkArgument(rollbackRequest.getLogBlocksToBeDeleted().isEmpty(),
+            "V8+ rollback should not have logBlocksToBeDeleted, but found for partition: "
+                + rollbackRequest.getPartitionPath() + ", fileId: " + rollbackRequest.getFileId());
         return Stream.of(
             Pair.of(rollbackRequest.getPartitionPath(),
                 HoodieRollbackStat.newBuilder()

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/rollback/RollbackHelper.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/rollback/RollbackHelper.java
@@ -35,6 +35,7 @@ import org.apache.hudi.common.util.collection.Pair;
 import org.apache.hudi.config.HoodieWriteConfig;
 import org.apache.hudi.exception.HoodieIOException;
 import org.apache.hudi.exception.HoodieRollbackException;
+import org.apache.hudi.exception.InvalidHoodiePathException;
 import org.apache.hudi.storage.StoragePath;
 import org.apache.hudi.storage.StoragePathInfo;
 import org.apache.hudi.table.HoodieTable;
@@ -50,6 +51,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -124,6 +126,7 @@ public class RollbackHelper implements Serializable {
         metaClient.getTableConfig().getTableVersion().greaterThanOrEquals(HoodieTableVersion.EIGHT)
             ? rollbackRequests
             : groupSerializableRollbackRequestsBasedOnFileGroup(rollbackRequests);
+    final Map<String, Pair<Integer, String>> logVersionMap = preComputeLogVersions(processedRollbackRequests);
     final TaskContextSupplier taskContextSupplier = context.getTaskContextSupplier();
     return context.flatMap(processedRollbackRequests, (SerializableFunction<SerializableHoodieRollbackRequest, Stream<Pair<String, HoodieRollbackStat>>>) rollbackRequest -> {
       List<String> filesToBeDeleted = rollbackRequest.getFilesToBeDeleted();
@@ -132,12 +135,14 @@ public class RollbackHelper implements Serializable {
         return rollbackStats.stream().map(entry -> Pair.of(entry.getPartitionPath(), entry));
       } else if (!rollbackRequest.getLogBlocksToBeDeleted().isEmpty()) {
         HoodieLogFormat.Writer writer = null;
-        final StoragePath filePath;
+        StoragePath filePath = null;
+        long fileSize = 0L;
+        boolean fileSizeCaptured = false;
         try {
           String fileId = rollbackRequest.getFileId();
           HoodieTableVersion tableVersion = metaClient.getTableConfig().getTableVersion();
 
-          writer = HoodieLogFormat.newWriterBuilder()
+          HoodieLogFormat.WriterBuilder writerBuilder = HoodieLogFormat.newWriterBuilder()
               .onParentPath(FSUtils.constructAbsolutePath(metaClient.getBasePath(), rollbackRequest.getPartitionPath()))
               .withFileId(fileId)
               .withLogWriteToken(CommonClientUtils.generateWriteToken(taskContextSupplier))
@@ -146,7 +151,16 @@ public class RollbackHelper implements Serializable {
                   )
               .withStorage(metaClient.getStorage())
               .withTableVersion(tableVersion)
-              .withFileExtension(HoodieLogFile.DELTA_EXTENSION).build();
+              .withFileExtension(HoodieLogFile.DELTA_EXTENSION);
+
+          String logVersionKey = logVersionLookupKey(rollbackRequest.getPartitionPath(), fileId, rollbackRequest.getLatestBaseInstant());
+          Pair<Integer, String> preComputedVersion = logVersionMap.get(logVersionKey);
+          if (preComputedVersion != null) {
+            writerBuilder.withLogVersion(preComputedVersion.getLeft())
+                .withLogWriteToken(preComputedVersion.getRight());
+          }
+
+          writer = writerBuilder.build();
 
           // generate metadata
           if (doDelete) {
@@ -154,6 +168,8 @@ public class RollbackHelper implements Serializable {
             // if update belongs to an existing log file
             // use the log file path from AppendResult in case the file handle may roll over
             filePath = writer.appendBlock(new HoodieCommandBlock(header)).logFile().getPath();
+            fileSize = writer.getCurrentSize();
+            fileSizeCaptured = true;
           } else {
             filePath = writer.getLogFile().getPath();
           }
@@ -169,13 +185,17 @@ public class RollbackHelper implements Serializable {
           }
         }
 
-        // This step is intentionally done after writer is closed. Guarantees that
-        // getFileStatus would reflect correct stats and FileNotFoundException is not thrown in
-        // cloud-storage : HUDI-168
-        Map<StoragePathInfo, Long> filesToNumBlocksRollback = Collections.singletonMap(
-            metaClient.getStorage().getPathInfo(Objects.requireNonNull(filePath)),
-            1L
-        );
+        Map<StoragePathInfo, Long> filesToNumBlocksRollback;
+        if (fileSizeCaptured) {
+          filesToNumBlocksRollback = Collections.singletonMap(
+              new StoragePathInfo(Objects.requireNonNull(filePath), fileSize, false, (short) 0, 0, 0), 1L);
+        } else {
+          // This step is intentionally done after writer is closed. Guarantees that
+          // getFileStatus would reflect correct stats and FileNotFoundException is not thrown in
+          // cloud-storage : HUDI-168
+          filesToNumBlocksRollback = Collections.singletonMap(
+              metaClient.getStorage().getPathInfo(Objects.requireNonNull(filePath)), 1L);
+        }
 
         return Stream.of(
                 Pair.of(rollbackRequest.getPartitionPath(),
@@ -192,6 +212,60 @@ public class RollbackHelper implements Serializable {
                     .build()));
       }
     }, numPartitions);
+  }
+
+  protected static String logVersionLookupKey(String partitionPath, String fileId, String commitTime) {
+    return partitionPath + "|" + fileId + "|" + commitTime;
+  }
+
+  /**
+   * Pre-compute the latest log version for each (partition, fileId, deltaCommitTime) tuple
+   * by listing each unique partition directory once. This replaces N per-request listing
+   * calls (one per rollback request) with P per-partition listings (where P is much less than N).
+   */
+  protected Map<String, Pair<Integer, String>> preComputeLogVersions(
+      List<SerializableHoodieRollbackRequest> rollbackRequests) {
+    Set<String> relativePartitionPaths = rollbackRequests.stream()
+        .filter(req -> !req.getLogBlocksToBeDeleted().isEmpty())
+        .map(SerializableHoodieRollbackRequest::getPartitionPath)
+        .collect(Collectors.toSet());
+
+    if (relativePartitionPaths.isEmpty()) {
+      return Collections.emptyMap();
+    }
+
+    log.info("Pre-computing log versions for {} partition(s) to avoid per-request listStatus calls",
+        relativePartitionPaths.size());
+
+    Map<String, Pair<Integer, String>> logVersionMap = new HashMap<>();
+
+    for (String relPartPath : relativePartitionPaths) {
+      StoragePath absolutePartPath = FSUtils.constructAbsolutePath(metaClient.getBasePath(), relPartPath);
+      try {
+        List<StoragePathInfo> statuses = metaClient.getStorage().listDirectEntries(absolutePartPath,
+            path -> path.getName().contains(HoodieLogFile.DELTA_EXTENSION));
+
+        for (StoragePathInfo status : statuses) {
+          try {
+            HoodieLogFile logFile = new HoodieLogFile(status);
+            String key = logVersionLookupKey(relPartPath, logFile.getFileId(), logFile.getDeltaCommitTime());
+            Pair<Integer, String> existing = logVersionMap.get(key);
+            if (existing == null || logFile.getLogVersion() > existing.getLeft()) {
+              logVersionMap.put(key, Pair.of(logFile.getLogVersion(), logFile.getLogWriteToken()));
+            }
+          } catch (InvalidHoodiePathException e) {
+            log.warn("Skipping non-standard log file during pre-compute: {}", status.getPath(), e);
+          }
+        }
+      } catch (IOException e) {
+        log.warn("Failed to pre-compute log versions for partition {}, will fall back to per-request listing",
+            relPartPath, e);
+      }
+    }
+
+    log.info("Pre-computed log versions for {} file groups across {} partition(s)",
+        logVersionMap.size(), relativePartitionPaths.size());
+    return logVersionMap;
   }
 
   /**

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/rollback/RollbackHelperV1.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/rollback/RollbackHelperV1.java
@@ -258,9 +258,8 @@ public class RollbackHelperV1 extends RollbackHelper {
           filesToNumBlocksRollback = Collections.singletonMap(
               new StoragePathInfo(Objects.requireNonNull(filePath), fileSize, false, (short) 0, 0, 0), 1L);
         } else {
-          // This step is intentionally done after writer is closed. Guarantees that
-          // getFileStatus would reflect correct stats and FileNotFoundException is not thrown in
-          // cloud-storage : HUDI-168
+          // No block was appended (doDelete=false), so file size was not
+          // captured in-memory. Fetch metadata from storage instead.
           filesToNumBlocksRollback = Collections.singletonMap(
               metaClient.getStorage().getPathInfo(Objects.requireNonNull(filePath)), 1L);
         }

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/rollback/RollbackHelperV1.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/rollback/RollbackHelperV1.java
@@ -40,6 +40,7 @@ import org.apache.hudi.common.util.collection.Pair;
 import org.apache.hudi.config.HoodieWriteConfig;
 import org.apache.hudi.exception.HoodieIOException;
 import org.apache.hudi.exception.HoodieRollbackException;
+import org.apache.hudi.exception.InvalidHoodiePathException;
 import org.apache.hudi.storage.HoodieStorage;
 import org.apache.hudi.storage.HoodieStorageUtils;
 import org.apache.hudi.storage.StorageConfiguration;
@@ -78,6 +79,92 @@ public class RollbackHelperV1 extends RollbackHelper {
 
   public RollbackHelperV1(HoodieTable table, HoodieWriteConfig config) {
     super(table, config);
+  }
+
+  /**
+   * Builds the lookup key for pre-computed log versions.
+   */
+  static String logVersionLookupKey(String partitionPath, String fileId, String commitTime) {
+    return partitionPath + "|" + fileId + "|" + commitTime;
+  }
+
+  /**
+   * Pre-compute the latest log version for each (partition, fileId, deltaCommitTime) tuple
+   * by listing each unique partition directory once. This replaces N per-request listing
+   * calls (one per rollback request) with P per-partition listings (where P is much less than N).
+   *
+   * <p>For file groups with no existing log files in a successfully listed partition, a sentinel
+   * of (LOGFILE_BASE_VERSION, UNKNOWN_WRITE_TOKEN) is inserted so the caller avoids a redundant
+   * per-request listing. If a partition listing fails (IOException), no sentinels are inserted
+   * and the caller falls back to per-request listing naturally.
+   */
+  Map<String, Pair<Integer, String>> preComputeLogVersions(
+      List<SerializableHoodieRollbackRequest> rollbackRequests) {
+    List<SerializableHoodieRollbackRequest> logBlockRequests = rollbackRequests.stream()
+        .filter(req -> !req.getLogBlocksToBeDeleted().isEmpty())
+        .collect(Collectors.toList());
+
+    if (logBlockRequests.isEmpty()) {
+      return Collections.emptyMap();
+    }
+
+    Map<String, Set<String>> expectedKeysByPartition = new HashMap<>();
+    for (SerializableHoodieRollbackRequest req : logBlockRequests) {
+      String key = logVersionLookupKey(req.getPartitionPath(), req.getFileId(), req.getLatestBaseInstant());
+      expectedKeysByPartition.computeIfAbsent(req.getPartitionPath(), k -> new HashSet<>()).add(key);
+    }
+
+    log.info("Pre-computing log versions for {} partition(s) to avoid per-request listStatus calls",
+        expectedKeysByPartition.size());
+
+    Map<String, Pair<Integer, String>> logVersionMap = new HashMap<>();
+
+    for (Map.Entry<String, Set<String>> entry : expectedKeysByPartition.entrySet()) {
+      String relPartPath = entry.getKey();
+      Set<String> expectedKeys = entry.getValue();
+      StoragePath absolutePartPath = FSUtils.constructAbsolutePath(metaClient.getBasePath(), relPartPath);
+      try {
+        List<StoragePathInfo> statuses = metaClient.getStorage().listDirectEntries(absolutePartPath,
+            path -> path.getName().contains(HoodieLogFile.DELTA_EXTENSION));
+
+        for (StoragePathInfo status : statuses) {
+          try {
+            HoodieLogFile logFile = new HoodieLogFile(status);
+            String key = logVersionLookupKey(relPartPath, logFile.getFileId(), logFile.getDeltaCommitTime());
+            Pair<Integer, String> existing = logVersionMap.get(key);
+            if (existing == null || logFile.getLogVersion() > existing.getLeft()) {
+              logVersionMap.put(key, Pair.of(logFile.getLogVersion(), logFile.getLogWriteToken()));
+            }
+          } catch (InvalidHoodiePathException e) {
+            log.warn("Skipping non-standard log file during pre-compute: {}", status.getPath(), e);
+          }
+        }
+
+        Pair<Integer, String> sentinel = Pair.of(HoodieLogFile.LOGFILE_BASE_VERSION, HoodieLogFormat.UNKNOWN_WRITE_TOKEN);
+        for (String expectedKey : expectedKeys) {
+          logVersionMap.putIfAbsent(expectedKey, sentinel);
+        }
+      } catch (IOException e) {
+        log.warn("Failed to pre-compute log versions for partition {}, will fall back to per-request listing",
+            relPartPath, e);
+      }
+    }
+
+    log.info("Pre-computed log versions for {} file groups across {} partition(s)",
+        logVersionMap.size(), expectedKeysByPartition.size());
+    return logVersionMap;
+  }
+
+  /**
+   * Generates the header for a rollback command block.
+   */
+  private Map<HoodieLogBlock.HeaderMetadataType, String> generateHeader(String commit) {
+    Map<HoodieLogBlock.HeaderMetadataType, String> header = new HashMap<>(3);
+    header.put(HoodieLogBlock.HeaderMetadataType.INSTANT_TIME, metaClient.getActiveTimeline().lastInstant().get().requestedTime());
+    header.put(HoodieLogBlock.HeaderMetadataType.TARGET_INSTANT_TIME, commit);
+    header.put(HoodieLogBlock.HeaderMetadataType.COMMAND_BLOCK_TYPE,
+        String.valueOf(HoodieCommandBlock.HoodieCommandBlockTypeEnum.ROLLBACK_BLOCK.ordinal()));
+    return header;
   }
 
   /**
@@ -169,6 +256,23 @@ public class RollbackHelperV1 extends RollbackHelper {
   }
 
   /**
+   * Collect all file info that needs to be rolled back, using the V1-specific
+   * 6-param {@code maybeDeleteAndCollectStats} so V6 log-block requests are handled correctly.
+   */
+  @Override
+  public List<HoodieRollbackStat> collectRollbackStats(HoodieEngineContext context, HoodieInstant instantToRollback,
+                                                       List<HoodieRollbackRequest> rollbackRequests) {
+    int parallelism = Math.max(Math.min(rollbackRequests.size(), config.getRollbackParallelism()), 1);
+    context.setJobStatus(this.getClass().getSimpleName(), "Collect rollback stats: " + config.getTableName());
+    List<SerializableHoodieRollbackRequest> serializableRequests = rollbackRequests.stream()
+        .map(SerializableHoodieRollbackRequest::new).collect(Collectors.toList());
+    return context.reduceByKey(
+        maybeDeleteAndCollectStats(context, EMPTY_STRING, instantToRollback,
+            serializableRequests, false, parallelism),
+        RollbackUtils::mergeRollbackStat, parallelism);
+  }
+
+  /**
    * May be delete interested files and collect stats or collect stats only.
    *
    * @param context           instance of {@link HoodieEngineContext} to use.
@@ -199,8 +303,6 @@ public class RollbackHelperV1 extends RollbackHelper {
       } else if (!rollbackRequest.getLogBlocksToBeDeleted().isEmpty()) {
         HoodieLogFormat.Writer writer = null;
         StoragePath filePath = null;
-        long fileSize = 0L;
-        boolean fileSizeCaptured = false;
         try {
           String partitionPath = rollbackRequest.getPartitionPath();
           String fileId = rollbackRequest.getFileId();
@@ -241,10 +343,6 @@ public class RollbackHelperV1 extends RollbackHelper {
             // if update belongs to an existing log file
             // use the log file path from AppendResult in case the file handle may roll over
             filePath = writer.appendBlock(new HoodieCommandBlock(header)).logFile().getPath();
-            // appendBlock() calls hsync() before returning, so the stream position
-            // matches the on-disk file size — no buffering or flush gap.
-            fileSize = writer.getCurrentSize();
-            fileSizeCaptured = true;
           } else {
             filePath = writer.getLogFile().getPath();
           }
@@ -260,16 +358,11 @@ public class RollbackHelperV1 extends RollbackHelper {
           }
         }
 
-        Map<StoragePathInfo, Long> filesToNumBlocksRollback;
-        if (fileSizeCaptured) {
-          filesToNumBlocksRollback = Collections.singletonMap(
-              new StoragePathInfo(Objects.requireNonNull(filePath), fileSize, false, (short) 0, 0, 0), 1L);
-        } else {
-          // No block was appended (doDelete=false), so file size was not
-          // captured in-memory. Fetch metadata from storage instead.
-          filesToNumBlocksRollback = Collections.singletonMap(
-              metaClient.getStorage().getPathInfo(Objects.requireNonNull(filePath)), 1L);
-        }
+        // This step is intentionally done after writer is closed. Guarantees that
+        // getFileStatus would reflect correct stats and FileNotFoundException is not thrown in
+        // cloud-storage : HUDI-168
+        Map<StoragePathInfo, Long> filesToNumBlocksRollback = Collections.singletonMap(
+            metaClient.getStorage().getPathInfo(Objects.requireNonNull(filePath)), 1L);
 
         // With listing based rollback, sometimes we only get the fileID of interest(so that we can add rollback command block) w/o the actual file name.
         // So, we want to ignore such invalid files from this list before we add it to the rollback stats.

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/rollback/RollbackHelperV1.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/rollback/RollbackHelperV1.java
@@ -221,6 +221,11 @@ public class RollbackHelperV1 extends RollbackHelper {
               .withTableVersion(tableVersion)
               .withFileExtension(HoodieLogFile.DELTA_EXTENSION);
 
+          // Supply the pre-computed latest log version and its write token so that
+          // WriterBuilder.build() skips the per-request FSUtils.getLatestLogVersion() listing.
+          // This produces the same result: build() would discover (N, T_existing), construct
+          // path (N, T_existing), find it exists, and roll over to N+1. Pre-computation
+          // feeds the same (N, T_existing), triggering the identical rollover in getOutputStream().
           String logVersionKey = logVersionLookupKey(partitionPath, fileId, rollbackRequest.getLatestBaseInstant());
           Pair<Integer, String> preComputedVersion = logVersionMap.get(logVersionKey);
           if (preComputedVersion != null) {
@@ -236,6 +241,8 @@ public class RollbackHelperV1 extends RollbackHelper {
             // if update belongs to an existing log file
             // use the log file path from AppendResult in case the file handle may roll over
             filePath = writer.appendBlock(new HoodieCommandBlock(header)).logFile().getPath();
+            // appendBlock() calls hsync() before returning, so the stream position
+            // matches the on-disk file size — no buffering or flush gap.
             fileSize = writer.getCurrentSize();
             fileSizeCaptured = true;
           } else {

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/rollback/RollbackHelperV1.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/rollback/RollbackHelperV1.java
@@ -187,6 +187,7 @@ public class RollbackHelperV1 extends RollbackHelper {
         metaClient.getTableConfig().getTableVersion().greaterThanOrEquals(HoodieTableVersion.EIGHT)
             ? rollbackRequests
             : groupSerializableRollbackRequestsBasedOnFileGroup(rollbackRequests);
+    final Map<String, Pair<Integer, String>> logVersionMap = preComputeLogVersions(processedRollbackRequests);
     final TaskContextSupplier taskContextSupplier = context.getTaskContextSupplier();
     return context.flatMap(processedRollbackRequests, (SerializableFunction<SerializableHoodieRollbackRequest, Stream<Pair<String, HoodieRollbackStat>>>) rollbackRequest -> {
       List<String> filesToBeDeleted = rollbackRequest.getFilesToBeDeleted();
@@ -197,7 +198,9 @@ public class RollbackHelperV1 extends RollbackHelper {
         return partitionToRollbackStats.stream();
       } else if (!rollbackRequest.getLogBlocksToBeDeleted().isEmpty()) {
         HoodieLogFormat.Writer writer = null;
-        final StoragePath filePath;
+        StoragePath filePath = null;
+        long fileSize = 0L;
+        boolean fileSizeCaptured = false;
         try {
           String partitionPath = rollbackRequest.getPartitionPath();
           String fileId = rollbackRequest.getFileId();
@@ -206,7 +209,7 @@ public class RollbackHelperV1 extends RollbackHelper {
           // Let's emit markers for rollback as well. markers are emitted under rollback instant time.
           WriteMarkers writeMarkers = WriteMarkersFactory.get(config.getMarkersType(), table, instantTime);
 
-          writer = HoodieLogFormat.newWriterBuilder()
+          HoodieLogFormat.WriterBuilder writerBuilder = HoodieLogFormat.newWriterBuilder()
               .onParentPath(FSUtils.constructAbsolutePath(metaClient.getBasePath(), partitionPath))
               .withFileId(fileId)
               .withLogWriteToken(CommonClientUtils.generateWriteToken(taskContextSupplier))
@@ -216,7 +219,16 @@ public class RollbackHelperV1 extends RollbackHelper {
               .withStorage(metaClient.getStorage())
               .withFileCreationCallback(getRollbackLogMarkerCallback(writeMarkers, partitionPath, fileId))
               .withTableVersion(tableVersion)
-              .withFileExtension(HoodieLogFile.DELTA_EXTENSION).build();
+              .withFileExtension(HoodieLogFile.DELTA_EXTENSION);
+
+          String logVersionKey = logVersionLookupKey(partitionPath, fileId, rollbackRequest.getLatestBaseInstant());
+          Pair<Integer, String> preComputedVersion = logVersionMap.get(logVersionKey);
+          if (preComputedVersion != null) {
+            writerBuilder.withLogVersion(preComputedVersion.getLeft())
+                .withLogWriteToken(preComputedVersion.getRight());
+          }
+
+          writer = writerBuilder.build();
 
           // generate metadata
           if (doDelete) {
@@ -224,6 +236,8 @@ public class RollbackHelperV1 extends RollbackHelper {
             // if update belongs to an existing log file
             // use the log file path from AppendResult in case the file handle may roll over
             filePath = writer.appendBlock(new HoodieCommandBlock(header)).logFile().getPath();
+            fileSize = writer.getCurrentSize();
+            fileSizeCaptured = true;
           } else {
             filePath = writer.getLogFile().getPath();
           }
@@ -239,13 +253,17 @@ public class RollbackHelperV1 extends RollbackHelper {
           }
         }
 
-        // This step is intentionally done after writer is closed. Guarantees that
-        // getFileStatus would reflect correct stats and FileNotFoundException is not thrown in
-        // cloud-storage : HUDI-168
-        Map<StoragePathInfo, Long> filesToNumBlocksRollback = Collections.singletonMap(
-            metaClient.getStorage().getPathInfo(Objects.requireNonNull(filePath)),
-            1L
-        );
+        Map<StoragePathInfo, Long> filesToNumBlocksRollback;
+        if (fileSizeCaptured) {
+          filesToNumBlocksRollback = Collections.singletonMap(
+              new StoragePathInfo(Objects.requireNonNull(filePath), fileSize, false, (short) 0, 0, 0), 1L);
+        } else {
+          // This step is intentionally done after writer is closed. Guarantees that
+          // getFileStatus would reflect correct stats and FileNotFoundException is not thrown in
+          // cloud-storage : HUDI-168
+          filesToNumBlocksRollback = Collections.singletonMap(
+              metaClient.getStorage().getPathInfo(Objects.requireNonNull(filePath)), 1L);
+        }
 
         // With listing based rollback, sometimes we only get the fileID of interest(so that we can add rollback command block) w/o the actual file name.
         // So, we want to ignore such invalid files from this list before we add it to the rollback stats.

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/upgrade/ZeroToOneUpgradeHandler.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/upgrade/ZeroToOneUpgradeHandler.java
@@ -32,8 +32,8 @@ import org.apache.hudi.exception.HoodieRollbackException;
 import org.apache.hudi.storage.StoragePath;
 import org.apache.hudi.storage.StoragePathInfo;
 import org.apache.hudi.table.HoodieTable;
-import org.apache.hudi.table.action.rollback.RollbackHelper;
 import org.apache.hudi.table.action.rollback.ListingBasedRollbackStrategy;
+import org.apache.hudi.table.action.rollback.RollbackHelperFactory;
 import org.apache.hudi.table.marker.WriteMarkers;
 import org.apache.hudi.table.marker.WriteMarkersFactory;
 
@@ -116,7 +116,7 @@ public class ZeroToOneUpgradeHandler implements UpgradeHandler {
     List<HoodieRollbackRequest> hoodieRollbackRequests =
         new ListingBasedRollbackStrategy(table, context, table.getConfig(), commitInstantOpt.get().requestedTime(), false)
             .getRollbackRequests(commitInstantOpt.get());
-    return new RollbackHelper(table, table.getConfig())
+    return RollbackHelperFactory.getRollBackHelper(table, table.getConfig())
         .collectRollbackStats(context, commitInstantOpt.get(), hoodieRollbackRequests);
   }
 

--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/table/action/rollback/TestRollbackHelper.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/table/action/rollback/TestRollbackHelper.java
@@ -64,6 +64,7 @@ import java.util.stream.IntStream;
 import static org.apache.hudi.common.testutils.HoodieTestUtils.INSTANT_GENERATOR;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.mock;
@@ -145,6 +146,32 @@ class TestRollbackHelper extends HoodieRollbackTestBase {
     return expected;
   }
 
+  /**
+   * Holds the test context for single-request rollback scenarios, shared between V8 and V6 tests.
+   */
+  private static class SingleRequestTestContext {
+    final List<SerializableHoodieRollbackRequest> rollbackRequests = new ArrayList<>();
+    final String baseInstantTimeOfLogFiles = "001";
+    final String instantToRollback = "002";
+    final String partition = "partition1";
+    String logFileId;
+    StoragePath baseFilePath;
+    Map<String, Long> logFilesToRollback;
+  }
+
+  private SingleRequestTestContext buildSingleRequestScenario(HoodieTableVersion tableVersion) throws IOException {
+    when(tableConfig.getTableVersion()).thenReturn(tableVersion);
+    SingleRequestTestContext ctx = new SingleRequestTestContext();
+    String baseFileId = UUID.randomUUID().toString();
+    ctx.logFileId = UUID.randomUUID().toString();
+    ctx.baseFilePath = addRollbackRequestForBaseFile(
+        ctx.rollbackRequests, ctx.partition, baseFileId, ctx.instantToRollback);
+    ctx.logFilesToRollback = addRollbackRequestForLogFiles(
+        ctx.rollbackRequests, tableVersion, ctx.partition, ctx.logFileId,
+        ctx.baseInstantTimeOfLogFiles, IntStream.range(1, ROLLBACK_LOG_VERSION));
+    return ctx;
+  }
+
   @Test
   void testMaybeDeleteAndCollectStatsWithMultipleRequestsPerFileGroup() throws IOException {
     MultiRequestTestContext ctx = buildMultiRequestScenario(HoodieTableVersion.EIGHT);
@@ -174,37 +201,58 @@ class TestRollbackHelper extends HoodieRollbackTestBase {
 
   @Test
   void testMaybeDeleteAndCollectStatsWithSingleRequestPerFileGroup() throws IOException {
-    HoodieTableVersion tableVersion = HoodieTableVersion.EIGHT;
-    when(tableConfig.getTableVersion()).thenReturn(tableVersion);
+    SingleRequestTestContext ctx = buildSingleRequestScenario(HoodieTableVersion.EIGHT);
+    String rollbackInstantTime = "003";
+    RollbackHelper rollbackHelper = new RollbackHelper(table, config);
+
+    setupMocksAndValidateInitialState(rollbackInstantTime, ctx.rollbackRequests);
+    List<Pair<String, HoodieRollbackStat>> rollbackStats = rollbackHelper.maybeDeleteAndCollectStats(
+        new HoodieLocalEngineContext(storage.getConf()),
+        INSTANT_GENERATOR.createNewInstant(HoodieInstant.State.INFLIGHT, HoodieTimeline.DELTA_COMMIT_ACTION, ctx.instantToRollback),
+        ctx.rollbackRequests, true, 5);
+    validateStateAfterRollback(ctx.rollbackRequests);
+
+    List<Pair<String, HoodieRollbackStat>> expected = new ArrayList<>();
+    expected.add(Pair.of(ctx.partition,
+        HoodieRollbackStat.newBuilder().withPartitionPath(ctx.partition)
+            .withDeletedFileResult(ctx.baseFilePath.toString(), true).build()));
+    getFullLogPathList(ctx.logFilesToRollback.keySet(), ctx.partition).forEach(logFilePath ->
+        expected.add(Pair.of(ctx.partition,
+            HoodieRollbackStat.newBuilder().withPartitionPath(ctx.partition)
+                .withDeletedFileResult(logFilePath, true).build())));
+    assertRollbackStatsEquals(expected, rollbackStats);
+  }
+
+  @Test
+  void testBaseRollbackHelperRejectsLogBlockRequests() throws IOException {
+    when(tableConfig.getTableVersion()).thenReturn(HoodieTableVersion.EIGHT);
     String rollbackInstantTime = "003";
     String instantToRollback = "002";
     RollbackHelper rollbackHelper = new RollbackHelper(table, config);
 
     List<SerializableHoodieRollbackRequest> rollbackRequests = new ArrayList<>();
-    String partition = "partition1";
-    String baseFileId = UUID.randomUUID().toString();
-    String logFileId = UUID.randomUUID().toString();
-    StoragePath baseFilePath = addRollbackRequestForBaseFile(
-        rollbackRequests, partition, baseFileId, instantToRollback);
-    Map<String, Long> logFilesToRollback = addRollbackRequestForLogFiles(
-        rollbackRequests, tableVersion, partition, logFileId, "001", IntStream.range(1, ROLLBACK_LOG_VERSION));
+    Map<String, Long> logBlocks = new HashMap<>();
+    logBlocks.put("someLogFile", 100L);
+    rollbackRequests.add(new SerializableHoodieRollbackRequest(
+        HoodieRollbackRequest.newBuilder()
+            .setPartitionPath("partition1")
+            .setFileId("fileId-001")
+            .setLatestBaseInstant(instantToRollback)
+            .setFilesToBeDeleted(Collections.emptyList())
+            .setLogBlocksToBeDeleted(logBlocks).build()));
 
-    setupMocksAndValidateInitialState(rollbackInstantTime, rollbackRequests);
-    List<Pair<String, HoodieRollbackStat>> rollbackStats = rollbackHelper.maybeDeleteAndCollectStats(
-        new HoodieLocalEngineContext(storage.getConf()),
-        INSTANT_GENERATOR.createNewInstant(HoodieInstant.State.INFLIGHT, HoodieTimeline.DELTA_COMMIT_ACTION, instantToRollback),
-        rollbackRequests, true, 5);
-    validateStateAfterRollback(rollbackRequests);
+    when(timeline.lastInstant()).thenReturn(Option.of(
+        INSTANT_GENERATOR.createNewInstant(
+            HoodieInstant.State.INFLIGHT, HoodieTimeline.ROLLBACK_ACTION, rollbackInstantTime)));
 
-    List<Pair<String, HoodieRollbackStat>> expected = new ArrayList<>();
-    expected.add(Pair.of(partition,
-        HoodieRollbackStat.newBuilder().withPartitionPath(partition)
-            .withDeletedFileResult(baseFilePath.toString(), true).build()));
-    getFullLogPathList(logFilesToRollback.keySet(), partition).forEach(logFilePath ->
-        expected.add(Pair.of(partition,
-            HoodieRollbackStat.newBuilder().withPartitionPath(partition)
-                .withDeletedFileResult(logFilePath, true).build())));
-    assertRollbackStatsEquals(expected, rollbackStats);
+    HoodieException ex = assertThrows(HoodieException.class, () ->
+        rollbackHelper.maybeDeleteAndCollectStats(
+            new HoodieLocalEngineContext(storage.getConf()),
+            INSTANT_GENERATOR.createNewInstant(HoodieInstant.State.INFLIGHT,
+                HoodieTimeline.DELTA_COMMIT_ACTION, instantToRollback),
+            rollbackRequests, false, 5));
+    assertTrue(ex.getCause() instanceof IllegalArgumentException);
+    assertTrue(ex.getCause().getMessage().contains("V8+ rollback should not have logBlocksToBeDeleted"));
   }
 
   @Test
@@ -527,47 +575,6 @@ class TestRollbackHelper extends HoodieRollbackTestBase {
   }
 
   @Test
-  void testMaybeDeleteAndCollectStatsDoDeleteFalseForLogBlocks() throws IOException {
-    when(tableConfig.getTableVersion()).thenReturn(HoodieTableVersion.SIX);
-    String rollbackInstantTime = "003";
-    String instantToRollback = "002";
-    RollbackHelperV1 rollbackHelper = new RollbackHelperV1(table, config);
-
-    List<SerializableHoodieRollbackRequest> rollbackRequests = new ArrayList<>();
-    String baseInstantTimeOfLogFiles = "001";
-    String partition = "partition1";
-    String logFileId = UUID.randomUUID().toString();
-    Map<String, Long> logFilesToRollback = addRollbackRequestForLogFiles(
-        rollbackRequests, HoodieTableVersion.SIX, partition, logFileId,
-        baseInstantTimeOfLogFiles, IntStream.range(1, 5));
-
-    setupMocksAndValidateInitialState(rollbackInstantTime, rollbackRequests);
-    List<Pair<String, HoodieRollbackStat>> rollbackStats = rollbackHelper.maybeDeleteAndCollectStats(
-        new HoodieLocalEngineContext(storage.getConf()),
-        rollbackInstantTime,
-        INSTANT_GENERATOR.createNewInstant(HoodieInstant.State.INFLIGHT,
-            HoodieTimeline.DELTA_COMMIT_ACTION, instantToRollback),
-        rollbackRequests, false, 5);
-
-    StoragePath partitionStoragePath = new StoragePath(basePath, partition);
-    for (String logFileName : logFilesToRollback.keySet()) {
-      assertTrue(storage.exists(new StoragePath(partitionStoragePath, logFileName)));
-    }
-
-    StoragePath rollbackLogPath = new StoragePath(partitionStoragePath,
-        FileCreateUtils.logFileName(baseInstantTimeOfLogFiles, logFileId, 4));
-    List<Pair<String, HoodieRollbackStat>> expected = Collections.singletonList(
-        Pair.of(partition,
-            HoodieRollbackStat.newBuilder()
-                .withPartitionPath(partition)
-                .withRollbackBlockAppendResults(Collections.singletonMap(
-                    storage.getPathInfo(rollbackLogPath), 1L))
-                .withLogFilesFromFailedCommit(logFilesToRollback)
-                .build()));
-    assertRollbackStatsEquals(expected, rollbackStats);
-  }
-
-  @Test
   void testPreComputeLogVersionsSkipsInvalidLogFiles() throws Exception {
     when(tableConfig.getTableVersion()).thenReturn(HoodieTableVersion.SIX);
     String partition = "partition1";
@@ -714,42 +721,30 @@ class TestRollbackHelper extends HoodieRollbackTestBase {
 
   @Test
   void testV1MaybeDeleteAndCollectStatsWithSingleRequestPerFileGroup() throws IOException {
-    HoodieTableVersion tableVersion = HoodieTableVersion.SIX;
-    when(tableConfig.getTableVersion()).thenReturn(tableVersion);
+    SingleRequestTestContext ctx = buildSingleRequestScenario(HoodieTableVersion.SIX);
     String rollbackInstantTime = "003";
-    String instantToRollback = "002";
     RollbackHelperV1 rollbackHelper = new RollbackHelperV1(table, config);
 
-    List<SerializableHoodieRollbackRequest> rollbackRequests = new ArrayList<>();
-    String baseInstantTimeOfLogFiles = "001";
-    String partition = "partition1";
-    String baseFileId = UUID.randomUUID().toString();
-    String logFileId = UUID.randomUUID().toString();
-    StoragePath baseFilePath = addRollbackRequestForBaseFile(
-        rollbackRequests, partition, baseFileId, instantToRollback);
-    Map<String, Long> logFilesToRollback = addRollbackRequestForLogFiles(
-        rollbackRequests, tableVersion, partition, logFileId, baseInstantTimeOfLogFiles, IntStream.range(1, ROLLBACK_LOG_VERSION));
-
-    setupMocksAndValidateInitialState(rollbackInstantTime, rollbackRequests);
+    setupMocksAndValidateInitialState(rollbackInstantTime, ctx.rollbackRequests);
     List<Pair<String, HoodieRollbackStat>> rollbackStats = rollbackHelper.maybeDeleteAndCollectStats(
         new HoodieLocalEngineContext(storage.getConf()),
         rollbackInstantTime,
-        INSTANT_GENERATOR.createNewInstant(HoodieInstant.State.INFLIGHT, HoodieTimeline.DELTA_COMMIT_ACTION, instantToRollback),
-        rollbackRequests, true, 5);
-    validateStateAfterRollback(rollbackRequests);
+        INSTANT_GENERATOR.createNewInstant(HoodieInstant.State.INFLIGHT, HoodieTimeline.DELTA_COMMIT_ACTION, ctx.instantToRollback),
+        ctx.rollbackRequests, true, 5);
+    validateStateAfterRollback(ctx.rollbackRequests);
 
-    StoragePath rollbackLogPath = new StoragePath(new StoragePath(basePath, partition),
-        FileCreateUtils.logFileName(baseInstantTimeOfLogFiles, logFileId, ROLLBACK_LOG_VERSION));
+    StoragePath rollbackLogPath = new StoragePath(new StoragePath(basePath, ctx.partition),
+        FileCreateUtils.logFileName(ctx.baseInstantTimeOfLogFiles, ctx.logFileId, ROLLBACK_LOG_VERSION));
 
     List<Pair<String, HoodieRollbackStat>> expected = new ArrayList<>();
-    expected.add(Pair.of(partition,
-        HoodieRollbackStat.newBuilder().withPartitionPath(partition)
-            .withDeletedFileResult(baseFilePath.toString(), true).build()));
-    expected.add(Pair.of(partition,
-        HoodieRollbackStat.newBuilder().withPartitionPath(partition)
+    expected.add(Pair.of(ctx.partition,
+        HoodieRollbackStat.newBuilder().withPartitionPath(ctx.partition)
+            .withDeletedFileResult(ctx.baseFilePath.toString(), true).build()));
+    expected.add(Pair.of(ctx.partition,
+        HoodieRollbackStat.newBuilder().withPartitionPath(ctx.partition)
             .withRollbackBlockAppendResults(Collections.singletonMap(
                 storage.getPathInfo(rollbackLogPath), 1L))
-            .withLogFilesFromFailedCommit(logFilesToRollback).build()));
+            .withLogFilesFromFailedCommit(ctx.logFilesToRollback).build()));
     assertRollbackStatsEquals(expected, rollbackStats);
   }
 

--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/table/action/rollback/TestRollbackHelper.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/table/action/rollback/TestRollbackHelper.java
@@ -576,5 +576,161 @@ class TestRollbackHelper extends HoodieRollbackTestBase {
     Mockito.verify(spiedStorage, Mockito.times(0))
         .listDirectEntries(Mockito.any(StoragePath.class), Mockito.any());
   }
+
+  @Test
+  void testMaybeDeleteAndCollectStatsDoDeleteFalseForLogBlocks() throws IOException {
+    when(tableConfig.getTableVersion()).thenReturn(HoodieTableVersion.SIX);
+    String rollbackInstantTime = "003";
+    String instantToRollback = "002";
+    RollbackHelper rollbackHelper = new RollbackHelper(table, config);
+
+    List<SerializableHoodieRollbackRequest> rollbackRequests = new ArrayList<>();
+    String baseInstantTimeOfLogFiles = "001";
+    String partition = "partition1";
+    String logFileId = UUID.randomUUID().toString();
+    Map<String, Long> logFilesToRollback = addRollbackRequestForLogFiles(
+        rollbackRequests, HoodieTableVersion.SIX, partition, logFileId,
+        baseInstantTimeOfLogFiles, IntStream.range(1, 5));
+
+    setupMocksAndValidateInitialState(rollbackInstantTime, rollbackRequests);
+    List<Pair<String, HoodieRollbackStat>> rollbackStats = rollbackHelper.maybeDeleteAndCollectStats(
+        new HoodieLocalEngineContext(storage.getConf()),
+        INSTANT_GENERATOR.createNewInstant(HoodieInstant.State.INFLIGHT,
+            HoodieTimeline.DELTA_COMMIT_ACTION, instantToRollback),
+        rollbackRequests, false, 5);
+
+    StoragePath partitionStoragePath = new StoragePath(basePath, partition);
+    for (String logFileName : logFilesToRollback.keySet()) {
+      assertTrue(storage.exists(new StoragePath(partitionStoragePath, logFileName)));
+    }
+
+    StoragePath rollbackLogPath = new StoragePath(partitionStoragePath,
+        FileCreateUtils.logFileName(baseInstantTimeOfLogFiles, logFileId, 5));
+    List<Pair<String, HoodieRollbackStat>> expected = Collections.singletonList(
+        Pair.of(partition,
+            HoodieRollbackStat.newBuilder()
+                .withPartitionPath(partition)
+                .withRollbackBlockAppendResults(Collections.singletonMap(
+                    storage.getPathInfo(rollbackLogPath), 1L))
+                .build()));
+    assertRollbackStatsEquals(expected, rollbackStats);
+  }
+
+  @Test
+  void testPreComputeLogVersionsSkipsInvalidLogFiles() throws Exception {
+    when(tableConfig.getTableVersion()).thenReturn(HoodieTableVersion.SIX);
+    String partition = "partition1";
+    String baseInstant = "001";
+
+    createLogFilesToRollback(partition, "fileId-001", baseInstant,
+        IntStream.rangeClosed(1, 2), 10L);
+    StoragePath partitionPath = new StoragePath(basePath, partition);
+    storage.create(new StoragePath(partitionPath, "invalid-file.log.backup")).close();
+
+    Map<String, Long> dummyLogBlocks = new HashMap<>();
+    dummyLogBlocks.put("dummyLogPath", 100L);
+
+    List<SerializableHoodieRollbackRequest> requests = Collections.singletonList(
+        new SerializableHoodieRollbackRequest(
+            HoodieRollbackRequest.newBuilder()
+                .setPartitionPath(partition).setFileId("fileId-001")
+                .setLatestBaseInstant(baseInstant)
+                .setFilesToBeDeleted(Collections.emptyList())
+                .setLogBlocksToBeDeleted(dummyLogBlocks).build()));
+
+    RollbackHelper helper = new RollbackHelper(table, config);
+    Map<String, Pair<Integer, String>> result = helper.preComputeLogVersions(requests);
+
+    assertEquals(1, result.size());
+    assertEquals(2,
+        (int) result.get(RollbackHelper.logVersionLookupKey(partition, "fileId-001", baseInstant)).getLeft());
+  }
+
+  @Test
+  void testPreComputeLogVersionsFallsBackOnIOException() throws Exception {
+    when(tableConfig.getTableVersion()).thenReturn(HoodieTableVersion.SIX);
+    String partition1 = "partition1";
+    String partition2 = "partition2";
+    String baseInstant = "001";
+
+    createLogFilesToRollback(partition1, "fileId-001", baseInstant,
+        IntStream.rangeClosed(1, 3), 10L);
+    createLogFilesToRollback(partition2, "fileId-002", baseInstant,
+        IntStream.of(1), 10L);
+
+    Map<String, Long> dummyLogBlocks = new HashMap<>();
+    dummyLogBlocks.put("dummyLogPath", 100L);
+
+    List<SerializableHoodieRollbackRequest> requests = new ArrayList<>();
+    requests.add(new SerializableHoodieRollbackRequest(
+        HoodieRollbackRequest.newBuilder()
+            .setPartitionPath(partition1).setFileId("fileId-001")
+            .setLatestBaseInstant(baseInstant)
+            .setFilesToBeDeleted(Collections.emptyList())
+            .setLogBlocksToBeDeleted(dummyLogBlocks).build()));
+    requests.add(new SerializableHoodieRollbackRequest(
+        HoodieRollbackRequest.newBuilder()
+            .setPartitionPath(partition2).setFileId("fileId-002")
+            .setLatestBaseInstant(baseInstant)
+            .setFilesToBeDeleted(Collections.emptyList())
+            .setLogBlocksToBeDeleted(dummyLogBlocks).build()));
+
+    HoodieStorage spiedStorage = Mockito.spy(storage);
+    when(metaClient.getStorage()).thenReturn(spiedStorage);
+    StoragePath partition2AbsPath = FSUtils.constructAbsolutePath(basePath, partition2);
+    Mockito.doThrow(new IOException("Simulated listing failure"))
+        .when(spiedStorage)
+        .listDirectEntries(Mockito.eq(partition2AbsPath), Mockito.any());
+
+    RollbackHelper helper = new RollbackHelper(table, config);
+    Map<String, Pair<Integer, String>> result = helper.preComputeLogVersions(requests);
+
+    assertEquals(1, result.size());
+    assertEquals(3,
+        (int) result.get(RollbackHelper.logVersionLookupKey(partition1, "fileId-001", baseInstant)).getLeft());
+    assertFalse(result.containsKey(
+        RollbackHelper.logVersionLookupKey(partition2, "fileId-002", baseInstant)));
+  }
+
+  @Test
+  void testV1MaybeDeleteAndCollectStatsDoDeleteFalseForLogBlocks() throws IOException {
+    when(tableConfig.getTableVersion()).thenReturn(HoodieTableVersion.SIX);
+    String rollbackInstantTime = "003";
+    String instantToRollback = "002";
+    RollbackHelperV1 rollbackHelperV1 = new RollbackHelperV1(table, config);
+
+    List<SerializableHoodieRollbackRequest> rollbackRequests = new ArrayList<>();
+    String baseInstantTimeOfLogFiles = "001";
+    String partition = "partition1";
+    String logFileId = UUID.randomUUID().toString();
+    Map<String, Long> logFilesToRollback = addRollbackRequestForLogFiles(
+        rollbackRequests, HoodieTableVersion.SIX, partition, logFileId,
+        baseInstantTimeOfLogFiles, IntStream.range(1, 5));
+
+    setupMocksAndValidateInitialState(rollbackInstantTime, rollbackRequests);
+    List<Pair<String, HoodieRollbackStat>> rollbackStats = rollbackHelperV1.maybeDeleteAndCollectStats(
+        new HoodieLocalEngineContext(storage.getConf()),
+        rollbackInstantTime,
+        INSTANT_GENERATOR.createNewInstant(HoodieInstant.State.INFLIGHT,
+            HoodieTimeline.DELTA_COMMIT_ACTION, instantToRollback),
+        rollbackRequests, false, 5);
+
+    StoragePath partitionStoragePath = new StoragePath(basePath, partition);
+    for (String logFileName : logFilesToRollback.keySet()) {
+      assertTrue(storage.exists(new StoragePath(partitionStoragePath, logFileName)));
+    }
+
+    StoragePath rollbackLogPath = new StoragePath(partitionStoragePath,
+        FileCreateUtils.logFileName(baseInstantTimeOfLogFiles, logFileId, 5));
+    List<Pair<String, HoodieRollbackStat>> expected = Collections.singletonList(
+        Pair.of(partition,
+            HoodieRollbackStat.newBuilder()
+                .withPartitionPath(partition)
+                .withRollbackBlockAppendResults(Collections.singletonMap(
+                    storage.getPathInfo(rollbackLogPath), 1L))
+                .withLogFilesFromFailedCommit(logFilesToRollback)
+                .build()));
+    assertRollbackStatsEquals(expected, rollbackStats);
+  }
 }
 

--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/table/action/rollback/TestRollbackHelper.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/table/action/rollback/TestRollbackHelper.java
@@ -556,13 +556,14 @@ class TestRollbackHelper extends HoodieRollbackTestBase {
     }
 
     StoragePath rollbackLogPath = new StoragePath(partitionStoragePath,
-        FileCreateUtils.logFileName(baseInstantTimeOfLogFiles, logFileId, 5));
+        FileCreateUtils.logFileName(baseInstantTimeOfLogFiles, logFileId, 4));
     List<Pair<String, HoodieRollbackStat>> expected = Collections.singletonList(
         Pair.of(partition,
             HoodieRollbackStat.newBuilder()
                 .withPartitionPath(partition)
                 .withRollbackBlockAppendResults(Collections.singletonMap(
                     storage.getPathInfo(rollbackLogPath), 1L))
+                .withLogFilesFromFailedCommit(logFilesToRollback)
                 .build()));
     assertRollbackStatsEquals(expected, rollbackStats);
   }
@@ -802,7 +803,7 @@ class TestRollbackHelper extends HoodieRollbackTestBase {
     }
 
     StoragePath rollbackLogPath = new StoragePath(partitionStoragePath,
-        FileCreateUtils.logFileName(baseInstantTimeOfLogFiles, logFileId, 5));
+        FileCreateUtils.logFileName(baseInstantTimeOfLogFiles, logFileId, 4));
     List<Pair<String, HoodieRollbackStat>> expected = Collections.singletonList(
         Pair.of(partition,
             HoodieRollbackStat.newBuilder()

--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/table/action/rollback/TestRollbackHelper.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/table/action/rollback/TestRollbackHelper.java
@@ -24,9 +24,11 @@ import org.apache.hudi.common.HoodieRollbackStat;
 import org.apache.hudi.common.engine.HoodieEngineContext;
 import org.apache.hudi.common.engine.HoodieLocalEngineContext;
 import org.apache.hudi.common.fs.FSUtils;
+import org.apache.hudi.common.model.HoodieLogFile;
 import org.apache.hudi.common.table.HoodieTableConfig;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.common.table.HoodieTableVersion;
+import org.apache.hudi.common.table.log.HoodieLogFormat;
 import org.apache.hudi.common.table.timeline.HoodieInstant;
 import org.apache.hudi.common.table.timeline.HoodieTimeline;
 import org.apache.hudi.common.testutils.FileCreateUtils;
@@ -38,7 +40,6 @@ import org.apache.hudi.exception.HoodieIOException;
 import org.apache.hudi.storage.HoodieStorage;
 import org.apache.hudi.storage.StorageConfiguration;
 import org.apache.hudi.storage.StoragePath;
-import org.apache.hudi.storage.StoragePathInfo;
 import org.apache.hudi.table.HoodieTable;
 
 import lombok.extern.slf4j.Slf4j;
@@ -83,85 +84,91 @@ class TestRollbackHelper extends HoodieRollbackTestBase {
     storage.deleteDirectory(basePath);
   }
 
-  @Test
-  void testMaybeDeleteAndCollectStatsWithMultipleRequestsPerFileGroup() throws IOException {
-    HoodieTableVersion tableVersion = HoodieTableVersion.EIGHT;
-    when(tableConfig.getTableVersion()).thenReturn(tableVersion);
-    String rollbackInstantTime = "003";
-    String instantToRollback = "002";
-    RollbackHelper rollbackHelper = new RollbackHelper(table, config);
+  /**
+   * Holds the test context for multi-request rollback scenarios, shared between V8 and V6 tests.
+   */
+  private static class MultiRequestTestContext {
+    final List<SerializableHoodieRollbackRequest> rollbackRequests = new ArrayList<>();
+    final String partition1 = "partition1";
+    final String partition2 = "partition2";
+    final String baseInstantTimeOfLogFiles = "001";
+    final String instantToRollback = "002";
+    String logFileId1;
+    String logFileId2;
+    StoragePath baseFilePath1;
+    StoragePath baseFilePath2;
+    StoragePath baseFilePath3;
+    Map<String, Long> logFilesToRollback1;
+    Map<String, Long> logFilesToRollback2;
+  }
 
-    List<SerializableHoodieRollbackRequest> rollbackRequests = new ArrayList<>();
-    String baseInstantTimeOfLogFiles = "001";
-    String partition1 = "partition1";
-    String partition2 = "partition2";
+  private MultiRequestTestContext buildMultiRequestScenario(HoodieTableVersion tableVersion) throws IOException {
+    when(tableConfig.getTableVersion()).thenReturn(tableVersion);
+    MultiRequestTestContext ctx = new MultiRequestTestContext();
     String baseFileId1 = UUID.randomUUID().toString();
     String baseFileId2 = UUID.randomUUID().toString();
     String baseFileId3 = UUID.randomUUID().toString();
-    String logFileId1 = UUID.randomUUID().toString();
-    String logFileId2 = UUID.randomUUID().toString();
-    // Base files to roll back
-    StoragePath baseFilePath1 = addRollbackRequestForBaseFile(rollbackRequests, partition1, baseFileId1, instantToRollback);
-    StoragePath baseFilePath2 = addRollbackRequestForBaseFile(rollbackRequests, partition2, baseFileId2, instantToRollback);
-    StoragePath baseFilePath3 = addRollbackRequestForBaseFile(rollbackRequests, partition2, baseFileId3, instantToRollback);
-    // Log files to roll back
-    Map<String, Long> logFilesToRollback1 = addRollbackRequestForLogFiles(
-        rollbackRequests, tableVersion, partition2, logFileId1, baseInstantTimeOfLogFiles, IntStream.of(1));
-    // Multiple rollback requests of log files belonging to the same file group
-    Map<String, Long> logFilesToRollback2 = IntStream.range(1, ROLLBACK_LOG_VERSION).boxed()
+    ctx.logFileId1 = UUID.randomUUID().toString();
+    ctx.logFileId2 = UUID.randomUUID().toString();
+
+    ctx.baseFilePath1 = addRollbackRequestForBaseFile(ctx.rollbackRequests, ctx.partition1, baseFileId1, ctx.instantToRollback);
+    ctx.baseFilePath2 = addRollbackRequestForBaseFile(ctx.rollbackRequests, ctx.partition2, baseFileId2, ctx.instantToRollback);
+    ctx.baseFilePath3 = addRollbackRequestForBaseFile(ctx.rollbackRequests, ctx.partition2, baseFileId3, ctx.instantToRollback);
+    ctx.logFilesToRollback1 = addRollbackRequestForLogFiles(
+        ctx.rollbackRequests, tableVersion, ctx.partition2, ctx.logFileId1, ctx.baseInstantTimeOfLogFiles, IntStream.of(1));
+    ctx.logFilesToRollback2 = IntStream.range(1, ROLLBACK_LOG_VERSION).boxed()
         .flatMap(version -> addRollbackRequestForLogFiles(
-            rollbackRequests, tableVersion, partition2, logFileId2, baseInstantTimeOfLogFiles, IntStream.of(version))
+            ctx.rollbackRequests, tableVersion, ctx.partition2, ctx.logFileId2, ctx.baseInstantTimeOfLogFiles, IntStream.of(version))
             .entrySet().stream())
         .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
-    // Empty rollback request
-    rollbackRequests.add(new SerializableHoodieRollbackRequest(
+    ctx.rollbackRequests.add(new SerializableHoodieRollbackRequest(
         HoodieRollbackRequest.newBuilder()
-            .setPartitionPath(partition2)
+            .setPartitionPath(ctx.partition2)
             .setFileId(baseFileId3)
-            .setLatestBaseInstant(instantToRollback)
+            .setLatestBaseInstant(ctx.instantToRollback)
             .setFilesToBeDeleted(Collections.emptyList())
             .setLogBlocksToBeDeleted(Collections.emptyMap()).build()));
+    return ctx;
+  }
 
-    setupMocksAndValidateInitialState(rollbackInstantTime, rollbackRequests);
+  private List<Pair<String, HoodieRollbackStat>> buildExpectedBaseFileStats(MultiRequestTestContext ctx) {
+    List<Pair<String, HoodieRollbackStat>> expected = new ArrayList<>();
+    expected.add(Pair.of(ctx.partition1,
+        HoodieRollbackStat.newBuilder().withPartitionPath(ctx.partition1)
+            .withDeletedFileResult(ctx.baseFilePath1.toString(), true).build()));
+    expected.add(Pair.of(ctx.partition2,
+        HoodieRollbackStat.newBuilder().withPartitionPath(ctx.partition2)
+            .withDeletedFileResult(ctx.baseFilePath2.toString(), true).build()));
+    expected.add(Pair.of(ctx.partition2,
+        HoodieRollbackStat.newBuilder().withPartitionPath(ctx.partition2)
+            .withDeletedFileResult(ctx.baseFilePath3.toString(), true).build()));
+    return expected;
+  }
+
+  @Test
+  void testMaybeDeleteAndCollectStatsWithMultipleRequestsPerFileGroup() throws IOException {
+    MultiRequestTestContext ctx = buildMultiRequestScenario(HoodieTableVersion.EIGHT);
+    String rollbackInstantTime = "003";
+    RollbackHelper rollbackHelper = new RollbackHelper(table, config);
+
+    setupMocksAndValidateInitialState(rollbackInstantTime, ctx.rollbackRequests);
     List<Pair<String, HoodieRollbackStat>> rollbackStats = rollbackHelper.maybeDeleteAndCollectStats(
         new HoodieLocalEngineContext(storage.getConf()),
-        INSTANT_GENERATOR.createNewInstant(HoodieInstant.State.INFLIGHT, HoodieTimeline.DELTA_COMMIT_ACTION, instantToRollback),
-        rollbackRequests, true, 5);
-    validateStateAfterRollback(rollbackRequests);
-    List<Pair<String, HoodieRollbackStat>> expected = new ArrayList<>();
-    expected.add(Pair.of(partition1,
-        HoodieRollbackStat.newBuilder()
-            .withPartitionPath(partition1)
-            .withDeletedFileResult(baseFilePath1.toString(), true)
-            .build()));
-    expected.add(Pair.of(partition2,
-        HoodieRollbackStat.newBuilder()
-            .withPartitionPath(partition2)
-            .withDeletedFileResult(baseFilePath2.toString(), true)
-            .build()));
-    expected.add(Pair.of(partition2,
-        HoodieRollbackStat.newBuilder()
-            .withPartitionPath(partition2)
-            .withDeletedFileResult(baseFilePath3.toString(), true)
-            .build()));
-    getFullLogPathList(logFilesToRollback1.keySet(), partition2).forEach(logFilePath -> {
-      expected.add(Pair.of(partition2,
-          HoodieRollbackStat.newBuilder()
-              .withPartitionPath(partition2)
-              .withDeletedFileResult(logFilePath, true)
-              .build()));
-    });
-    getFullLogPathList(logFilesToRollback2.keySet(), partition2).forEach(logFilePath -> {
-      expected.add(Pair.of(partition2,
-          HoodieRollbackStat.newBuilder()
-              .withPartitionPath(partition2)
-              .withDeletedFileResult(logFilePath, true)
-              .build()));
-    });
-    expected.add(Pair.of(partition2,
-        HoodieRollbackStat.newBuilder()
-            .withPartitionPath(partition2)
-            .build()));
+        INSTANT_GENERATOR.createNewInstant(HoodieInstant.State.INFLIGHT, HoodieTimeline.DELTA_COMMIT_ACTION, ctx.instantToRollback),
+        ctx.rollbackRequests, true, 5);
+    validateStateAfterRollback(ctx.rollbackRequests);
+
+    List<Pair<String, HoodieRollbackStat>> expected = buildExpectedBaseFileStats(ctx);
+    getFullLogPathList(ctx.logFilesToRollback1.keySet(), ctx.partition2).forEach(logFilePath ->
+        expected.add(Pair.of(ctx.partition2,
+            HoodieRollbackStat.newBuilder().withPartitionPath(ctx.partition2)
+                .withDeletedFileResult(logFilePath, true).build())));
+    getFullLogPathList(ctx.logFilesToRollback2.keySet(), ctx.partition2).forEach(logFilePath ->
+        expected.add(Pair.of(ctx.partition2,
+            HoodieRollbackStat.newBuilder().withPartitionPath(ctx.partition2)
+                .withDeletedFileResult(logFilePath, true).build())));
+    expected.add(Pair.of(ctx.partition2,
+        HoodieRollbackStat.newBuilder().withPartitionPath(ctx.partition2).build()));
     assertRollbackStatsEquals(expected, rollbackStats);
   }
 
@@ -174,16 +181,13 @@ class TestRollbackHelper extends HoodieRollbackTestBase {
     RollbackHelper rollbackHelper = new RollbackHelper(table, config);
 
     List<SerializableHoodieRollbackRequest> rollbackRequests = new ArrayList<>();
-    String baseInstantTimeOfLogFiles = "001";
     String partition = "partition1";
     String baseFileId = UUID.randomUUID().toString();
     String logFileId = UUID.randomUUID().toString();
-    // Base files to roll back
     StoragePath baseFilePath = addRollbackRequestForBaseFile(
         rollbackRequests, partition, baseFileId, instantToRollback);
-    // A single rollback request of log files belonging to the same file group
     Map<String, Long> logFilesToRollback = addRollbackRequestForLogFiles(
-        rollbackRequests, tableVersion, partition, logFileId, baseInstantTimeOfLogFiles, IntStream.range(1, ROLLBACK_LOG_VERSION));
+        rollbackRequests, tableVersion, partition, logFileId, "001", IntStream.range(1, ROLLBACK_LOG_VERSION));
 
     setupMocksAndValidateInitialState(rollbackInstantTime, rollbackRequests);
     List<Pair<String, HoodieRollbackStat>> rollbackStats = rollbackHelper.maybeDeleteAndCollectStats(
@@ -191,20 +195,15 @@ class TestRollbackHelper extends HoodieRollbackTestBase {
         INSTANT_GENERATOR.createNewInstant(HoodieInstant.State.INFLIGHT, HoodieTimeline.DELTA_COMMIT_ACTION, instantToRollback),
         rollbackRequests, true, 5);
     validateStateAfterRollback(rollbackRequests);
+
     List<Pair<String, HoodieRollbackStat>> expected = new ArrayList<>();
     expected.add(Pair.of(partition,
-        HoodieRollbackStat.newBuilder()
-            .withPartitionPath(partition)
-            .withDeletedFileResult(baseFilePath.toString(), true)
-            .build()
-    ));
-    getFullLogPathList(logFilesToRollback.keySet(), partition).forEach(logFilePath -> {
-      expected.add(Pair.of(partition,
-          HoodieRollbackStat.newBuilder()
-              .withPartitionPath(partition)
-              .withDeletedFileResult(logFilePath, true)
-              .build()));
-    });
+        HoodieRollbackStat.newBuilder().withPartitionPath(partition)
+            .withDeletedFileResult(baseFilePath.toString(), true).build()));
+    getFullLogPathList(logFilesToRollback.keySet(), partition).forEach(logFilePath ->
+        expected.add(Pair.of(partition,
+            HoodieRollbackStat.newBuilder().withPartitionPath(partition)
+                .withDeletedFileResult(logFilePath, true).build())));
     assertRollbackStatsEquals(expected, rollbackStats);
   }
 
@@ -485,7 +484,7 @@ class TestRollbackHelper extends HoodieRollbackTestBase {
     HoodieStorage spiedStorage = Mockito.spy(storage);
     when(metaClient.getStorage()).thenReturn(spiedStorage);
 
-    RollbackHelper helper = new RollbackHelper(table, config);
+    RollbackHelperV1 helper = new RollbackHelperV1(table, config);
     Map<String, Pair<Integer, String>> result = helper.preComputeLogVersions(requests);
 
     // Two listing calls: one per partition (not one per log file)
@@ -493,9 +492,9 @@ class TestRollbackHelper extends HoodieRollbackTestBase {
         .listDirectEntries(Mockito.any(StoragePath.class), Mockito.any());
 
     assertEquals(3, result.size());
-    assertEquals(3, (int) result.get(RollbackHelper.logVersionLookupKey(partition1, "fileId-001", baseInstant)).getLeft());
-    assertEquals(1, (int) result.get(RollbackHelper.logVersionLookupKey(partition1, "fileId-002", baseInstant)).getLeft());
-    assertEquals(2, (int) result.get(RollbackHelper.logVersionLookupKey(partition2, "fileId-003", baseInstant)).getLeft());
+    assertEquals(3, (int) result.get(RollbackHelperV1.logVersionLookupKey(partition1, "fileId-001", baseInstant)).getLeft());
+    assertEquals(1, (int) result.get(RollbackHelperV1.logVersionLookupKey(partition1, "fileId-002", baseInstant)).getLeft());
+    assertEquals(2, (int) result.get(RollbackHelperV1.logVersionLookupKey(partition2, "fileId-003", baseInstant)).getLeft());
   }
 
   @Test
@@ -519,7 +518,7 @@ class TestRollbackHelper extends HoodieRollbackTestBase {
     HoodieStorage spiedStorage = Mockito.spy(storage);
     when(metaClient.getStorage()).thenReturn(spiedStorage);
 
-    RollbackHelper helper = new RollbackHelper(table, config);
+    RollbackHelperV1 helper = new RollbackHelperV1(table, config);
     Map<String, Pair<Integer, String>> result = helper.preComputeLogVersions(requests);
 
     assertTrue(result.isEmpty());
@@ -590,12 +589,12 @@ class TestRollbackHelper extends HoodieRollbackTestBase {
                 .setFilesToBeDeleted(Collections.emptyList())
                 .setLogBlocksToBeDeleted(dummyLogBlocks).build()));
 
-    RollbackHelper helper = new RollbackHelper(table, config);
+    RollbackHelperV1 helper = new RollbackHelperV1(table, config);
     Map<String, Pair<Integer, String>> result = helper.preComputeLogVersions(requests);
 
     assertEquals(1, result.size());
     assertEquals(2,
-        (int) result.get(RollbackHelper.logVersionLookupKey(partition, "fileId-001", baseInstant)).getLeft());
+        (int) result.get(RollbackHelperV1.logVersionLookupKey(partition, "fileId-001", baseInstant)).getLeft());
   }
 
   @Test
@@ -634,98 +633,82 @@ class TestRollbackHelper extends HoodieRollbackTestBase {
         .when(spiedStorage)
         .listDirectEntries(Mockito.eq(partition2AbsPath), Mockito.any());
 
-    RollbackHelper helper = new RollbackHelper(table, config);
+    RollbackHelperV1 helper = new RollbackHelperV1(table, config);
     Map<String, Pair<Integer, String>> result = helper.preComputeLogVersions(requests);
 
     assertEquals(1, result.size());
     assertEquals(3,
-        (int) result.get(RollbackHelper.logVersionLookupKey(partition1, "fileId-001", baseInstant)).getLeft());
+        (int) result.get(RollbackHelperV1.logVersionLookupKey(partition1, "fileId-001", baseInstant)).getLeft());
     assertFalse(result.containsKey(
-        RollbackHelper.logVersionLookupKey(partition2, "fileId-002", baseInstant)));
+        RollbackHelperV1.logVersionLookupKey(partition2, "fileId-002", baseInstant)));
+  }
+
+  @Test
+  void testPreComputeLogVersionsSentinelForMissingFileGroups() throws Exception {
+    when(tableConfig.getTableVersion()).thenReturn(HoodieTableVersion.SIX);
+    String partition = "partition1";
+    String baseInstant = "001";
+
+    createLogFilesToRollback(partition, "fileId-001", baseInstant,
+        IntStream.of(1), 10L);
+
+    Map<String, Long> dummyLogBlocks = new HashMap<>();
+    dummyLogBlocks.put("dummyLogPath", 100L);
+
+    List<SerializableHoodieRollbackRequest> requests = new ArrayList<>();
+    requests.add(new SerializableHoodieRollbackRequest(
+        HoodieRollbackRequest.newBuilder()
+            .setPartitionPath(partition).setFileId("fileId-001").setLatestBaseInstant(baseInstant)
+            .setFilesToBeDeleted(Collections.emptyList()).setLogBlocksToBeDeleted(dummyLogBlocks).build()));
+    requests.add(new SerializableHoodieRollbackRequest(
+        HoodieRollbackRequest.newBuilder()
+            .setPartitionPath(partition).setFileId("fileId-no-logs").setLatestBaseInstant(baseInstant)
+            .setFilesToBeDeleted(Collections.emptyList()).setLogBlocksToBeDeleted(dummyLogBlocks).build()));
+
+    RollbackHelperV1 helper = new RollbackHelperV1(table, config);
+    Map<String, Pair<Integer, String>> result = helper.preComputeLogVersions(requests);
+
+    assertEquals(2, result.size());
+    assertEquals(1, (int) result.get(
+        RollbackHelperV1.logVersionLookupKey(partition, "fileId-001", baseInstant)).getLeft());
+    String missingKey = RollbackHelperV1.logVersionLookupKey(partition, "fileId-no-logs", baseInstant);
+    assertTrue(result.containsKey(missingKey));
+    assertEquals(HoodieLogFile.LOGFILE_BASE_VERSION, (int) result.get(missingKey).getLeft());
+    assertEquals(HoodieLogFormat.UNKNOWN_WRITE_TOKEN, result.get(missingKey).getRight());
   }
 
   @Test
   void testV1MaybeDeleteAndCollectStatsWithMultipleRequestsPerFileGroup() throws IOException {
-    HoodieTableVersion tableVersion = HoodieTableVersion.SIX;
-    when(tableConfig.getTableVersion()).thenReturn(tableVersion);
+    MultiRequestTestContext ctx = buildMultiRequestScenario(HoodieTableVersion.SIX);
     String rollbackInstantTime = "003";
-    String instantToRollback = "002";
     RollbackHelperV1 rollbackHelper = new RollbackHelperV1(table, config);
 
-    List<SerializableHoodieRollbackRequest> rollbackRequests = new ArrayList<>();
-    String baseInstantTimeOfLogFiles = "001";
-    String partition1 = "partition1";
-    String partition2 = "partition2";
-    String baseFileId1 = UUID.randomUUID().toString();
-    String baseFileId2 = UUID.randomUUID().toString();
-    String baseFileId3 = UUID.randomUUID().toString();
-    String logFileId1 = UUID.randomUUID().toString();
-    String logFileId2 = UUID.randomUUID().toString();
-    StoragePath baseFilePath1 = addRollbackRequestForBaseFile(rollbackRequests, partition1, baseFileId1, instantToRollback);
-    StoragePath baseFilePath2 = addRollbackRequestForBaseFile(rollbackRequests, partition2, baseFileId2, instantToRollback);
-    StoragePath baseFilePath3 = addRollbackRequestForBaseFile(rollbackRequests, partition2, baseFileId3, instantToRollback);
-    Map<String, Long> logFilesToRollback1 = addRollbackRequestForLogFiles(
-        rollbackRequests, tableVersion, partition2, logFileId1, baseInstantTimeOfLogFiles, IntStream.of(1));
-    Map<String, Long> logFilesToRollback2 = IntStream.range(1, ROLLBACK_LOG_VERSION).boxed()
-        .flatMap(version -> addRollbackRequestForLogFiles(
-            rollbackRequests, tableVersion, partition2, logFileId2, baseInstantTimeOfLogFiles, IntStream.of(version))
-            .entrySet().stream())
-        .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
-    rollbackRequests.add(new SerializableHoodieRollbackRequest(
-        HoodieRollbackRequest.newBuilder()
-            .setPartitionPath(partition2)
-            .setFileId(baseFileId3)
-            .setLatestBaseInstant(instantToRollback)
-            .setFilesToBeDeleted(Collections.emptyList())
-            .setLogBlocksToBeDeleted(Collections.emptyMap()).build()));
-
-    setupMocksAndValidateInitialState(rollbackInstantTime, rollbackRequests);
+    setupMocksAndValidateInitialState(rollbackInstantTime, ctx.rollbackRequests);
     List<Pair<String, HoodieRollbackStat>> rollbackStats = rollbackHelper.maybeDeleteAndCollectStats(
         new HoodieLocalEngineContext(storage.getConf()),
         rollbackInstantTime,
-        INSTANT_GENERATOR.createNewInstant(HoodieInstant.State.INFLIGHT, HoodieTimeline.DELTA_COMMIT_ACTION, instantToRollback),
-        rollbackRequests, true, 5);
-    validateStateAfterRollback(rollbackRequests);
+        INSTANT_GENERATOR.createNewInstant(HoodieInstant.State.INFLIGHT, HoodieTimeline.DELTA_COMMIT_ACTION, ctx.instantToRollback),
+        ctx.rollbackRequests, true, 5);
+    validateStateAfterRollback(ctx.rollbackRequests);
 
-    StoragePath rollbackLogPath1 = new StoragePath(new StoragePath(basePath, partition2),
-        FileCreateUtils.logFileName(baseInstantTimeOfLogFiles, logFileId1, 2));
-    StoragePath rollbackLogPath2 = new StoragePath(new StoragePath(basePath, partition2),
-        FileCreateUtils.logFileName(baseInstantTimeOfLogFiles, logFileId2, ROLLBACK_LOG_VERSION));
+    StoragePath rollbackLogPath1 = new StoragePath(new StoragePath(basePath, ctx.partition2),
+        FileCreateUtils.logFileName(ctx.baseInstantTimeOfLogFiles, ctx.logFileId1, 2));
+    StoragePath rollbackLogPath2 = new StoragePath(new StoragePath(basePath, ctx.partition2),
+        FileCreateUtils.logFileName(ctx.baseInstantTimeOfLogFiles, ctx.logFileId2, ROLLBACK_LOG_VERSION));
 
-    List<Pair<String, HoodieRollbackStat>> expected = new ArrayList<>();
-    expected.add(Pair.of(partition1,
-        HoodieRollbackStat.newBuilder()
-            .withPartitionPath(partition1)
-            .withDeletedFileResult(baseFilePath1.toString(), true)
-            .build()));
-    expected.add(Pair.of(partition2,
-        HoodieRollbackStat.newBuilder()
-            .withPartitionPath(partition2)
-            .withDeletedFileResult(baseFilePath2.toString(), true)
-            .build()));
-    expected.add(Pair.of(partition2,
-        HoodieRollbackStat.newBuilder()
-            .withPartitionPath(partition2)
-            .withDeletedFileResult(baseFilePath3.toString(), true)
-            .build()));
-    expected.add(Pair.of(partition2,
-        HoodieRollbackStat.newBuilder()
-            .withPartitionPath(partition2)
+    List<Pair<String, HoodieRollbackStat>> expected = buildExpectedBaseFileStats(ctx);
+    expected.add(Pair.of(ctx.partition2,
+        HoodieRollbackStat.newBuilder().withPartitionPath(ctx.partition2)
             .withRollbackBlockAppendResults(Collections.singletonMap(
-                new StoragePathInfo(rollbackLogPath1, 0L, false, (short) 0, 0, 0), 1L))
-            .withLogFilesFromFailedCommit(logFilesToRollback1)
-            .build()));
-    expected.add(Pair.of(partition2,
-        HoodieRollbackStat.newBuilder()
-            .withPartitionPath(partition2)
+                storage.getPathInfo(rollbackLogPath1), 1L))
+            .withLogFilesFromFailedCommit(ctx.logFilesToRollback1).build()));
+    expected.add(Pair.of(ctx.partition2,
+        HoodieRollbackStat.newBuilder().withPartitionPath(ctx.partition2)
             .withRollbackBlockAppendResults(Collections.singletonMap(
-                new StoragePathInfo(rollbackLogPath2, 0L, false, (short) 0, 0, 0), 1L))
-            .withLogFilesFromFailedCommit(logFilesToRollback2)
-            .build()));
-    expected.add(Pair.of(partition2,
-        HoodieRollbackStat.newBuilder()
-            .withPartitionPath(partition2)
-            .build()));
+                storage.getPathInfo(rollbackLogPath2), 1L))
+            .withLogFilesFromFailedCommit(ctx.logFilesToRollback2).build()));
+    expected.add(Pair.of(ctx.partition2,
+        HoodieRollbackStat.newBuilder().withPartitionPath(ctx.partition2).build()));
     assertRollbackStatsEquals(expected, rollbackStats);
   }
 
@@ -760,17 +743,13 @@ class TestRollbackHelper extends HoodieRollbackTestBase {
 
     List<Pair<String, HoodieRollbackStat>> expected = new ArrayList<>();
     expected.add(Pair.of(partition,
-        HoodieRollbackStat.newBuilder()
-            .withPartitionPath(partition)
-            .withDeletedFileResult(baseFilePath.toString(), true)
-            .build()));
+        HoodieRollbackStat.newBuilder().withPartitionPath(partition)
+            .withDeletedFileResult(baseFilePath.toString(), true).build()));
     expected.add(Pair.of(partition,
-        HoodieRollbackStat.newBuilder()
-            .withPartitionPath(partition)
+        HoodieRollbackStat.newBuilder().withPartitionPath(partition)
             .withRollbackBlockAppendResults(Collections.singletonMap(
-                new StoragePathInfo(rollbackLogPath, 0L, false, (short) 0, 0, 0), 1L))
-            .withLogFilesFromFailedCommit(logFilesToRollback)
-            .build()));
+                storage.getPathInfo(rollbackLogPath), 1L))
+            .withLogFilesFromFailedCommit(logFilesToRollback).build()));
     assertRollbackStatsEquals(expected, rollbackStats);
   }
 

--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/table/action/rollback/TestRollbackHelper.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/table/action/rollback/TestRollbackHelper.java
@@ -48,6 +48,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.Mockito;
 
 import java.io.FileNotFoundException;
 import java.io.IOException;
@@ -55,6 +56,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -497,6 +499,82 @@ class TestRollbackHelper extends HoodieRollbackTestBase {
         }).reduce(Boolean::logicalAnd).get());
       }
     });
+  }
+
+  @Test
+  void testPreComputeLogVersionsListsOncePerPartition() throws Exception {
+    when(tableConfig.getTableVersion()).thenReturn(HoodieTableVersion.SIX);
+    String partition1 = "partition1";
+    String partition2 = "partition2";
+    String baseInstant = "001";
+
+    // fileId-001 in partition1 with three log file versions
+    createLogFilesToRollback(partition1, "fileId-001", baseInstant, IntStream.rangeClosed(1, 3), 10L);
+    // fileId-002 in partition1 with one log file version
+    createLogFilesToRollback(partition1, "fileId-002", baseInstant, IntStream.of(1), 10L);
+    // fileId-003 in partition2 with two log file versions
+    createLogFilesToRollback(partition2, "fileId-003", baseInstant, IntStream.rangeClosed(1, 2), 10L);
+
+    Map<String, Long> dummyLogBlocks = new HashMap<>();
+    dummyLogBlocks.put("dummyLogPath", 100L);
+
+    List<SerializableHoodieRollbackRequest> requests = new ArrayList<>();
+    requests.add(new SerializableHoodieRollbackRequest(
+        HoodieRollbackRequest.newBuilder()
+            .setPartitionPath(partition1).setFileId("fileId-001").setLatestBaseInstant(baseInstant)
+            .setFilesToBeDeleted(Collections.emptyList()).setLogBlocksToBeDeleted(dummyLogBlocks).build()));
+    requests.add(new SerializableHoodieRollbackRequest(
+        HoodieRollbackRequest.newBuilder()
+            .setPartitionPath(partition1).setFileId("fileId-002").setLatestBaseInstant(baseInstant)
+            .setFilesToBeDeleted(Collections.emptyList()).setLogBlocksToBeDeleted(dummyLogBlocks).build()));
+    requests.add(new SerializableHoodieRollbackRequest(
+        HoodieRollbackRequest.newBuilder()
+            .setPartitionPath(partition2).setFileId("fileId-003").setLatestBaseInstant(baseInstant)
+            .setFilesToBeDeleted(Collections.emptyList()).setLogBlocksToBeDeleted(dummyLogBlocks).build()));
+
+    HoodieStorage spiedStorage = Mockito.spy(storage);
+    when(metaClient.getStorage()).thenReturn(spiedStorage);
+
+    RollbackHelper helper = new RollbackHelper(table, config);
+    Map<String, Pair<Integer, String>> result = helper.preComputeLogVersions(requests);
+
+    // Two listing calls: one per partition (not one per log file)
+    Mockito.verify(spiedStorage, Mockito.times(2))
+        .listDirectEntries(Mockito.any(StoragePath.class), Mockito.any());
+
+    assertEquals(3, result.size());
+    assertEquals(3, (int) result.get(RollbackHelper.logVersionLookupKey(partition1, "fileId-001", baseInstant)).getLeft());
+    assertEquals(1, (int) result.get(RollbackHelper.logVersionLookupKey(partition1, "fileId-002", baseInstant)).getLeft());
+    assertEquals(2, (int) result.get(RollbackHelper.logVersionLookupKey(partition2, "fileId-003", baseInstant)).getLeft());
+  }
+
+  @Test
+  void testPreComputeLogVersionsEmptyWhenNoLogBlockRequests() throws Exception {
+    when(tableConfig.getTableVersion()).thenReturn(HoodieTableVersion.SIX);
+    String partition1 = "partition1";
+    String partition2 = "partition2";
+
+    List<SerializableHoodieRollbackRequest> requests = new ArrayList<>();
+    requests.add(new SerializableHoodieRollbackRequest(
+        HoodieRollbackRequest.newBuilder()
+            .setPartitionPath(partition1).setFileId("fileId-001").setLatestBaseInstant("001")
+            .setFilesToBeDeleted(Collections.singletonList("/some/file/to/delete"))
+            .setLogBlocksToBeDeleted(Collections.emptyMap()).build()));
+    requests.add(new SerializableHoodieRollbackRequest(
+        HoodieRollbackRequest.newBuilder()
+            .setPartitionPath(partition2).setFileId("fileId-002").setLatestBaseInstant("001")
+            .setFilesToBeDeleted(Collections.singletonList("/another/file"))
+            .setLogBlocksToBeDeleted(Collections.emptyMap()).build()));
+
+    HoodieStorage spiedStorage = Mockito.spy(storage);
+    when(metaClient.getStorage()).thenReturn(spiedStorage);
+
+    RollbackHelper helper = new RollbackHelper(table, config);
+    Map<String, Pair<Integer, String>> result = helper.preComputeLogVersions(requests);
+
+    assertTrue(result.isEmpty());
+    Mockito.verify(spiedStorage, Mockito.times(0))
+        .listDirectEntries(Mockito.any(StoragePath.class), Mockito.any());
   }
 }
 

--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/table/action/rollback/TestRollbackHelper.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/table/action/rollback/TestRollbackHelper.java
@@ -38,6 +38,7 @@ import org.apache.hudi.exception.HoodieIOException;
 import org.apache.hudi.storage.HoodieStorage;
 import org.apache.hudi.storage.StorageConfiguration;
 import org.apache.hudi.storage.StoragePath;
+import org.apache.hudi.storage.StoragePathInfo;
 import org.apache.hudi.table.HoodieTable;
 
 import lombok.extern.slf4j.Slf4j;
@@ -640,6 +641,136 @@ class TestRollbackHelper extends HoodieRollbackTestBase {
         (int) result.get(RollbackHelper.logVersionLookupKey(partition1, "fileId-001", baseInstant)).getLeft());
     assertFalse(result.containsKey(
         RollbackHelper.logVersionLookupKey(partition2, "fileId-002", baseInstant)));
+  }
+
+  @Test
+  void testV1MaybeDeleteAndCollectStatsWithMultipleRequestsPerFileGroup() throws IOException {
+    HoodieTableVersion tableVersion = HoodieTableVersion.SIX;
+    when(tableConfig.getTableVersion()).thenReturn(tableVersion);
+    String rollbackInstantTime = "003";
+    String instantToRollback = "002";
+    RollbackHelperV1 rollbackHelper = new RollbackHelperV1(table, config);
+
+    List<SerializableHoodieRollbackRequest> rollbackRequests = new ArrayList<>();
+    String baseInstantTimeOfLogFiles = "001";
+    String partition1 = "partition1";
+    String partition2 = "partition2";
+    String baseFileId1 = UUID.randomUUID().toString();
+    String baseFileId2 = UUID.randomUUID().toString();
+    String baseFileId3 = UUID.randomUUID().toString();
+    String logFileId1 = UUID.randomUUID().toString();
+    String logFileId2 = UUID.randomUUID().toString();
+    StoragePath baseFilePath1 = addRollbackRequestForBaseFile(rollbackRequests, partition1, baseFileId1, instantToRollback);
+    StoragePath baseFilePath2 = addRollbackRequestForBaseFile(rollbackRequests, partition2, baseFileId2, instantToRollback);
+    StoragePath baseFilePath3 = addRollbackRequestForBaseFile(rollbackRequests, partition2, baseFileId3, instantToRollback);
+    Map<String, Long> logFilesToRollback1 = addRollbackRequestForLogFiles(
+        rollbackRequests, tableVersion, partition2, logFileId1, baseInstantTimeOfLogFiles, IntStream.of(1));
+    Map<String, Long> logFilesToRollback2 = IntStream.range(1, ROLLBACK_LOG_VERSION).boxed()
+        .flatMap(version -> addRollbackRequestForLogFiles(
+            rollbackRequests, tableVersion, partition2, logFileId2, baseInstantTimeOfLogFiles, IntStream.of(version))
+            .entrySet().stream())
+        .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+    rollbackRequests.add(new SerializableHoodieRollbackRequest(
+        HoodieRollbackRequest.newBuilder()
+            .setPartitionPath(partition2)
+            .setFileId(baseFileId3)
+            .setLatestBaseInstant(instantToRollback)
+            .setFilesToBeDeleted(Collections.emptyList())
+            .setLogBlocksToBeDeleted(Collections.emptyMap()).build()));
+
+    setupMocksAndValidateInitialState(rollbackInstantTime, rollbackRequests);
+    List<Pair<String, HoodieRollbackStat>> rollbackStats = rollbackHelper.maybeDeleteAndCollectStats(
+        new HoodieLocalEngineContext(storage.getConf()),
+        rollbackInstantTime,
+        INSTANT_GENERATOR.createNewInstant(HoodieInstant.State.INFLIGHT, HoodieTimeline.DELTA_COMMIT_ACTION, instantToRollback),
+        rollbackRequests, true, 5);
+    validateStateAfterRollback(rollbackRequests);
+
+    StoragePath rollbackLogPath1 = new StoragePath(new StoragePath(basePath, partition2),
+        FileCreateUtils.logFileName(baseInstantTimeOfLogFiles, logFileId1, 2));
+    StoragePath rollbackLogPath2 = new StoragePath(new StoragePath(basePath, partition2),
+        FileCreateUtils.logFileName(baseInstantTimeOfLogFiles, logFileId2, ROLLBACK_LOG_VERSION));
+
+    List<Pair<String, HoodieRollbackStat>> expected = new ArrayList<>();
+    expected.add(Pair.of(partition1,
+        HoodieRollbackStat.newBuilder()
+            .withPartitionPath(partition1)
+            .withDeletedFileResult(baseFilePath1.toString(), true)
+            .build()));
+    expected.add(Pair.of(partition2,
+        HoodieRollbackStat.newBuilder()
+            .withPartitionPath(partition2)
+            .withDeletedFileResult(baseFilePath2.toString(), true)
+            .build()));
+    expected.add(Pair.of(partition2,
+        HoodieRollbackStat.newBuilder()
+            .withPartitionPath(partition2)
+            .withDeletedFileResult(baseFilePath3.toString(), true)
+            .build()));
+    expected.add(Pair.of(partition2,
+        HoodieRollbackStat.newBuilder()
+            .withPartitionPath(partition2)
+            .withRollbackBlockAppendResults(Collections.singletonMap(
+                new StoragePathInfo(rollbackLogPath1, 0L, false, (short) 0, 0, 0), 1L))
+            .withLogFilesFromFailedCommit(logFilesToRollback1)
+            .build()));
+    expected.add(Pair.of(partition2,
+        HoodieRollbackStat.newBuilder()
+            .withPartitionPath(partition2)
+            .withRollbackBlockAppendResults(Collections.singletonMap(
+                new StoragePathInfo(rollbackLogPath2, 0L, false, (short) 0, 0, 0), 1L))
+            .withLogFilesFromFailedCommit(logFilesToRollback2)
+            .build()));
+    expected.add(Pair.of(partition2,
+        HoodieRollbackStat.newBuilder()
+            .withPartitionPath(partition2)
+            .build()));
+    assertRollbackStatsEquals(expected, rollbackStats);
+  }
+
+  @Test
+  void testV1MaybeDeleteAndCollectStatsWithSingleRequestPerFileGroup() throws IOException {
+    HoodieTableVersion tableVersion = HoodieTableVersion.SIX;
+    when(tableConfig.getTableVersion()).thenReturn(tableVersion);
+    String rollbackInstantTime = "003";
+    String instantToRollback = "002";
+    RollbackHelperV1 rollbackHelper = new RollbackHelperV1(table, config);
+
+    List<SerializableHoodieRollbackRequest> rollbackRequests = new ArrayList<>();
+    String baseInstantTimeOfLogFiles = "001";
+    String partition = "partition1";
+    String baseFileId = UUID.randomUUID().toString();
+    String logFileId = UUID.randomUUID().toString();
+    StoragePath baseFilePath = addRollbackRequestForBaseFile(
+        rollbackRequests, partition, baseFileId, instantToRollback);
+    Map<String, Long> logFilesToRollback = addRollbackRequestForLogFiles(
+        rollbackRequests, tableVersion, partition, logFileId, baseInstantTimeOfLogFiles, IntStream.range(1, ROLLBACK_LOG_VERSION));
+
+    setupMocksAndValidateInitialState(rollbackInstantTime, rollbackRequests);
+    List<Pair<String, HoodieRollbackStat>> rollbackStats = rollbackHelper.maybeDeleteAndCollectStats(
+        new HoodieLocalEngineContext(storage.getConf()),
+        rollbackInstantTime,
+        INSTANT_GENERATOR.createNewInstant(HoodieInstant.State.INFLIGHT, HoodieTimeline.DELTA_COMMIT_ACTION, instantToRollback),
+        rollbackRequests, true, 5);
+    validateStateAfterRollback(rollbackRequests);
+
+    StoragePath rollbackLogPath = new StoragePath(new StoragePath(basePath, partition),
+        FileCreateUtils.logFileName(baseInstantTimeOfLogFiles, logFileId, ROLLBACK_LOG_VERSION));
+
+    List<Pair<String, HoodieRollbackStat>> expected = new ArrayList<>();
+    expected.add(Pair.of(partition,
+        HoodieRollbackStat.newBuilder()
+            .withPartitionPath(partition)
+            .withDeletedFileResult(baseFilePath.toString(), true)
+            .build()));
+    expected.add(Pair.of(partition,
+        HoodieRollbackStat.newBuilder()
+            .withPartitionPath(partition)
+            .withRollbackBlockAppendResults(Collections.singletonMap(
+                new StoragePathInfo(rollbackLogPath, 0L, false, (short) 0, 0, 0), 1L))
+            .withLogFilesFromFailedCommit(logFilesToRollback)
+            .build()));
+    assertRollbackStatsEquals(expected, rollbackStats);
   }
 
   @Test

--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/table/action/rollback/TestRollbackHelper.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/table/action/rollback/TestRollbackHelper.java
@@ -24,11 +24,9 @@ import org.apache.hudi.common.HoodieRollbackStat;
 import org.apache.hudi.common.engine.HoodieEngineContext;
 import org.apache.hudi.common.engine.HoodieLocalEngineContext;
 import org.apache.hudi.common.fs.FSUtils;
-import org.apache.hudi.common.model.HoodieFileFormat;
 import org.apache.hudi.common.table.HoodieTableConfig;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.common.table.HoodieTableVersion;
-import org.apache.hudi.common.table.log.HoodieLogFormat;
 import org.apache.hudi.common.table.timeline.HoodieInstant;
 import org.apache.hudi.common.table.timeline.HoodieTimeline;
 import org.apache.hudi.common.testutils.FileCreateUtils;
@@ -46,8 +44,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.Mockito;
 
 import java.io.FileNotFoundException;
@@ -86,9 +82,9 @@ class TestRollbackHelper extends HoodieRollbackTestBase {
     storage.deleteDirectory(basePath);
   }
 
-  @ParameterizedTest
-  @ValueSource(strings = {"SIX", "EIGHT"})
-  void testMaybeDeleteAndCollectStatsWithMultipleRequestsPerFileGroup(HoodieTableVersion tableVersion) throws IOException {
+  @Test
+  void testMaybeDeleteAndCollectStatsWithMultipleRequestsPerFileGroup() throws IOException {
+    HoodieTableVersion tableVersion = HoodieTableVersion.EIGHT;
     when(tableConfig.getTableVersion()).thenReturn(tableVersion);
     String rollbackInstantTime = "003";
     String instantToRollback = "002";
@@ -131,16 +127,6 @@ class TestRollbackHelper extends HoodieRollbackTestBase {
         INSTANT_GENERATOR.createNewInstant(HoodieInstant.State.INFLIGHT, HoodieTimeline.DELTA_COMMIT_ACTION, instantToRollback),
         rollbackRequests, true, 5);
     validateStateAfterRollback(rollbackRequests);
-    StoragePath rollbackLogPath1 = new StoragePath(new StoragePath(basePath, partition2),
-        tableVersion.greaterThanOrEquals(HoodieTableVersion.EIGHT)
-            ? FSUtils.makeLogFileName(logFileId1, HoodieFileFormat.HOODIE_LOG.getFileExtension(),
-            instantToRollback, 1, HoodieLogFormat.DEFAULT_WRITE_TOKEN)
-            : FileCreateUtils.logFileName(baseInstantTimeOfLogFiles, logFileId1, 2));
-    StoragePath rollbackLogPath2 = new StoragePath(new StoragePath(basePath, partition2),
-        tableVersion.greaterThanOrEquals(HoodieTableVersion.EIGHT)
-            ? FSUtils.makeLogFileName(logFileId2, HoodieFileFormat.HOODIE_LOG.getFileExtension(),
-            instantToRollback, 1, HoodieLogFormat.DEFAULT_WRITE_TOKEN)
-            : FileCreateUtils.logFileName(baseInstantTimeOfLogFiles, logFileId2, ROLLBACK_LOG_VERSION));
     List<Pair<String, HoodieRollbackStat>> expected = new ArrayList<>();
     expected.add(Pair.of(partition1,
         HoodieRollbackStat.newBuilder()
@@ -157,39 +143,20 @@ class TestRollbackHelper extends HoodieRollbackTestBase {
             .withPartitionPath(partition2)
             .withDeletedFileResult(baseFilePath3.toString(), true)
             .build()));
-    if (tableVersion.greaterThanOrEquals(HoodieTableVersion.EIGHT)) {
-      // For log file rollbacks in table version 8, the log files are deleted in parallel
-      // so there is no grouping per file group
-      getFullLogPathList(logFilesToRollback1.keySet(), partition2).forEach(logFilePath -> {
-        expected.add(Pair.of(partition2,
-            HoodieRollbackStat.newBuilder()
-                .withPartitionPath(partition2)
-                .withDeletedFileResult(logFilePath, true)
-                .build()));
-      });
-      getFullLogPathList(logFilesToRollback2.keySet(), partition2).forEach(logFilePath -> {
-        expected.add(Pair.of(partition2,
-            HoodieRollbackStat.newBuilder()
-                .withPartitionPath(partition2)
-                .withDeletedFileResult(logFilePath, true)
-                .build()));
-      });
-    } else {
-      // For log file rollbacks in table version 6, the log files are kept and
-      // the rollback command log block is added
+    getFullLogPathList(logFilesToRollback1.keySet(), partition2).forEach(logFilePath -> {
       expected.add(Pair.of(partition2,
           HoodieRollbackStat.newBuilder()
               .withPartitionPath(partition2)
-              .withRollbackBlockAppendResults(Collections.singletonMap(
-                  storage.getPathInfo(rollbackLogPath1), 1L))
+              .withDeletedFileResult(logFilePath, true)
               .build()));
+    });
+    getFullLogPathList(logFilesToRollback2.keySet(), partition2).forEach(logFilePath -> {
       expected.add(Pair.of(partition2,
           HoodieRollbackStat.newBuilder()
               .withPartitionPath(partition2)
-              .withRollbackBlockAppendResults(Collections.singletonMap(
-                  storage.getPathInfo(rollbackLogPath2), 1L))
+              .withDeletedFileResult(logFilePath, true)
               .build()));
-    }
+    });
     expected.add(Pair.of(partition2,
         HoodieRollbackStat.newBuilder()
             .withPartitionPath(partition2)
@@ -197,9 +164,9 @@ class TestRollbackHelper extends HoodieRollbackTestBase {
     assertRollbackStatsEquals(expected, rollbackStats);
   }
 
-  @ParameterizedTest
-  @ValueSource(strings = {"SIX", "EIGHT"})
-  void testMaybeDeleteAndCollectStatsWithSingleRequestPerFileGroup(HoodieTableVersion tableVersion) throws IOException {
+  @Test
+  void testMaybeDeleteAndCollectStatsWithSingleRequestPerFileGroup() throws IOException {
+    HoodieTableVersion tableVersion = HoodieTableVersion.EIGHT;
     when(tableConfig.getTableVersion()).thenReturn(tableVersion);
     String rollbackInstantTime = "003";
     String instantToRollback = "002";
@@ -223,11 +190,6 @@ class TestRollbackHelper extends HoodieRollbackTestBase {
         INSTANT_GENERATOR.createNewInstant(HoodieInstant.State.INFLIGHT, HoodieTimeline.DELTA_COMMIT_ACTION, instantToRollback),
         rollbackRequests, true, 5);
     validateStateAfterRollback(rollbackRequests);
-    StoragePath rollbackLogPath = new StoragePath(new StoragePath(basePath, partition),
-        tableVersion.greaterThanOrEquals(HoodieTableVersion.EIGHT)
-            ? FSUtils.makeLogFileName(logFileId, HoodieFileFormat.HOODIE_LOG.getFileExtension(),
-            instantToRollback, 1, HoodieLogFormat.DEFAULT_WRITE_TOKEN)
-            : FileCreateUtils.logFileName(baseInstantTimeOfLogFiles, logFileId, ROLLBACK_LOG_VERSION));
     List<Pair<String, HoodieRollbackStat>> expected = new ArrayList<>();
     expected.add(Pair.of(partition,
         HoodieRollbackStat.newBuilder()
@@ -235,26 +197,13 @@ class TestRollbackHelper extends HoodieRollbackTestBase {
             .withDeletedFileResult(baseFilePath.toString(), true)
             .build()
     ));
-    if (tableVersion.greaterThanOrEquals(HoodieTableVersion.EIGHT)) {
-      // For log file rollbacks in table version 8, the log files are deleted in parallel
-      // so there is no grouping per file group
-      getFullLogPathList(logFilesToRollback.keySet(), partition).forEach(logFilePath -> {
-        expected.add(Pair.of(partition,
-            HoodieRollbackStat.newBuilder()
-                .withPartitionPath(partition)
-                .withDeletedFileResult(logFilePath, true)
-                .build()));
-      });
-    } else {
-      // For log file rollbacks in table version 6, the log files are kept and
-      // the rollback command log block is added
+    getFullLogPathList(logFilesToRollback.keySet(), partition).forEach(logFilePath -> {
       expected.add(Pair.of(partition,
           HoodieRollbackStat.newBuilder()
               .withPartitionPath(partition)
-              .withRollbackBlockAppendResults(Collections.singletonMap(
-                  storage.getPathInfo(rollbackLogPath), 1L))
+              .withDeletedFileResult(logFilePath, true)
               .build()));
-    }
+    });
     assertRollbackStatsEquals(expected, rollbackStats);
   }
 
@@ -582,7 +531,7 @@ class TestRollbackHelper extends HoodieRollbackTestBase {
     when(tableConfig.getTableVersion()).thenReturn(HoodieTableVersion.SIX);
     String rollbackInstantTime = "003";
     String instantToRollback = "002";
-    RollbackHelper rollbackHelper = new RollbackHelper(table, config);
+    RollbackHelperV1 rollbackHelper = new RollbackHelperV1(table, config);
 
     List<SerializableHoodieRollbackRequest> rollbackRequests = new ArrayList<>();
     String baseInstantTimeOfLogFiles = "001";
@@ -595,6 +544,7 @@ class TestRollbackHelper extends HoodieRollbackTestBase {
     setupMocksAndValidateInitialState(rollbackInstantTime, rollbackRequests);
     List<Pair<String, HoodieRollbackStat>> rollbackStats = rollbackHelper.maybeDeleteAndCollectStats(
         new HoodieLocalEngineContext(storage.getConf()),
+        rollbackInstantTime,
         INSTANT_GENERATOR.createNewInstant(HoodieInstant.State.INFLIGHT,
             HoodieTimeline.DELTA_COMMIT_ACTION, instantToRollback),
         rollbackRequests, false, 5);

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/table/functional/TestMarkerBasedRollbackStrategy.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/table/functional/TestMarkerBasedRollbackStrategy.java
@@ -116,6 +116,9 @@ public class TestMarkerBasedRollbackStrategy extends HoodieClientTestBase {
     tearDown();
     tableType = HoodieTableType.MERGE_ON_READ;
     setUp();
+    Properties props = new Properties();
+    props.put(HoodieTableConfig.VERSION.key(), HoodieTableVersion.SIX.versionCode());
+    initMetaClient(tableType, props);
     HoodieTestTable testTable = HoodieTestTable.of(metaClient);
     String f0 = testTable.addRequestedCommit("000")
         .getFileIdsWithBaseFilesInPartitions("partA").get("partA");
@@ -134,11 +137,22 @@ public class TestMarkerBasedRollbackStrategy extends HoodieClientTestBase {
     tearDown();
     tableType = HoodieTableType.MERGE_ON_READ;
     setUp();
+    if (testIOType == IOType.APPEND) {
+      Properties props = new Properties();
+      props.put(HoodieTableConfig.VERSION.key(), HoodieTableVersion.SIX.versionCode());
+      initMetaClient(tableType, props);
+    }
     HoodieTestTable testTable = HoodieTestTable.of(metaClient);
     String f0 = testTable.addRequestedCommit("000")
         .getFileIdWithLogFile("partA");
-    testTable.forCommit("001")
-        .withLogMarkerFile("partA", f0, testIOType);
+    testTable.forCommit("001");
+    if (testIOType == IOType.APPEND) {
+      testTable.withLogFile("partA", f0, "000", 1);
+      String logFileName = FileCreateUtils.logFileName("000", f0, 1);
+      testTable.withLogMarkerFile("partA", logFileName);
+    } else {
+      testTable.withLogMarkerFile("partA", f0, testIOType);
+    }
 
     HoodieTable hoodieTable = HoodieSparkTable.create(getConfig(), context, metaClient);
     List<HoodieRollbackRequest> rollbackRequests = new MarkerBasedRollbackStrategy(hoodieTable, context, getConfig(),
@@ -293,6 +307,9 @@ public class TestMarkerBasedRollbackStrategy extends HoodieClientTestBase {
 
   @Test
   public void testMarkerBasedRollbackFallbackToTimelineServerWhenDirectMarkerFails() throws Exception {
+    Properties props = new Properties();
+    props.put(HoodieTableConfig.VERSION.key(), HoodieTableVersion.SIX.versionCode());
+    initMetaClient(tableType, props);
     HoodieTestTable testTable = HoodieTestTable.of(metaClient);
     String f0 = testTable.addRequestedCommit("000")
         .getFileIdsWithBaseFilesInPartitions("partA").get("partA");

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestColumnStatsIndex.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestColumnStatsIndex.scala
@@ -26,7 +26,7 @@ import org.apache.hudi.avro.model.DecimalWrapper
 import org.apache.hudi.client.common.HoodieSparkEngineContext
 import org.apache.hudi.common.config.{HoodieCommonConfig, HoodieMetadataConfig, HoodieStorageConfig}
 import org.apache.hudi.common.fs.FSUtils
-import org.apache.hudi.common.model.{HoodieRecord, HoodieTableType}
+import org.apache.hudi.common.model.{HoodieRecord, HoodieTableType, IOType}
 import org.apache.hudi.common.schema.HoodieSchema
 import org.apache.hudi.common.table.{HoodieTableConfig, HoodieTableMetaClient, HoodieTableVersion}
 import org.apache.hudi.common.table.timeline.versioning.v1.InstantFileNameGeneratorV1
@@ -866,10 +866,13 @@ class TestColumnStatsIndex extends ColumnStatIndexTestBase {
 
     // re-create marker for the deleted file.
     if (tableType == HoodieTableType.MERGE_ON_READ) {
+      val ioType = if (metaClient.getTableConfig.getTableVersion
+        .greaterThanOrEquals(HoodieTableVersion.EIGHT)) IOType.CREATE else IOType.APPEND
+      val markerSuffix = HoodieTableMetaClient.MARKER_EXTN + "." + ioType.name()
       if (StringUtils.isNullOrEmpty(partitionCol)) {
-        metaClient.getStorage.create(new StoragePath(metaClient.getBasePath.toString + "/.hoodie/.temp/" + lastCompletedCommit.requestedTime + "/" + logFileName + ".marker.APPEND"))
+        metaClient.getStorage.create(new StoragePath(metaClient.getBasePath.toString + "/.hoodie/.temp/" + lastCompletedCommit.requestedTime + "/" + logFileName + markerSuffix))
       } else {
-        metaClient.getStorage.create(new StoragePath(metaClient.getBasePath.toString + "/.hoodie/.temp/" + lastCompletedCommit.requestedTime + "/9/" + logFileName + ".marker.APPEND"))
+        metaClient.getStorage.create(new StoragePath(metaClient.getBasePath.toString + "/.hoodie/.temp/" + lastCompletedCommit.requestedTime + "/9/" + logFileName + markerSuffix))
       }
     } else {
       if (StringUtils.isNullOrEmpty(partitionCol)) {

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestPartitionStatsPruning.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestPartitionStatsPruning.scala
@@ -22,8 +22,8 @@ package org.apache.hudi.functional
 import org.apache.hudi.DataSourceWriteOptions
 import org.apache.hudi.DataSourceWriteOptions.{ORDERING_FIELDS, PARTITIONPATH_FIELD, RECORDKEY_FIELD}
 import org.apache.hudi.common.config.HoodieMetadataConfig
-import org.apache.hudi.common.model.{HoodieRecord, HoodieTableType}
-import org.apache.hudi.common.table.{HoodieTableConfig, HoodieTableMetaClient}
+import org.apache.hudi.common.model.{HoodieRecord, HoodieTableType, IOType}
+import org.apache.hudi.common.table.{HoodieTableConfig, HoodieTableMetaClient, HoodieTableVersion}
 import org.apache.hudi.common.testutils.HoodieTestUtils.INSTANT_FILE_NAME_GENERATOR
 import org.apache.hudi.common.util.StringUtils
 import org.apache.hudi.config.{HoodieCompactionConfig, HoodieWriteConfig}
@@ -389,10 +389,13 @@ class TestPartitionStatsPruning extends ColumnStatIndexTestBase {
 
     // re-create marker for the deleted file.
     if (tableType == HoodieTableType.MERGE_ON_READ) {
+      val ioType = if (metaClient.getTableConfig.getTableVersion
+        .greaterThanOrEquals(HoodieTableVersion.EIGHT)) IOType.CREATE else IOType.APPEND
+      val markerSuffix = HoodieTableMetaClient.MARKER_EXTN + "." + ioType.name()
       if (StringUtils.isNullOrEmpty(partitionCol)) {
-        metaClient.getStorage.create(new StoragePath(metaClient.getBasePath.toString + "/.hoodie/.temp/" + lastCompletedCommit.requestedTime + "/" + logFileName + ".marker.APPEND"))
+        metaClient.getStorage.create(new StoragePath(metaClient.getBasePath.toString + "/.hoodie/.temp/" + lastCompletedCommit.requestedTime + "/" + logFileName + markerSuffix))
       } else {
-        metaClient.getStorage.create(new StoragePath(metaClient.getBasePath.toString + "/.hoodie/.temp/" + lastCompletedCommit.requestedTime + "/9/" + logFileName + ".marker.APPEND"))
+        metaClient.getStorage.create(new StoragePath(metaClient.getBasePath.toString + "/.hoodie/.temp/" + lastCompletedCommit.requestedTime + "/9/" + logFileName + markerSuffix))
       }
     } else {
       if (StringUtils.isNullOrEmpty(partitionCol)) {


### PR DESCRIPTION
Mirror of https://github.com/apache/hudi/pull/18279 for automated bot review.

**Original author:** @nbalajee
**Base branch:** master


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Vector search SQL table-valued functions for KNN similarity queries
  * Catalog-backed partition listing option
  * Record limit push-down for source reads
  * Variant Parquet shredding for richer Variant types

* **Improvements**
  * Column pruning for incremental reads (reduced IO)
  * Configurable clustering expiration with rollback eligibility
  * Enhanced log compaction scheduling and partition discovery

* **Configuration**
  * New clustering expiration settings (enable + threshold minutes)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->