### PR TITLE
[OSS PR #18484] feat(flink): Add metrics for RocksDB index backend in bucket assigner

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/util/collection/RocksDBDAO.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/util/collection/RocksDBDAO.java
@@ -24,6 +24,7 @@ import org.apache.hudi.common.util.HoodieTimer;
 import org.apache.hudi.common.util.SerializationUtils;
 import org.apache.hudi.common.util.StringUtils;
 import org.apache.hudi.common.util.ValidationUtils;
+import org.apache.hudi.common.util.VisibleForTesting;
 import org.apache.hudi.exception.HoodieException;
 import org.apache.hudi.exception.HoodieIOException;
 import org.apache.hudi.io.util.FileIOUtils;
@@ -42,6 +43,8 @@ import org.rocksdb.RocksDB;
 import org.rocksdb.RocksDBException;
 import org.rocksdb.RocksIterator;
 import org.rocksdb.Statistics;
+import org.rocksdb.TickerType;
+import org.rocksdb.FlushOptions;
 import org.rocksdb.WriteBatch;
 import org.rocksdb.WriteOptions;
 
@@ -75,6 +78,7 @@ public class RocksDBDAO {
   private final String rocksDBBasePath;
   private final transient ConcurrentHashMap<String, CustomSerializer<?>> columnFamilySerializers;
   private transient WriteOptions defaultWriteOptions;
+  private transient Statistics statistics;
   private final boolean disableWALForWrites;
   @Getter
   private long totalBytesWritten;
@@ -113,9 +117,10 @@ public class RocksDBDAO {
       managedDescriptorMap = new ConcurrentHashMap<>();
 
       // If already present, loads the existing column-family handles
-
       final DBOptions dbOptions = new DBOptions().setCreateIfMissing(true).setCreateMissingColumnFamilies(true)
-          .setWalDir(rocksDBBasePath).setStatsDumpPeriodSec(300).setStatistics(new Statistics());
+          .setWalDir(rocksDBBasePath).setStatsDumpPeriodSec(300);
+      this.statistics = new Statistics();
+      dbOptions.setStatistics(statistics);
       dbOptions.setLogger(new org.rocksdb.Logger(dbOptions) {
         @Override
         protected void log(InfoLogLevel infoLogLevel, String logMsg) {
@@ -466,6 +471,32 @@ public class RocksDBDAO {
   }
 
   /**
+   * Retrieves a numeric property aggregated across all column families.
+   */
+  public synchronized long getLongProperty(String property) throws RocksDBException {
+    return closed ? 0L : getRocksDB().getAggregatedLongProperty(property);
+  }
+
+  /**
+   * Retrieves the current ticker count.
+   */
+  public synchronized long getTickerCount(TickerType tickerType) {
+    return closed || statistics == null ? 0L : statistics.getTickerCount(tickerType);
+  }
+
+  /**
+   * Flushes all pending data to SST files.
+   */
+  @VisibleForTesting
+  public void flush() {
+    try (FlushOptions flushOptions = new FlushOptions().setWaitForFlush(true)) {
+      getRocksDB().flush(flushOptions, new ArrayList<>(managedHandlesMap.values()));
+    } catch (RocksDBException e) {
+      throw new HoodieException(e);
+    }
+  }
+
+  /**
    * Note : Does not delete from underlying DB. Just closes the handle.
    *
    * @param columnFamilyName Column Family Name
@@ -499,6 +530,10 @@ public class RocksDBDAO {
         defaultWriteOptions.close();
       }
       getRocksDB().close();
+      if (statistics != null) {
+        statistics.close();
+        statistics = null;
+      }
       try {
         FileIOUtils.deleteDirectory(new File(rocksDBBasePath));
       } catch (IOException e) {

--- a/hudi-common/src/main/java/org/apache/hudi/common/util/collection/RocksDBDAO.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/util/collection/RocksDBDAO.java
@@ -24,7 +24,6 @@ import org.apache.hudi.common.util.HoodieTimer;
 import org.apache.hudi.common.util.SerializationUtils;
 import org.apache.hudi.common.util.StringUtils;
 import org.apache.hudi.common.util.ValidationUtils;
-import org.apache.hudi.common.util.VisibleForTesting;
 import org.apache.hudi.exception.HoodieException;
 import org.apache.hudi.exception.HoodieIOException;
 import org.apache.hudi.io.util.FileIOUtils;
@@ -44,7 +43,6 @@ import org.rocksdb.RocksDBException;
 import org.rocksdb.RocksIterator;
 import org.rocksdb.Statistics;
 import org.rocksdb.TickerType;
-import org.rocksdb.FlushOptions;
 import org.rocksdb.WriteBatch;
 import org.rocksdb.WriteOptions;
 
@@ -482,18 +480,6 @@ public class RocksDBDAO {
    */
   public synchronized long getTickerCount(TickerType tickerType) {
     return closed || statistics == null ? 0L : statistics.getTickerCount(tickerType);
-  }
-
-  /**
-   * Flushes all pending data to SST files.
-   */
-  @VisibleForTesting
-  public void flush() {
-    try (FlushOptions flushOptions = new FlushOptions().setWaitForFlush(true)) {
-      getRocksDB().flush(flushOptions, new ArrayList<>(managedHandlesMap.values()));
-    } catch (RocksDBException e) {
-      throw new HoodieException(e);
-    }
   }
 
   /**

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/metrics/FlinkRocksDBIndexMetrics.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/metrics/FlinkRocksDBIndexMetrics.java
@@ -1,0 +1,128 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.metrics;
+
+import org.apache.hudi.sink.partitioner.index.RocksDBIndexBackend;
+
+import org.apache.flink.metrics.Gauge;
+import org.apache.flink.metrics.MetricGroup;
+import org.rocksdb.TickerType;
+
+/**
+ * Metrics for RocksDB-backed index bootstrap state in flink bucket assign.
+ */
+public class FlinkRocksDBIndexMetrics extends HoodieFlinkMetrics {
+  private static final String TOTAL_SST_FILES_SIZE_PROPERTY = "rocksdb.total-sst-files-size";
+  private static final String LIVE_SST_FILES_SIZE_PROPERTY = "rocksdb.live-sst-files-size";
+  private static final String BLOCK_CACHE_CAPACITY_PROPERTY = "rocksdb.block-cache-capacity";
+  private static final String BLOCK_CACHE_USAGE_PROPERTY = "rocksdb.block-cache-usage";
+  private static final String ACTIVE_MEMTABLE_SIZE_PROPERTY = "rocksdb.cur-size-active-mem-table";
+  private static final String ALL_MEMTABLES_SIZE_PROPERTY = "rocksdb.cur-size-all-mem-tables";
+  private static final String IMMUTABLE_MEMTABLE_COUNT_PROPERTY = "rocksdb.num-immutable-mem-table";
+
+  public static final String ROCKSDB_DISK_TOTAL_SST_FILES_SIZE = "rocksdb.disk.total_sst_files_size";
+  public static final String ROCKSDB_DISK_LIVE_SST_FILES_SIZE = "rocksdb.disk.live_sst_files_size";
+  public static final String ROCKSDB_BLOCK_CACHE_CAPACITY = "rocksdb.block_cache.capacity";
+  public static final String ROCKSDB_BLOCK_CACHE_USAGE = "rocksdb.block_cache.usage";
+  public static final String ROCKSDB_BLOCK_CACHE_HIT_RATIO = "rocksdb.block_cache.hit_ratio";
+  public static final String ROCKSDB_BLOCK_CACHE_DATA_HIT_RATIO = "rocksdb.block_cache.data_hit_ratio";
+  public static final String ROCKSDB_BLOCK_CACHE_INDEX_HIT_RATIO = "rocksdb.block_cache.index_hit_ratio";
+  public static final String ROCKSDB_BLOCK_CACHE_FILTER_HIT_RATIO = "rocksdb.block_cache.filter_hit_ratio";
+
+  public static final String ROCKSDB_MEMTABLE_ACTIVE_SIZE = "rocksdb.memtable.active_size";
+  public static final String ROCKSDB_MEMTABLE_ALL_SIZE = "rocksdb.memtable.all_size";
+  public static final String ROCKSDB_MEMTABLE_IMMUTABLE_COUNT = "rocksdb.memtable.immutable_count";
+  public static final String ROCKSDB_MEMTABLE_HIT_RATIO = "rocksdb.memtable.hit_ratio";
+
+  private final RocksDBIndexBackend rocksDBIndexBackend;
+
+  public FlinkRocksDBIndexMetrics(MetricGroup metricGroup, RocksDBIndexBackend rocksDBIndexBackend) {
+    super(metricGroup);
+    this.rocksDBIndexBackend = rocksDBIndexBackend;
+  }
+
+  @Override
+  public void registerMetrics() {
+    // disk metric
+    metricGroup.gauge(ROCKSDB_DISK_TOTAL_SST_FILES_SIZE, (Gauge<Long>) this::getTotalSstFilesSize);
+    metricGroup.gauge(ROCKSDB_DISK_LIVE_SST_FILES_SIZE, (Gauge<Long>) this::getLiveSstFilesSize);
+
+    // block cache metric
+    metricGroup.gauge(ROCKSDB_BLOCK_CACHE_CAPACITY, (Gauge<Long>) this::getBlockCacheCapacity);
+    metricGroup.gauge(ROCKSDB_BLOCK_CACHE_USAGE, (Gauge<Long>) this::getBlockCacheUsage);
+    metricGroup.gauge(ROCKSDB_BLOCK_CACHE_HIT_RATIO, (Gauge<Double>) this::getBlockCacheHitRatio);
+    metricGroup.gauge(ROCKSDB_BLOCK_CACHE_DATA_HIT_RATIO, (Gauge<Double>) this::getBlockCacheDataHitRatio);
+    metricGroup.gauge(ROCKSDB_BLOCK_CACHE_INDEX_HIT_RATIO, (Gauge<Double>) this::getBlockCacheIndexHitRatio);
+    metricGroup.gauge(ROCKSDB_BLOCK_CACHE_FILTER_HIT_RATIO, (Gauge<Double>) this::getBlockCacheFilterHitRatio);
+
+    // mem-table metric
+    metricGroup.gauge(ROCKSDB_MEMTABLE_ACTIVE_SIZE, (Gauge<Long>) this::getActiveMemTableSize);
+    metricGroup.gauge(ROCKSDB_MEMTABLE_ALL_SIZE, (Gauge<Long>) this::getAllMemTablesSize);
+    metricGroup.gauge(ROCKSDB_MEMTABLE_IMMUTABLE_COUNT, (Gauge<Long>) this::getImmutableMemTableCount);
+    metricGroup.gauge(ROCKSDB_MEMTABLE_HIT_RATIO, (Gauge<Double>) this::getMemTableHitRatio);
+  }
+
+  private long getTotalSstFilesSize() {
+    return rocksDBIndexBackend.getLongMetric(TOTAL_SST_FILES_SIZE_PROPERTY);
+  }
+
+  private long getLiveSstFilesSize() {
+    return rocksDBIndexBackend.getLongMetric(LIVE_SST_FILES_SIZE_PROPERTY);
+  }
+
+  private long getBlockCacheCapacity() {
+    return rocksDBIndexBackend.getLongMetric(BLOCK_CACHE_CAPACITY_PROPERTY);
+  }
+
+  private long getBlockCacheUsage() {
+    return rocksDBIndexBackend.getLongMetric(BLOCK_CACHE_USAGE_PROPERTY);
+  }
+
+  private double getBlockCacheHitRatio() {
+    return rocksDBIndexBackend.getRatioMetric(TickerType.BLOCK_CACHE_HIT, TickerType.BLOCK_CACHE_MISS);
+  }
+
+  private double getBlockCacheDataHitRatio() {
+    return rocksDBIndexBackend.getRatioMetric(TickerType.BLOCK_CACHE_DATA_HIT, TickerType.BLOCK_CACHE_DATA_MISS);
+  }
+
+  private double getBlockCacheIndexHitRatio() {
+    return rocksDBIndexBackend.getRatioMetric(TickerType.BLOCK_CACHE_INDEX_HIT, TickerType.BLOCK_CACHE_INDEX_MISS);
+  }
+
+  private double getBlockCacheFilterHitRatio() {
+    return rocksDBIndexBackend.getRatioMetric(TickerType.BLOCK_CACHE_FILTER_HIT, TickerType.BLOCK_CACHE_FILTER_MISS);
+  }
+
+  private long getActiveMemTableSize() {
+    return rocksDBIndexBackend.getLongMetric(ACTIVE_MEMTABLE_SIZE_PROPERTY);
+  }
+
+  private long getAllMemTablesSize() {
+    return rocksDBIndexBackend.getLongMetric(ALL_MEMTABLES_SIZE_PROPERTY);
+  }
+
+  private long getImmutableMemTableCount() {
+    return rocksDBIndexBackend.getLongMetric(IMMUTABLE_MEMTABLE_COUNT_PROPERTY);
+  }
+
+  private double getMemTableHitRatio() {
+    return rocksDBIndexBackend.getRatioMetric(TickerType.MEMTABLE_HIT, TickerType.MEMTABLE_MISS);
+  }
+}

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/partitioner/BucketAssignFunction.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/partitioner/BucketAssignFunction.java
@@ -137,6 +137,7 @@ public class BucketAssignFunction
   @Override
   public void initializeState(FunctionInitializationContext context) throws Exception {
     this.indexBackend = IndexBackendFactory.create(conf, context, getRuntimeContext());
+    this.indexBackend.registerMetrics(getRuntimeContext().getMetricGroup());
   }
 
   @Override

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/partitioner/index/IndexBackend.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/partitioner/index/IndexBackend.java
@@ -21,6 +21,8 @@ package org.apache.hudi.sink.partitioner.index;
 import org.apache.hudi.common.model.HoodieRecordGlobalLocation;
 import org.apache.hudi.sink.event.Correspondent;
 
+import org.apache.flink.metrics.MetricGroup;
+
 import java.io.Closeable;
 import java.io.IOException;
 
@@ -62,6 +64,15 @@ public interface IndexBackend extends Closeable {
    * @param completedCheckpointId The latest completed checkpoint id
    */
   default void onCheckpointComplete(Correspondent correspondent, long completedCheckpointId) {
+    // do nothing.
+  }
+
+  /**
+   * Registers metrics for this backend.
+   *
+   * @param metricGroup flink metric group
+   */
+  default void registerMetrics(MetricGroup metricGroup) {
     // do nothing.
   }
 }

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/partitioner/index/RocksDBIndexBackend.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/partitioner/index/RocksDBIndexBackend.java
@@ -20,7 +20,6 @@ package org.apache.hudi.sink.partitioner.index;
 
 import org.apache.hudi.common.model.HoodieRecordGlobalLocation;
 import org.apache.hudi.common.serialization.CustomSerializer;
-import org.apache.hudi.common.util.VisibleForTesting;
 import org.apache.hudi.common.util.collection.RocksDBDAO;
 import org.apache.hudi.metrics.FlinkRocksDBIndexMetrics;
 
@@ -68,11 +67,6 @@ public class RocksDBIndexBackend implements IndexBackend {
     }
     this.rocksDBIndexMetrics = new FlinkRocksDBIndexMetrics(metricGroup, this);
     this.rocksDBIndexMetrics.registerMetrics();
-  }
-
-  @VisibleForTesting
-  void flush() {
-    this.rocksDBDAO.flush();
   }
 
   public long getLongMetric(String property) {

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/partitioner/index/RocksDBIndexBackend.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/sink/partitioner/index/RocksDBIndexBackend.java
@@ -20,7 +20,14 @@ package org.apache.hudi.sink.partitioner.index;
 
 import org.apache.hudi.common.model.HoodieRecordGlobalLocation;
 import org.apache.hudi.common.serialization.CustomSerializer;
+import org.apache.hudi.common.util.VisibleForTesting;
 import org.apache.hudi.common.util.collection.RocksDBDAO;
+import org.apache.hudi.metrics.FlinkRocksDBIndexMetrics;
+
+import lombok.extern.slf4j.Slf4j;
+import org.apache.flink.metrics.MetricGroup;
+import org.rocksdb.RocksDBException;
+import org.rocksdb.TickerType;
 
 import java.io.IOException;
 import java.util.concurrent.ConcurrentHashMap;
@@ -28,10 +35,12 @@ import java.util.concurrent.ConcurrentHashMap;
 /**
  * An implementation of {@link IndexBackend} based on RocksDB.
  */
+@Slf4j
 public class RocksDBIndexBackend implements IndexBackend {
   private static final String COLUMN_FAMILY = "index_cache";
 
   private final RocksDBDAO rocksDBDAO;
+  private transient FlinkRocksDBIndexMetrics rocksDBIndexMetrics;
 
   public RocksDBIndexBackend(String rocksDbBasePath) {
     // Register custom serializer for HoodieRecordGlobalLocation to minimize storage overhead
@@ -50,6 +59,41 @@ public class RocksDBIndexBackend implements IndexBackend {
   @Override
   public void update(String recordKey, HoodieRecordGlobalLocation recordGlobalLocation) {
     this.rocksDBDAO.put(COLUMN_FAMILY, recordKey, recordGlobalLocation);
+  }
+
+  @Override
+  public void registerMetrics(MetricGroup metricGroup) {
+    if (rocksDBIndexMetrics != null) {
+      return;
+    }
+    this.rocksDBIndexMetrics = new FlinkRocksDBIndexMetrics(metricGroup, this);
+    this.rocksDBIndexMetrics.registerMetrics();
+  }
+
+  @VisibleForTesting
+  void flush() {
+    this.rocksDBDAO.flush();
+  }
+
+  public long getLongMetric(String property) {
+    try {
+      return this.rocksDBDAO.getLongProperty(property);
+    } catch (RocksDBException | RuntimeException e) {
+      log.debug("Failed to read RocksDB metric property {}", property, e);
+      return 0L;
+    }
+  }
+
+  public double getRatioMetric(TickerType hitTicker, TickerType missTicker) {
+    try {
+      long hits = this.rocksDBDAO.getTickerCount(hitTicker);
+      long misses = this.rocksDBDAO.getTickerCount(missTicker);
+      long total = hits + misses;
+      return total == 0 ? 0D : (double) hits / total;
+    } catch (RuntimeException e) {
+      log.debug("Failed to read RocksDB ticker metrics {} and {}", hitTicker, missTicker, e);
+      return 0D;
+    }
   }
 
   @Override

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/partitioner/index/TestRocksDBIndexBackend.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/partitioner/index/TestRocksDBIndexBackend.java
@@ -32,6 +32,7 @@ import java.util.Map;
 import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.ArgumentMatchers.any;
@@ -99,7 +100,7 @@ public class TestRocksDBIndexBackend {
   }
 
   @Test
-  void testMetricsReflectWritesReadsAndFlush() throws Exception {
+  void testMetricsReflectWritesReadsAndAutoFlush() throws Exception {
     try (RocksDBIndexBackend rocksDBIndexBackend = new RocksDBIndexBackend(tempFile.getAbsolutePath())) {
       MetricGroup metricGroup = mock(MetricGroup.class);
       Map<String, Gauge<?>> gauges = new HashMap<>();
@@ -120,18 +121,27 @@ public class TestRocksDBIndexBackend {
       assertTrue(((Number) gauges.get(FlinkRocksDBIndexMetrics.ROCKSDB_MEMTABLE_ALL_SIZE).getValue()).longValue() > 0L);
 
       for (int i = 0; i < 32; i++) {
-        assertTrue(rocksDBIndexBackend.get("id" + i) != null);
+        assertNotNull(rocksDBIndexBackend.get("id" + i));
       }
 
       assertTrue(((Number) gauges.get(FlinkRocksDBIndexMetrics.ROCKSDB_MEMTABLE_HIT_RATIO).getValue()).doubleValue() > 0D);
 
-      rocksDBIndexBackend.flush();
-
-      assertTrue(((Number) gauges.get(FlinkRocksDBIndexMetrics.ROCKSDB_DISK_TOTAL_SST_FILES_SIZE).getValue()).longValue() > 0L);
-      assertTrue(((Number) gauges.get(FlinkRocksDBIndexMetrics.ROCKSDB_DISK_LIVE_SST_FILES_SIZE).getValue()).longValue() > 0L);
+      // Keep writing larger records to trigger auto-flushes memtable into SST.
+      int nextKey = 32;
+      for (int i = 0; i < 32768; i++) {
+        String par = "par-" + nextKey + "-" + "x".repeat(4096);
+        rocksDBIndexBackend.update("id" + nextKey,
+            new HoodieRecordGlobalLocation(par, "00" + nextKey, UUID.randomUUID().toString()));
+        nextKey++;
+      }
+      long totalSstSize =
+          ((Number) gauges.get(FlinkRocksDBIndexMetrics.ROCKSDB_DISK_TOTAL_SST_FILES_SIZE).getValue()).longValue();
+      long liveSstSize =
+          ((Number) gauges.get(FlinkRocksDBIndexMetrics.ROCKSDB_DISK_LIVE_SST_FILES_SIZE).getValue()).longValue();
+      assertTrue(totalSstSize > 0 || liveSstSize > 0);
 
       for (int i = 0; i < 32; i++) {
-        assertTrue(rocksDBIndexBackend.get("id" + i) != null);
+        assertNotNull(rocksDBIndexBackend.get("id" + i));
       }
 
       assertTrue(((Number) gauges.get(FlinkRocksDBIndexMetrics.ROCKSDB_BLOCK_CACHE_HIT_RATIO).getValue()).doubleValue() >= 0D);

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/partitioner/index/TestRocksDBIndexBackend.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/sink/partitioner/index/TestRocksDBIndexBackend.java
@@ -19,15 +19,25 @@
 package org.apache.hudi.sink.partitioner.index;
 
 import org.apache.hudi.common.model.HoodieRecordGlobalLocation;
+import org.apache.hudi.metrics.FlinkRocksDBIndexMetrics;
 
+import org.apache.flink.metrics.Gauge;
+import org.apache.flink.metrics.MetricGroup;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
 import java.io.File;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
 
 /**
  * Test cases for {@link RocksDBIndexBackend}.
@@ -50,5 +60,111 @@ public class TestRocksDBIndexBackend {
       rocksDBIndexBackend.update("id2", location2);
       assertEquals(location2, rocksDBIndexBackend.get("id2"));
     }
+  }
+
+  @Test
+  void testMetricsRegistrationAndSnapshot() throws Exception {
+    try (RocksDBIndexBackend rocksDBIndexBackend = new RocksDBIndexBackend(tempFile.getAbsolutePath())) {
+      MetricGroup metricGroup = mock(MetricGroup.class);
+      Map<String, Gauge<?>> gauges = new HashMap<>();
+      doAnswer(invocation -> {
+        String name = invocation.getArgument(0);
+        Gauge<?> gauge = invocation.getArgument(1);
+        gauges.put(name, gauge);
+        return gauge;
+      }).when(metricGroup).gauge(anyString(), any(Gauge.class));
+
+      rocksDBIndexBackend.registerMetrics(metricGroup);
+
+      assertTrue(gauges.containsKey(FlinkRocksDBIndexMetrics.ROCKSDB_DISK_TOTAL_SST_FILES_SIZE));
+      assertTrue(gauges.containsKey(FlinkRocksDBIndexMetrics.ROCKSDB_DISK_LIVE_SST_FILES_SIZE));
+      assertTrue(gauges.containsKey(FlinkRocksDBIndexMetrics.ROCKSDB_BLOCK_CACHE_CAPACITY));
+      assertTrue(gauges.containsKey(FlinkRocksDBIndexMetrics.ROCKSDB_BLOCK_CACHE_USAGE));
+      assertTrue(gauges.containsKey(FlinkRocksDBIndexMetrics.ROCKSDB_BLOCK_CACHE_HIT_RATIO));
+      assertTrue(gauges.containsKey(FlinkRocksDBIndexMetrics.ROCKSDB_BLOCK_CACHE_DATA_HIT_RATIO));
+      assertTrue(gauges.containsKey(FlinkRocksDBIndexMetrics.ROCKSDB_BLOCK_CACHE_INDEX_HIT_RATIO));
+      assertTrue(gauges.containsKey(FlinkRocksDBIndexMetrics.ROCKSDB_BLOCK_CACHE_FILTER_HIT_RATIO));
+      assertTrue(gauges.containsKey(FlinkRocksDBIndexMetrics.ROCKSDB_MEMTABLE_ACTIVE_SIZE));
+      assertTrue(gauges.containsKey(FlinkRocksDBIndexMetrics.ROCKSDB_MEMTABLE_ALL_SIZE));
+      assertTrue(gauges.containsKey(FlinkRocksDBIndexMetrics.ROCKSDB_MEMTABLE_IMMUTABLE_COUNT));
+      assertTrue(gauges.containsKey(FlinkRocksDBIndexMetrics.ROCKSDB_MEMTABLE_HIT_RATIO));
+
+      rocksDBIndexBackend.registerMetrics(metricGroup);
+      assertEquals(12, gauges.size());
+
+      assertEquals(0D, ((Number) gauges.get(FlinkRocksDBIndexMetrics.ROCKSDB_BLOCK_CACHE_HIT_RATIO).getValue()).doubleValue());
+      assertEquals(0D, ((Number) gauges.get(FlinkRocksDBIndexMetrics.ROCKSDB_MEMTABLE_HIT_RATIO).getValue()).doubleValue());
+      assertEquals(0L, ((Number) gauges.get(FlinkRocksDBIndexMetrics.ROCKSDB_DISK_TOTAL_SST_FILES_SIZE).getValue()).longValue());
+    }
+  }
+
+  @Test
+  void testMetricsReflectWritesReadsAndFlush() throws Exception {
+    try (RocksDBIndexBackend rocksDBIndexBackend = new RocksDBIndexBackend(tempFile.getAbsolutePath())) {
+      MetricGroup metricGroup = mock(MetricGroup.class);
+      Map<String, Gauge<?>> gauges = new HashMap<>();
+      doAnswer(invocation -> {
+        String name = invocation.getArgument(0);
+        Gauge<?> gauge = invocation.getArgument(1);
+        gauges.put(name, gauge);
+        return gauge;
+      }).when(metricGroup).gauge(anyString(), any(Gauge.class));
+      rocksDBIndexBackend.registerMetrics(metricGroup);
+
+      for (int i = 0; i < 32; i++) {
+        rocksDBIndexBackend.update("id" + i,
+            new HoodieRecordGlobalLocation("par" + (i % 2), "00" + i, UUID.randomUUID().toString()));
+      }
+
+      assertTrue(((Number) gauges.get(FlinkRocksDBIndexMetrics.ROCKSDB_MEMTABLE_ACTIVE_SIZE).getValue()).longValue() > 0L);
+      assertTrue(((Number) gauges.get(FlinkRocksDBIndexMetrics.ROCKSDB_MEMTABLE_ALL_SIZE).getValue()).longValue() > 0L);
+
+      for (int i = 0; i < 32; i++) {
+        assertTrue(rocksDBIndexBackend.get("id" + i) != null);
+      }
+
+      assertTrue(((Number) gauges.get(FlinkRocksDBIndexMetrics.ROCKSDB_MEMTABLE_HIT_RATIO).getValue()).doubleValue() > 0D);
+
+      rocksDBIndexBackend.flush();
+
+      assertTrue(((Number) gauges.get(FlinkRocksDBIndexMetrics.ROCKSDB_DISK_TOTAL_SST_FILES_SIZE).getValue()).longValue() > 0L);
+      assertTrue(((Number) gauges.get(FlinkRocksDBIndexMetrics.ROCKSDB_DISK_LIVE_SST_FILES_SIZE).getValue()).longValue() > 0L);
+
+      for (int i = 0; i < 32; i++) {
+        assertTrue(rocksDBIndexBackend.get("id" + i) != null);
+      }
+
+      assertTrue(((Number) gauges.get(FlinkRocksDBIndexMetrics.ROCKSDB_BLOCK_CACHE_HIT_RATIO).getValue()).doubleValue() >= 0D);
+      assertTrue(((Number) gauges.get(FlinkRocksDBIndexMetrics.ROCKSDB_BLOCK_CACHE_DATA_HIT_RATIO).getValue()).doubleValue() >= 0D);
+      assertTrue(((Number) gauges.get(FlinkRocksDBIndexMetrics.ROCKSDB_BLOCK_CACHE_INDEX_HIT_RATIO).getValue()).doubleValue() >= 0D);
+      assertTrue(((Number) gauges.get(FlinkRocksDBIndexMetrics.ROCKSDB_BLOCK_CACHE_FILTER_HIT_RATIO).getValue()).doubleValue() >= 0D);
+      assertTrue(((Number) gauges.get(FlinkRocksDBIndexMetrics.ROCKSDB_BLOCK_CACHE_HIT_RATIO).getValue()).doubleValue() <= 1D);
+      assertTrue(((Number) gauges.get(FlinkRocksDBIndexMetrics.ROCKSDB_MEMTABLE_IMMUTABLE_COUNT).getValue()).longValue() >= 0L);
+
+      if (((Number) gauges.get(FlinkRocksDBIndexMetrics.ROCKSDB_BLOCK_CACHE_CAPACITY).getValue()).longValue() > 0L) {
+        assertTrue(((Number) gauges.get(FlinkRocksDBIndexMetrics.ROCKSDB_BLOCK_CACHE_USAGE).getValue()).longValue() > 0L);
+      }
+    }
+  }
+
+  @Test
+  void testMetricsSnapshotAfterCloseReturnsDefaultValues() throws Exception {
+    MetricGroup metricGroup = mock(MetricGroup.class);
+    Map<String, Gauge<?>> gauges = new HashMap<>();
+    doAnswer(invocation -> {
+      String name = invocation.getArgument(0);
+      Gauge<?> gauge = invocation.getArgument(1);
+      gauges.put(name, gauge);
+      return gauge;
+    }).when(metricGroup).gauge(anyString(), any(Gauge.class));
+
+    RocksDBIndexBackend rocksDBIndexBackend = new RocksDBIndexBackend(tempFile.getAbsolutePath());
+    rocksDBIndexBackend.registerMetrics(metricGroup);
+    rocksDBIndexBackend.close();
+
+    assertEquals(0L, ((Number) gauges.get(FlinkRocksDBIndexMetrics.ROCKSDB_DISK_TOTAL_SST_FILES_SIZE).getValue()).longValue());
+    assertEquals(0L, ((Number) gauges.get(FlinkRocksDBIndexMetrics.ROCKSDB_DISK_LIVE_SST_FILES_SIZE).getValue()).longValue());
+    assertEquals(0D, ((Number) gauges.get(FlinkRocksDBIndexMetrics.ROCKSDB_BLOCK_CACHE_HIT_RATIO).getValue()).doubleValue());
+    assertEquals(0D, ((Number) gauges.get(FlinkRocksDBIndexMetrics.ROCKSDB_MEMTABLE_HIT_RATIO).getValue()).doubleValue());
   }
 }


### PR DESCRIPTION
Mirror of https://github.com/apache/hudi/pull/18484 for automated bot review.

**Original author:** @cshuo
**Base branch:** master


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added clustering expiration with heartbeat-based rollback eligibility.
  * Introduced vector data type support with shredded variant schemas for Parquet.
  * Added SQL vector search functions for KNN similarity queries.
  * Implemented column pruning optimization for incremental reads.
  * Added catalog-backed partition discovery option.

* **Improvements**
  * Enhanced log compaction with threshold-based scheduling.
  * Improved CDC record iteration and image management in Flink.
  * Centralized table service handler factory for cleaner compaction pipelines.
  * Enhanced read statistics tracking for log blocks.

* **Bug Fixes**
  * Removed deprecated wrapper filesystem metrics initialization.
  * Fixed LANCE format validation in non-Spark engines.
  * Improved instant time validation and formatting for incremental queries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->