### PR TITLE
[OSS PR #18322] feat: Support to cap max commits to clean in one round of clean commit

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/utils/ArchivalUtils.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/utils/ArchivalUtils.java
@@ -117,6 +117,8 @@ public class ArchivalUtils {
       int cleanerCommitsRetained, int cleanerHoursRetained) {
     Option<HoodieInstant> earliestCommitToRetain = Option.empty();
     try {
+      // For archival, we don't need to cap commits to clean, so pass empty previousEarliestCommitToRetain
+      // and Long.MAX_VALUE for maxCommitsToClean
       earliestCommitToRetain = CleanerUtils.getEarliestCommitToRetain(
           metaClient.getActiveTimeline().getCommitsTimeline(),
           cleanerPolicy,
@@ -125,7 +127,9 @@ public class ArchivalUtils {
               ? parseDateFromInstantTime(latestCommit.get().requestedTime()).toInstant()
               : Instant.now(),
           cleanerHoursRetained,
-          metaClient.getTableConfig().getTimelineTimezone());
+          metaClient.getTableConfig().getTimelineTimezone(),
+          Option.empty(),
+          Long.MAX_VALUE);
     } catch (ParseException e) {
       if (NOT_PARSABLE_TIMESTAMPS.stream().noneMatch(ts -> latestCommit.get().requestedTime().startsWith(ts))) {
         log.info("Error parsing instant time: {}", latestCommit.get().requestedTime());

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieCleanConfig.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieCleanConfig.java
@@ -421,7 +421,7 @@ public class HoodieCleanConfig extends HoodieConfig {
       return this;
     }
 
-    public HoodieCleanConfig.Builder withMaxCommitsToClean(int maxCommitsToClean) {
+    public HoodieCleanConfig.Builder withMaxCommitsToClean(long maxCommitsToClean) {
       cleanConfig.setValue(MAX_COMMITS_TO_CLEAN, String.valueOf(maxCommitsToClean));
       return this;
     }

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieCleanConfig.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieCleanConfig.java
@@ -133,7 +133,7 @@ public class HoodieCleanConfig extends HoodieConfig {
       .markAdvanced()
       .withDocumentation(CleaningTriggerStrategy.class);
 
-  public static final ConfigProperty<String> CLEAN_MAX_COMMITS = ConfigProperty
+  public static final ConfigProperty<String> CLEAN_TRIGGER_MAX_COMMITS = ConfigProperty
       .key("hoodie.clean.trigger.max.commits")
       .defaultValue("1")
       .withAlternatives("hoodie.clean.max.commits")
@@ -243,6 +243,13 @@ public class HoodieCleanConfig extends HoodieConfig {
           + "Only the specified partitions will be cleaned. "
           + "This can be useful for very large tables to avoid OOM issues during cleaning. "
           + "If both this config and " + CLEAN_PARTITION_FILTER_REGEX_KEY + " are set, the selected partitions take precedence.");
+
+  public static final ConfigProperty<Long> MAX_COMMITS_TO_CLEAN = ConfigProperty
+      .key("hoodie.clean.max.commits.to.clean")
+      .defaultValue(Long.MAX_VALUE)
+      .markAdvanced()
+      .withDocumentation("Maximum Number of commits to clean in one clean commit. Applicable only when the clean policy is based on KEEP_LATEST_COMMITS or KEEP_LATEST_HOURS");
+
 
   /** @deprecated Use {@link #CLEANER_POLICY} and its methods instead */
   @Deprecated
@@ -360,7 +367,7 @@ public class HoodieCleanConfig extends HoodieConfig {
     }
 
     public HoodieCleanConfig.Builder withMaxCommitsBeforeCleaning(int maxCommitsBeforeCleaning) {
-      cleanConfig.setValue(CLEAN_MAX_COMMITS, String.valueOf(maxCommitsBeforeCleaning));
+      cleanConfig.setValue(CLEAN_TRIGGER_MAX_COMMITS, String.valueOf(maxCommitsBeforeCleaning));
       return this;
     }
 
@@ -411,6 +418,11 @@ public class HoodieCleanConfig extends HoodieConfig {
 
     public HoodieCleanConfig.Builder withPreWriteCleanerPolicy(HoodiePreWriteCleanerPolicy preWriteCleanerPolicy) {
       cleanConfig.setValue(PREWRITE_CLEANER_POLICY, preWriteCleanerPolicy.name());
+      return this;
+    }
+
+    public HoodieCleanConfig.Builder withMaxCommitsToClean(int maxCommitsToClean) {
+      cleanConfig.setValue(MAX_COMMITS_TO_CLEAN, String.valueOf(maxCommitsToClean));
       return this;
     }
 

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieCleanConfig.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieCleanConfig.java
@@ -248,7 +248,7 @@ public class HoodieCleanConfig extends HoodieConfig {
       .key("hoodie.clean.max.commits.to.clean")
       .defaultValue(Long.MAX_VALUE)
       .markAdvanced()
-      .withDocumentation("Maximum Number of commits to clean in one clean commit. Applicable only when the clean policy is based on KEEP_LATEST_COMMITS or KEEP_LATEST_HOURS");
+      .withDocumentation("Maximum number of commits to clean in one clean commit. Applicable only when the clean policy is based on KEEP_LATEST_COMMITS or KEEP_LATEST_HOURS");
 
 
   /** @deprecated Use {@link #CLEANER_POLICY} and its methods instead */
@@ -430,6 +430,10 @@ public class HoodieCleanConfig extends HoodieConfig {
       cleanConfig.setDefaults(HoodieCleanConfig.class.getName());
       HoodieCleaningPolicy.valueOf(cleanConfig.getString(CLEANER_POLICY));
       HoodiePreWriteCleanerPolicy.fromString(cleanConfig.getString(PREWRITE_CLEANER_POLICY));
+      long maxCommitsToClean = cleanConfig.getLong(MAX_COMMITS_TO_CLEAN);
+      if (maxCommitsToClean < 1) {
+        throw new IllegalArgumentException(MAX_COMMITS_TO_CLEAN.key() + " must be >= 1, but was " + maxCommitsToClean);
+      }
       return cleanConfig;
     }
   }

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieWriteConfig.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieWriteConfig.java
@@ -1813,8 +1813,8 @@ public class HoodieWriteConfig extends HoodieConfig {
     return getInt(HoodieCleanConfig.CLEANER_PARALLELISM_VALUE);
   }
 
-  public int getCleaningMaxCommits() {
-    return getInt(HoodieCleanConfig.CLEAN_MAX_COMMITS);
+  public int getCleanTriggerMaxCommits() {
+    return getInt(HoodieCleanConfig.CLEAN_TRIGGER_MAX_COMMITS);
   }
 
   public CleaningTriggerStrategy getCleaningTriggerStrategy() {
@@ -1823,6 +1823,10 @@ public class HoodieWriteConfig extends HoodieConfig {
 
   public boolean isAutoClean() {
     return getBoolean(HoodieCleanConfig.AUTO_CLEAN);
+  }
+
+  public int getMaxCommitsToClean() {
+    return getInt(HoodieCleanConfig.MAX_COMMITS_TO_CLEAN);
   }
 
   public boolean shouldArchiveBeyondSavepoint() {

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieWriteConfig.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/config/HoodieWriteConfig.java
@@ -1825,10 +1825,6 @@ public class HoodieWriteConfig extends HoodieConfig {
     return getBoolean(HoodieCleanConfig.AUTO_CLEAN);
   }
 
-  public int getMaxCommitsToClean() {
-    return getInt(HoodieCleanConfig.MAX_COMMITS_TO_CLEAN);
-  }
-
   public boolean shouldArchiveBeyondSavepoint() {
     return getBooleanOrDefault(HoodieArchivalConfig.ARCHIVE_BEYOND_SAVEPOINT);
   }
@@ -1855,6 +1851,10 @@ public class HoodieWriteConfig extends HoodieConfig {
 
   public String getCleanerPartitionFilterSelected() {
     return getString(HoodieCleanConfig.CLEAN_PARTITION_FILTER_SELECTED);
+  }
+
+  public long getMaxCommitsToClean() {
+    return getLong(HoodieCleanConfig.MAX_COMMITS_TO_CLEAN);
   }
 
   public boolean inlineCompactionEnabled() {

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/HoodieMetadataWriteUtils.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/metadata/HoodieMetadataWriteUtils.java
@@ -165,7 +165,7 @@ public class HoodieMetadataWriteUtils {
         .withAutoClean(false)
         .withCleanerParallelism(MDT_DEFAULT_PARALLELISM)
         .withFailedWritesCleaningPolicy(failedWritesCleaningPolicy)
-        .withMaxCommitsBeforeCleaning(writeConfig.getCleaningMaxCommits())
+        .withMaxCommitsBeforeCleaning(writeConfig.getCleanTriggerMaxCommits())
         .withCleanOptimizationWithLocalEngineEnabled(
             writeConfig.isCleanOptimizationWithLocalEngineEnabled());
 
@@ -375,7 +375,6 @@ public class HoodieMetadataWriteUtils {
    * @param enabledPartitionTypes       - Set of enabled MDT partitions to update
    * @param bloomFilterType             - Type of generated bloom filter records
    * @param bloomIndexParallelism       - Parallelism for bloom filter record generation
-   * @param enableOptimizeLogBlocksScan - flag used to enable scanInternalV2 for log blocks in data table
    * @return Map of partition to metadata records for the commit action
    */
   public static Map<String, HoodieData<HoodieRecord>> convertMetadataToRecords(HoodieEngineContext context, HoodieWriteConfig dataWriteConfig, HoodieCommitMetadata commitMetadata,

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/clean/CleanPlanActionExecutor.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/clean/CleanPlanActionExecutor.java
@@ -87,7 +87,7 @@ public class CleanPlanActionExecutor<T, I, K, O> extends BaseActionExecutor<T, I
   private boolean needsCleaning(CleaningTriggerStrategy strategy) {
     if (strategy == CleaningTriggerStrategy.NUM_COMMITS) {
       int numberOfCommits = getCommitsSinceLastCleaning();
-      int maxInlineCommitsForNextClean = config.getCleaningMaxCommits();
+      int maxInlineCommitsForNextClean = config.getCleanTriggerMaxCommits();
       return numberOfCommits >= maxInlineCommitsForNextClean;
     } else {
       throw new HoodieException("Unsupported cleaning trigger strategy: " + config.getCleaningTriggerStrategy());

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/clean/CleanPlanner.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/clean/CleanPlanner.java
@@ -94,6 +94,8 @@ public class CleanPlanner<T, I, K, O> implements Serializable {
   @Getter(AccessLevel.PACKAGE)
   private final List<String> savepointedTimestamps;
   private Option<HoodieInstant> earliestCommitToRetain = Option.empty();
+  private Option<HoodieInstant> lastCompletedClean = Option.empty();
+  private Option<HoodieCleanMetadata> lastCleanMetadata = Option.empty();
 
   public CleanPlanner(HoodieEngineContext context, HoodieTable<T, I, K, O> hoodieTable, HoodieWriteConfig config) {
     this.context = context;
@@ -175,9 +177,10 @@ public class CleanPlanner<T, I, K, O> implements Serializable {
     }
 
     if (config.incrementalCleanerModeEnabled()) {
-      Option<HoodieInstant> lastClean = hoodieTable.getCleanTimeline().filterCompletedInstants().lastInstant();
+      Option<HoodieInstant> lastClean = lastCompletedClean.or(Option.of(hoodieTable.getCleanTimeline().filterCompletedInstants().lastInstant().get()));
       if (lastClean.isPresent()) {
-        HoodieCleanMetadata cleanMetadata = hoodieTable.getActiveTimeline().readCleanMetadata(lastClean.get());
+        HoodieCleanMetadata cleanMetadata = (lastCompletedClean.isPresent() && lastCleanMetadata.isPresent()) ? lastCleanMetadata.get()
+            : hoodieTable.getActiveTimeline().readCleanMetadata(lastClean.get());
         if ((cleanMetadata.getEarliestCommitToRetain() != null)
                 && !cleanMetadata.getEarliestCommitToRetain().trim().isEmpty()
                 && !hoodieTable.getActiveTimeline().getCommitsTimeline().isBeforeTimelineStarts(cleanMetadata.getEarliestCommitToRetain())) {
@@ -592,10 +595,11 @@ public class CleanPlanner<T, I, K, O> implements Serializable {
     if (!earliestCommitToRetain.isPresent()) {
       // Get the previous clean's earliest commit to retain, if available
       Option<String> previousEarliestCommitToRetain = Option.empty();
-      Option<HoodieInstant> lastClean = hoodieTable.getCleanTimeline().filterCompletedInstants().lastInstant();
-      if (lastClean.isPresent()) {
+      lastCompletedClean = hoodieTable.getCleanTimeline().filterCompletedInstants().lastInstant();
+      if (lastCompletedClean.isPresent() && config.getMaxCommitsToClean() != Long.MAX_VALUE) {
         try {
-          HoodieCleanMetadata cleanMetadata = hoodieTable.getActiveTimeline().readCleanMetadata(lastClean.get());
+          HoodieCleanMetadata cleanMetadata = hoodieTable.getActiveTimeline().readCleanMetadata(lastCompletedClean.get());
+          lastCleanMetadata = Option.of(cleanMetadata);
           if (cleanMetadata.getEarliestCommitToRetain() != null
               && !cleanMetadata.getEarliestCommitToRetain().trim().isEmpty()) {
             previousEarliestCommitToRetain = Option.of(cleanMetadata.getEarliestCommitToRetain());

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/clean/CleanPlanner.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/clean/CleanPlanner.java
@@ -177,9 +177,9 @@ public class CleanPlanner<T, I, K, O> implements Serializable {
     }
 
     if (config.incrementalCleanerModeEnabled()) {
-      Option<HoodieInstant> lastClean = lastCompletedClean.or(Option.of(hoodieTable.getCleanTimeline().filterCompletedInstants().lastInstant().get()));
+      Option<HoodieInstant> lastClean = lastCompletedClean.or(hoodieTable.getCleanTimeline().filterCompletedInstants().lastInstant());
       if (lastClean.isPresent()) {
-        HoodieCleanMetadata cleanMetadata = (lastCompletedClean.isPresent() && lastCleanMetadata.isPresent()) ? lastCleanMetadata.get()
+        HoodieCleanMetadata cleanMetadata = lastCleanMetadata.isPresent() ? lastCleanMetadata.get()
             : hoodieTable.getActiveTimeline().readCleanMetadata(lastClean.get());
         if ((cleanMetadata.getEarliestCommitToRetain() != null)
                 && !cleanMetadata.getEarliestCommitToRetain().trim().isEmpty()

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/clean/CleanPlanner.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/table/action/clean/CleanPlanner.java
@@ -590,13 +590,30 @@ public class CleanPlanner<T, I, K, O> implements Serializable {
    */
   public Option<HoodieInstant> getEarliestCommitToRetain() {
     if (!earliestCommitToRetain.isPresent()) {
+      // Get the previous clean's earliest commit to retain, if available
+      Option<String> previousEarliestCommitToRetain = Option.empty();
+      Option<HoodieInstant> lastClean = hoodieTable.getCleanTimeline().filterCompletedInstants().lastInstant();
+      if (lastClean.isPresent()) {
+        try {
+          HoodieCleanMetadata cleanMetadata = hoodieTable.getActiveTimeline().readCleanMetadata(lastClean.get());
+          if (cleanMetadata.getEarliestCommitToRetain() != null
+              && !cleanMetadata.getEarliestCommitToRetain().trim().isEmpty()) {
+            previousEarliestCommitToRetain = Option.of(cleanMetadata.getEarliestCommitToRetain());
+          }
+        } catch (Exception e) {
+          log.warn("Failed to read previous clean metadata, proceeding without capping commits to clean", e);
+        }
+      }
+
       earliestCommitToRetain = CleanerUtils.getEarliestCommitToRetain(
           hoodieTable.getMetaClient().getActiveTimeline().getCommitsAndCompactionTimeline(),
           config.getCleanerPolicy(),
           config.getCleanerCommitsRetained(),
           Instant.now(),
           config.getCleanerHoursRetained(),
-          hoodieTable.getMetaClient().getTableConfig().getTimelineTimezone());
+          hoodieTable.getMetaClient().getTableConfig().getTimelineTimezone(),
+          previousEarliestCommitToRetain,
+          config.getMaxCommitsToClean());
     }
     return earliestCommitToRetain;
   }

--- a/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/metadata/TestHoodieMetadataWriteUtils.java
+++ b/hudi-client/hudi-client-common/src/test/java/org/apache/hudi/metadata/TestHoodieMetadataWriteUtils.java
@@ -50,7 +50,7 @@ public class TestHoodieMetadataWriteUtils {
         HoodieTableVersion.SIX);
     assertEquals(HoodieFailedWritesCleaningPolicy.EAGER, metadataWriteConfig1.getFailedWritesCleanPolicy());
     assertEquals(HoodieCleaningPolicy.KEEP_LATEST_COMMITS, metadataWriteConfig1.getCleanerPolicy());
-    assertEquals(1, metadataWriteConfig1.getCleaningMaxCommits());
+    assertEquals(1, metadataWriteConfig1.getCleanTriggerMaxCommits());
     // default value already greater than data cleaner commits retained * 1.2
     assertEquals(HoodieMetadataConfig.DEFAULT_METADATA_CLEANER_COMMITS_RETAINED, metadataWriteConfig1.getCleanerCommitsRetained());
 
@@ -71,7 +71,7 @@ public class TestHoodieMetadataWriteUtils {
     assertEquals(HoodieCleaningPolicy.KEEP_LATEST_COMMITS, metadataWriteConfig2.getCleanerPolicy());
     // data cleaner commits retained * 1.2 is greater than default
     assertEquals(24, metadataWriteConfig2.getCleanerCommitsRetained());
-    assertEquals(10, metadataWriteConfig2.getCleaningMaxCommits());
+    assertEquals(10, metadataWriteConfig2.getCleanTriggerMaxCommits());
   }
 
   @Test

--- a/hudi-common/src/main/java/org/apache/hudi/common/util/CleanerUtils.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/util/CleanerUtils.java
@@ -169,7 +169,24 @@ public class CleanerUtils {
 
   /**
    * Cap the number of commits to clean based on maxCommitsToClean configuration.
-   * This prevents cleaning too many commits in a single clean operation.
+   * This prevents cleaning too many commits in a single clean operation, which can cause
+   * performance issues or timeouts when there's a large backlog of commits to clean.
+   *
+   * <p>Algorithm: This method compares the number of commits that would be cleaned (those between
+   * previousEarliestCommitToRetain and calculatedEarliestCommitToRetain) against maxCommitsToClean.
+   * If the number exceeds the cap, it adjusts the earliest commit to retain such that only
+   * maxCommitsToClean commits are cleaned in this operation. The next clean will continue
+   * from where this one left off.
+   *
+   * <p>Example: If there are commits [0, 1, 2, ..., 99] and:
+   * <ul>
+   *   <li>calculatedEarliestCommitToRetain = commit 88 (would clean commits 0-87, keeping 88+)</li>
+   *   <li>previousEarliestCommitToRetain = commit 0 (last clean retained from commit 0 onwards)</li>
+   *   <li>maxCommitsToClean = 50</li>
+   * </ul>
+   * Then this method returns commit 50 as the new earliest to retain, meaning we only clean
+   * commits 0-49 in this operation. The next clean will use commit 50 as the previous earliest
+   * and can clean the remaining commits 50-87 (capped again if needed).
    *
    * @param completedCommitsTimeline Timeline of completed commits
    * @param calculatedEarliestCommitToRetain The earliest commit to retain calculated by policy
@@ -190,9 +207,9 @@ public class CleanerUtils {
 
     // If the number of commits to clean exceeds the cap, adjust the earliest commit to retain
     if (commitsEligibleForCleaning.size() > maxCommitsToClean) {
-      // Clean only the oldest maxCommitsToClean commits
-      // Return the (maxCommitsToClean)th commit as the new earliest commit to retain
-      HoodieInstant cappedEarliestCommitToRetain = commitsEligibleForCleaning.get((int) maxCommitsToClean - 1);
+      // Clean only the oldest maxCommitsToClean commits (indices 0 to maxCommitsToClean-1)
+      // Return the commit at index maxCommitsToClean as the new earliest commit to retain
+      HoodieInstant cappedEarliestCommitToRetain = commitsEligibleForCleaning.get((int) maxCommitsToClean);
       log.info("Capping commits to clean from {} to {}. Adjusted earliest commit to retain from {} to {}",
           commitsEligibleForCleaning.size(), maxCommitsToClean,
           calculatedEarliestCommitToRetain.requestedTime(), cappedEarliestCommitToRetain.requestedTime());

--- a/hudi-common/src/main/java/org/apache/hudi/common/util/CleanerUtils.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/util/CleanerUtils.java
@@ -125,7 +125,8 @@ public class CleanerUtils {
 
   public static Option<HoodieInstant> getEarliestCommitToRetain(
       HoodieTimeline commitsTimeline, HoodieCleaningPolicy cleaningPolicy, int commitsRetained,
-      Instant latestInstant, int hoursRetained, HoodieTimelineTimeZone timeZone) {
+      Instant latestInstant, int hoursRetained, HoodieTimelineTimeZone timeZone,
+      Option<String> previousEarliestCommitToRetain, long maxCommitsToClean) {
     HoodieTimeline completedCommitsTimeline = commitsTimeline.filterCompletedInstants();
     Option<HoodieInstant> earliestCommitToRetain = Option.empty();
 
@@ -153,7 +154,53 @@ public class CleanerUtils {
       earliestCommitToRetain = Option.fromJavaOptional(completedCommitsTimeline.getInstantsAsStream().filter(i -> compareTimestamps(i.requestedTime(),
           GREATER_THAN_OR_EQUALS, earliestTimeToRetain)).findFirst());
     }
+
+    // Apply maxCommitsToClean cap if configured and applicable
+    if (earliestCommitToRetain.isPresent()
+        && (cleaningPolicy == HoodieCleaningPolicy.KEEP_LATEST_COMMITS || cleaningPolicy == HoodieCleaningPolicy.KEEP_LATEST_BY_HOURS)
+        && maxCommitsToClean != Long.MAX_VALUE
+        && previousEarliestCommitToRetain.isPresent()) {
+      earliestCommitToRetain = capCommitsToClean(completedCommitsTimeline, earliestCommitToRetain.get(),
+          previousEarliestCommitToRetain.get(), maxCommitsToClean);
+    }
+
     return earliestCommitToRetain;
+  }
+
+  /**
+   * Cap the number of commits to clean based on maxCommitsToClean configuration.
+   * This prevents cleaning too many commits in a single clean operation.
+   *
+   * @param completedCommitsTimeline Timeline of completed commits
+   * @param calculatedEarliestCommitToRetain The earliest commit to retain calculated by policy
+   * @param previousEarliestCommitToRetain The earliest commit to retain from previous clean
+   * @param maxCommitsToClean Maximum number of commits to clean in one operation
+   * @return Adjusted earliest commit to retain that respects the cap
+   */
+  private static Option<HoodieInstant> capCommitsToClean(HoodieTimeline completedCommitsTimeline,
+      HoodieInstant calculatedEarliestCommitToRetain, String previousEarliestCommitToRetain,
+      long maxCommitsToClean) {
+    // Get all commits before the calculated earliest commit to retain
+    HoodieTimeline commitsToClean = completedCommitsTimeline.findInstantsBefore(calculatedEarliestCommitToRetain.requestedTime());
+
+    // Filter to get only commits after (or equal to) the previous earliest commit to retain
+    List<HoodieInstant> commitsEligibleForCleaning = commitsToClean.getInstantsAsStream()
+        .filter(instant -> compareTimestamps(instant.requestedTime(), GREATER_THAN_OR_EQUALS, previousEarliestCommitToRetain))
+        .collect(Collectors.toList());
+
+    // If the number of commits to clean exceeds the cap, adjust the earliest commit to retain
+    if (commitsEligibleForCleaning.size() > maxCommitsToClean) {
+      // Clean only the oldest maxCommitsToClean commits
+      // Return the (maxCommitsToClean)th commit as the new earliest commit to retain
+      HoodieInstant cappedEarliestCommitToRetain = commitsEligibleForCleaning.get((int) maxCommitsToClean - 1);
+      log.info("Capping commits to clean from {} to {}. Adjusted earliest commit to retain from {} to {}",
+          commitsEligibleForCleaning.size(), maxCommitsToClean,
+          calculatedEarliestCommitToRetain.requestedTime(), cappedEarliestCommitToRetain.requestedTime());
+      return Option.of(cappedEarliestCommitToRetain);
+    }
+
+    // No capping needed, return the original calculated value
+    return Option.of(calculatedEarliestCommitToRetain);
   }
 
   /**

--- a/hudi-common/src/test/java/org/apache/hudi/common/util/TestCleanerUtils.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/util/TestCleanerUtils.java
@@ -108,8 +108,9 @@ class TestCleanerUtils {
     );
 
     assertTrue(result.isPresent());
-    // Should cap at 50 commits from commit 0, so earliest commit to retain should be commit 49
-    assertEquals("20000000000049", result.get().requestedTime());
+    // Should cap at 50 commits from commit 0, so earliest commit to retain should be commit 50
+    // (Clean commits 0-49, retain from 50 onwards)
+    assertEquals("20000000000050", result.get().requestedTime());
 
     result = CleanerUtils.getEarliestCommitToRetain(
         timeline,
@@ -118,13 +119,14 @@ class TestCleanerUtils {
         Instant.now(),
         24, // hours retained
         HoodieTimelineTimeZone.UTC,
-        Option.of("20000000000049"), // previous clean's earliest commit to retain (commit 0)
+        Option.of("20000000000050"), // previous clean's earliest commit to retain (commit 50)
         50L // maxCommitsToClean
     );
 
     assertTrue(result.isPresent());
-    // Should cap at 50 commits from commit 0, so earliest commit to retain should be commit 49
-    assertEquals("20000000000098", result.get().requestedTime());
+    // Should cap at 50 commits from commit 50, so earliest commit to retain should be commit 100
+    // (Clean commits 50-99, retain from 100 onwards)
+    assertEquals("20000000000100", result.get().requestedTime());
   }
 
   @Test

--- a/hudi-common/src/test/java/org/apache/hudi/common/util/TestCleanerUtils.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/util/TestCleanerUtils.java
@@ -18,11 +18,22 @@
 
 package org.apache.hudi.common.util;
 
+import org.apache.hudi.common.model.HoodieCleaningPolicy;
 import org.apache.hudi.common.model.HoodieFailedWritesCleaningPolicy;
+import org.apache.hudi.common.model.HoodieTimelineTimeZone;
 import org.apache.hudi.common.table.timeline.HoodieActiveTimeline;
+import org.apache.hudi.common.table.timeline.HoodieInstant;
+import org.apache.hudi.common.table.timeline.HoodieTimeline;
+import org.apache.hudi.common.table.timeline.versioning.v2.InstantComparatorV2;
 
 import org.junit.jupiter.api.Test;
 
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
@@ -55,5 +66,200 @@ class TestCleanerUtils {
   void rollbackFailedWrites_CommitWithLazyPolicy() {
     assertFalse(CleanerUtils.rollbackFailedWrites(HoodieFailedWritesCleaningPolicy.LAZY, HoodieActiveTimeline.COMMIT_ACTION, rollbackFunction));
     verify(rollbackFunction, never()).apply();
+  }
+
+  @Test
+  void testGetEarliestCommitToRetain_WithMaxCommitsToClean_NoCapping() {
+    // Test scenario: 20 commits, retain 12, clean 8 commits, maxCommitsToClean=50
+    // Expected: No capping needed, should return the originally calculated earliest commit
+    HoodieTimeline timeline = createMockTimeline(20);
+
+    Option<HoodieInstant> result = CleanerUtils.getEarliestCommitToRetain(
+        timeline,
+        HoodieCleaningPolicy.KEEP_LATEST_COMMITS,
+        12, // commits to retain
+        Instant.now(),
+        24, // hours retained
+        HoodieTimelineTimeZone.UTC,
+        Option.of("20000000000005"), // previous clean's earliest commit to retain (commit 5)
+        50L // maxCommitsToClean
+    );
+
+    assertTrue(result.isPresent());
+    // With 20 commits and retain 12, earliest commit to retain should be commit at index 8 (20-12=8)
+    assertEquals("20000000000008", result.get().requestedTime());
+  }
+
+  @Test
+  void testGetEarliestCommitToRetain_WithMaxCommitsToClean_WithCapping() {
+    // Test scenario: 1000 commits, retain 12, would clean 988 commits, maxCommitsToClean=50
+    // Expected: Should cap to clean only 50 commits
+    HoodieTimeline timeline = createMockTimeline(1000);
+
+    Option<HoodieInstant> result = CleanerUtils.getEarliestCommitToRetain(
+        timeline,
+        HoodieCleaningPolicy.KEEP_LATEST_COMMITS,
+        12, // commits to retain
+        Instant.now(),
+        24, // hours retained
+        HoodieTimelineTimeZone.UTC,
+        Option.of("20000000000000"), // previous clean's earliest commit to retain (commit 0)
+        50L // maxCommitsToClean
+    );
+
+    assertTrue(result.isPresent());
+    // Should cap at 50 commits from commit 0, so earliest commit to retain should be commit 49
+    assertEquals("20000000000049", result.get().requestedTime());
+
+    result = CleanerUtils.getEarliestCommitToRetain(
+        timeline,
+        HoodieCleaningPolicy.KEEP_LATEST_COMMITS,
+        12, // commits to retain
+        Instant.now(),
+        24, // hours retained
+        HoodieTimelineTimeZone.UTC,
+        Option.of("20000000000049"), // previous clean's earliest commit to retain (commit 0)
+        50L // maxCommitsToClean
+    );
+
+    assertTrue(result.isPresent());
+    // Should cap at 50 commits from commit 0, so earliest commit to retain should be commit 49
+    assertEquals("20000000000098", result.get().requestedTime());
+  }
+
+  @Test
+  void testGetEarliestCommitToRetain_WithMaxCommitsToClean_ExactBoundary() {
+    // Test scenario: Clean exactly maxCommitsToClean commits
+    HoodieTimeline timeline = createMockTimeline(100);
+
+    Option<HoodieInstant> result = CleanerUtils.getEarliestCommitToRetain(
+        timeline,
+        HoodieCleaningPolicy.KEEP_LATEST_COMMITS,
+        12, // commits to retain
+        Instant.now(),
+        24, // hours retained
+        HoodieTimelineTimeZone.UTC,
+        Option.of("20000000000000"), // previous clean at commit 0
+        88L // maxCommitsToClean (exactly the number of commits eligible: 88)
+    );
+
+    assertTrue(result.isPresent());
+    // With 100 commits and retain 12, earliest would be commit 88
+    // With previous clean at 0 and max 88 to clean, we can clean commits 0-87, so earliest to retain is 88
+    assertEquals("20000000000088", result.get().requestedTime());
+  }
+
+  @Test
+  void testGetEarliestCommitToRetain_WithMaxCommitsToClean_NoPreviousClean() {
+    // Test scenario: No previous clean metadata available
+    HoodieTimeline timeline = createMockTimeline(100);
+
+    Option<HoodieInstant> result = CleanerUtils.getEarliestCommitToRetain(
+        timeline,
+        HoodieCleaningPolicy.KEEP_LATEST_COMMITS,
+        12, // commits to retain
+        Instant.now(),
+        24, // hours retained
+        HoodieTimelineTimeZone.UTC,
+        Option.empty(), // no previous clean
+        50L // maxCommitsToClean
+    );
+
+    assertTrue(result.isPresent());
+    // Without previous clean, capping should not apply
+    // With 100 commits and retain 12, earliest commit to retain should be commit 88
+    assertEquals("20000000000088", result.get().requestedTime());
+  }
+
+  @Test
+  void testGetEarliestCommitToRetain_WithMaxCommitsToClean_DefaultValue() {
+    // Test scenario: maxCommitsToClean is set to default Long.MAX_VALUE (no capping)
+    HoodieTimeline timeline = createMockTimeline(1000);
+
+    Option<HoodieInstant> result = CleanerUtils.getEarliestCommitToRetain(
+        timeline,
+        HoodieCleaningPolicy.KEEP_LATEST_COMMITS,
+        12, // commits to retain
+        Instant.now(),
+        24, // hours retained
+        HoodieTimelineTimeZone.UTC,
+        Option.of("20000000000000"), // previous clean at commit 0
+        Long.MAX_VALUE // no capping
+    );
+
+    assertTrue(result.isPresent());
+    // With no capping and 1000 commits retain 12, earliest should be commit 988
+    assertEquals("20000000000988", result.get().requestedTime());
+  }
+
+  @Test
+  void testGetEarliestCommitToRetain_WithMaxCommitsToClean_KeepLatestByHours() {
+    // Test scenario: KEEP_LATEST_BY_HOURS policy with capping
+    // We're testing that the capping logic is invoked for KEEP_LATEST_BY_HOURS policy
+    // Since KEEP_LATEST_BY_HOURS may return empty for test timelines, we just verify no exception
+    HoodieTimeline timeline = createMockTimeline(100);
+
+    Option<HoodieInstant> result = CleanerUtils.getEarliestCommitToRetain(
+        timeline,
+        HoodieCleaningPolicy.KEEP_LATEST_BY_HOURS,
+        12, // commits to retain (not used for BY_HOURS)
+        Instant.now(),
+        1, // 1 hour retained - will likely return empty for mock timestamps
+        HoodieTimelineTimeZone.UTC,
+        Option.of("20000000000000"), // previous clean at first commit
+        20L // maxCommitsToClean
+    );
+
+    // For KEEP_LATEST_BY_HOURS with mock timestamps, result may be empty
+    // The important thing is that the method executes without error and capping logic is available
+    // The actual capping behavior for KEEP_LATEST_BY_HOURS is tested in integration tests
+    // This unit test just verifies the code path doesn't throw exceptions
+    assertFalse(result.isPresent() && result.get().requestedTime().isEmpty());
+  }
+
+  /**
+   * Helper method to create a mock timeline with specified number of commits.
+   * Commits are named as "20000000000000", "20000000000001", etc.
+   */
+  private HoodieTimeline createMockTimeline(int numCommits) {
+    HoodieTimeline timeline = mock(HoodieTimeline.class);
+    HoodieTimeline completedTimeline = mock(HoodieTimeline.class);
+
+    List<HoodieInstant> instants = new ArrayList<>();
+    for (int i = 0; i < numCommits; i++) {
+      String timestamp = String.format("200000000%05d", i);
+      HoodieInstant instant = new HoodieInstant(HoodieInstant.State.COMPLETED,
+          HoodieTimeline.COMMIT_ACTION, timestamp, InstantComparatorV2.COMPLETION_TIME_BASED_COMPARATOR);
+      instants.add(instant);
+    }
+
+    when(timeline.filterCompletedInstants()).thenReturn(completedTimeline);
+    when(completedTimeline.countInstants()).thenReturn(numCommits);
+    when(completedTimeline.getInstantsAsStream()).thenReturn(instants.stream());
+
+    // Mock nthInstant to return the nth instant from the list
+    for (int i = 0; i < numCommits; i++) {
+      int index = i;
+      when(completedTimeline.nthInstant(i)).thenReturn(Option.of(instants.get(index)));
+    }
+
+    // Mock findInstantsBefore to return all instants before a given timestamp
+    when(completedTimeline.findInstantsBefore(org.mockito.ArgumentMatchers.anyString()))
+        .thenAnswer(invocation -> {
+          String timestamp = invocation.getArgument(0);
+          HoodieTimeline beforeTimeline = mock(HoodieTimeline.class);
+          List<HoodieInstant> beforeInstants = instants.stream()
+              .filter(i -> i.requestedTime().compareTo(timestamp) < 0)
+              .collect(Collectors.toList());
+          when(beforeTimeline.getInstantsAsStream()).thenReturn(beforeInstants.stream());
+          return beforeTimeline;
+        });
+
+    // Mock filter for pending commits (empty for this test)
+    HoodieTimeline emptyTimeline = mock(HoodieTimeline.class);
+    when(emptyTimeline.firstInstant()).thenReturn(Option.empty());
+    when(timeline.filter(org.mockito.ArgumentMatchers.any())).thenReturn(emptyTimeline);
+
+    return timeline;
   }
 }

--- a/hudi-common/src/test/java/org/apache/hudi/common/util/TestCleanerUtils.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/util/TestCleanerUtils.java
@@ -29,7 +29,10 @@ import org.apache.hudi.common.table.timeline.versioning.v2.InstantComparatorV2;
 import org.junit.jupiter.api.Test;
 
 import java.time.Instant;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
 import java.util.ArrayList;
+import java.util.Date;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -196,27 +199,43 @@ class TestCleanerUtils {
 
   @Test
   void testGetEarliestCommitToRetain_WithMaxCommitsToClean_KeepLatestByHours() {
-    // Test scenario: KEEP_LATEST_BY_HOURS policy with capping
-    // We're testing that the capping logic is invoked for KEEP_LATEST_BY_HOURS policy
-    // Since KEEP_LATEST_BY_HOURS may return empty for test timelines, we just verify no exception
-    HoodieTimeline timeline = createMockTimeline(100);
+    // Test scenario: 100 commits spanning 10 hours, retain last 2 hours, maxCommitsToClean=10
+    // Commits are spaced ~6 min apart (100 commits over 10 hours).
+    // With hoursRetained=2, the BY_HOURS policy calculates an earliest commit to retain ~80% through the timeline.
+    // The previous clean was at commit 0, so all commits before the calculated earliest are eligible for cleaning.
+    // With maxCommitsToClean=10, capping should kick in and only allow cleaning 10 commits from commit 0.
+    Instant now = Instant.now();
+    ZonedDateTime nowUtc = ZonedDateTime.ofInstant(now, ZoneId.of("UTC"));
+    int numCommits = 100;
+    int totalHoursSpan = 10;
+
+    // Generate timestamps: commit 0 is 10 hours ago, commit 99 is now
+    List<String> timestamps = new ArrayList<>();
+    for (int i = 0; i < numCommits; i++) {
+      ZonedDateTime commitTime = nowUtc.minusHours(totalHoursSpan).plusMinutes((long) i * totalHoursSpan * 60 / numCommits);
+      String ts = org.apache.hudi.common.table.timeline.TimelineUtils.formatDate(Date.from(commitTime.toInstant()));
+      timestamps.add(ts);
+    }
+
+    HoodieTimeline timeline = createMockTimelineWithTimestamps(timestamps);
+    String previousCleanEarliestCommit = timestamps.get(0);
 
     Option<HoodieInstant> result = CleanerUtils.getEarliestCommitToRetain(
         timeline,
         HoodieCleaningPolicy.KEEP_LATEST_BY_HOURS,
         12, // commits to retain (not used for BY_HOURS)
-        Instant.now(),
-        1, // 1 hour retained - will likely return empty for mock timestamps
+        now,
+        2, // retain last 2 hours
         HoodieTimelineTimeZone.UTC,
-        Option.of("20000000000000"), // previous clean at first commit
-        20L // maxCommitsToClean
+        Option.of(previousCleanEarliestCommit),
+        10L // maxCommitsToClean
     );
 
-    // For KEEP_LATEST_BY_HOURS with mock timestamps, result may be empty
-    // The important thing is that the method executes without error and capping logic is available
-    // The actual capping behavior for KEEP_LATEST_BY_HOURS is tested in integration tests
-    // This unit test just verifies the code path doesn't throw exceptions
-    assertFalse(result.isPresent() && result.get().requestedTime().isEmpty());
+    assertTrue(result.isPresent());
+    // The BY_HOURS policy would calculate an earliest commit to retain ~80 commits in (retaining ~last 20).
+    // With maxCommitsToClean=10, capping adjusts to only clean 10 commits from the previous clean point.
+    // So the result should be commit at index 10.
+    assertEquals(timestamps.get(10), result.get().requestedTime());
   }
 
   /**
@@ -224,12 +243,23 @@ class TestCleanerUtils {
    * Commits are named as "20000000000000", "20000000000001", etc.
    */
   private HoodieTimeline createMockTimeline(int numCommits) {
+    List<String> timestamps = new ArrayList<>();
+    for (int i = 0; i < numCommits; i++) {
+      timestamps.add(String.format("200000000%05d", i));
+    }
+    return createMockTimelineWithTimestamps(timestamps);
+  }
+
+  /**
+   * Helper method to create a mock timeline with specified timestamps.
+   */
+  private HoodieTimeline createMockTimelineWithTimestamps(List<String> timestamps) {
+    int numCommits = timestamps.size();
     HoodieTimeline timeline = mock(HoodieTimeline.class);
     HoodieTimeline completedTimeline = mock(HoodieTimeline.class);
 
     List<HoodieInstant> instants = new ArrayList<>();
-    for (int i = 0; i < numCommits; i++) {
-      String timestamp = String.format("200000000%05d", i);
+    for (String timestamp : timestamps) {
       HoodieInstant instant = new HoodieInstant(HoodieInstant.State.COMPLETED,
           HoodieTimeline.COMMIT_ACTION, timestamp, InstantComparatorV2.COMPLETION_TIME_BASED_COMPARATOR);
       instants.add(instant);
@@ -237,7 +267,7 @@ class TestCleanerUtils {
 
     when(timeline.filterCompletedInstants()).thenReturn(completedTimeline);
     when(completedTimeline.countInstants()).thenReturn(numCommits);
-    when(completedTimeline.getInstantsAsStream()).thenReturn(instants.stream());
+    when(completedTimeline.getInstantsAsStream()).thenAnswer(invocation -> instants.stream());
 
     // Mock nthInstant to return the nth instant from the list
     for (int i = 0; i < numCommits; i++) {
@@ -253,7 +283,7 @@ class TestCleanerUtils {
           List<HoodieInstant> beforeInstants = instants.stream()
               .filter(i -> i.requestedTime().compareTo(timestamp) < 0)
               .collect(Collectors.toList());
-          when(beforeTimeline.getInstantsAsStream()).thenReturn(beforeInstants.stream());
+          when(beforeTimeline.getInstantsAsStream()).thenAnswer(inv -> beforeInstants.stream());
           return beforeTimeline;
         });
 

--- a/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/RunCleanProcedure.scala
+++ b/hudi-spark-datasource/hudi-spark/src/main/scala/org/apache/spark/sql/hudi/command/procedures/RunCleanProcedure.scala
@@ -85,7 +85,7 @@ class RunCleanProcedure extends BaseProcedure with ProcedureBuilder with Logging
       confs += HoodieCleanConfig.CLEAN_TRIGGER_STRATEGY.key() -> getArgValueOrDefault(args, PARAMETERS(6)).get.toString
     }
     if (getArgValueOrDefault(args, PARAMETERS(7)).isDefined) {
-      confs += HoodieCleanConfig.CLEAN_MAX_COMMITS.key() -> getArgValueOrDefault(args, PARAMETERS(7)).get.toString
+      confs += HoodieCleanConfig.CLEAN_TRIGGER_MAX_COMMITS.key() -> getArgValueOrDefault(args, PARAMETERS(7)).get.toString
     }
     if (getArgValueOrDefault(args, PARAMETERS(8)).isDefined) {
       confs ++= HoodieCLIUtils.extractOptions(getArgValueOrDefault(args, PARAMETERS(8)).get.asInstanceOf[String])

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestPartitionStatsIndex.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestPartitionStatsIndex.scala
@@ -426,7 +426,7 @@ class TestPartitionStatsIndex extends PartitionStatsIndexTestBase {
     // Add more ingests and trigger a clean to remove files from first ingestion.
     val writeOpt = hudiOpts ++ Map(
       HoodieCleanConfig.AUTO_CLEAN.key -> "true",
-      HoodieCleanConfig.CLEAN_MAX_COMMITS.key -> "1",
+      HoodieCleanConfig.CLEAN_TRIGGER_MAX_COMMITS.key -> "1",
       HoodieCleanConfig.CLEANER_COMMITS_RETAINED.key -> "2")
     // Do three more ingestion to trigger clean operation.
     for (i <- 0 until 3) {


### PR DESCRIPTION
Mirror of https://github.com/apache/hudi/pull/18322 for automated bot review.

**Original author:** @nsivabalan
**Base branch:** master


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a new configuration option to limit the number of commits cleaned in a single operation, enabling better control over cleanup performance.

* **Refactor**
  * Renamed cleaning trigger configuration parameter for improved clarity.
  * Enhanced cleanup logic to enforce commit-per-operation limits and optimize retention calculations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->