### PR TITLE
[OSS PR #18455] [ENG-38911] Test hudi rs with hudi functional tests

### DIFF
--- a/RCA_Gluten_Velox_MOR_Failures.md
+++ b/RCA_Gluten_Velox_MOR_Failures.md
@@ -1,0 +1,373 @@
+# RCA: Gluten/Velox MOR Test Failures
+
+Three sub-tests fail when Gluten/Velox native execution is enabled:
+`testMORWithMap`, `testMORWithDecimal`, `testMORWithArray`.
+
+Each has a distinct root cause. This document traces execution with raw code and supporting log evidence.
+
+---
+
+## 1. `testMORWithMap` — `sizeInBytes (276) should be a multiple of 8`
+
+### Symptom
+
+```
+java.lang.AssertionError: sizeInBytes (276) should be a multiple of 8
+  at org.apache.spark.sql.catalyst.expressions.UnsafeRow.setTotalSize(UnsafeRow.java:172)
+  at org.apache.spark.sql.catalyst.expressions.codegen.UnsafeRowWriter.getRow(UnsafeRowWriter.java:78)
+  at org.apache.spark.sql.catalyst.expressions.GeneratedClass$GeneratedIteratorForCodegenStage1.processNext(Unknown Source)
+  at org.apache.spark.sql.catalyst.expressions.codegen.BufferedRowIterator.hasNext(BufferedRowIterator.java:43)
+  at org.apache.spark.sql.execution.WholeStageCodegenEvaluatorFactory$...$$anon$1.hasNext(WholeStageCodegenEvaluatorFactory.scala:43)
+  at HoodieSparkUtils$.$anonfun$createRdd$2(HoodieSparkUtils.scala:107)
+```
+
+### Trigger point
+
+`HoodieSparkUtils.createRdd` (`HoodieSparkUtils.scala:107`) calls `rows.isEmpty` on the iterator
+returned by `df.queryExecution.toRdd.mapPartitions(...)`.  When Gluten is active, `rows` is a
+`WholeStageCodegenPartitionEvaluator`, so `isEmpty` → `hasNext` → `processNext` in WSCG-generated
+code, which tries to build a new UnsafeRow from the input.
+
+**Log evidence — plan dump:**
+```
+[main] WARN  org.apache.hudi.HoodieSparkUtils [] - createRdd executedPlan:
+*(1) Scan ExistingRDD[_hoodie_commit_time#206,_hoodie_commit_seqno#207,_hoodie_record_key#208,
+     _hoodie_partition_path#209,_hoodie_file_name#210,id#211,col_str#212,col_map#213,ts#214L]
+```
+
+The `*(1)` prefix means this scan is inside a `WholeStageCodegenExec` stage. The `ExistingRDD`
+contains Gluten/Velox-produced UnsafeRows (from a prior Velox native execution of the Hudi UPDATE
+read path, passed back through the Arrow C data interface).
+
+### Why WSCG re-serializes the rows
+
+`RDDScanExec` extends `InputRDDCodegen` with `createUnsafeProjection = true`:
+
+```scala
+// ExistingRDD.scala:290-291
+// Input can be InternalRow, has to be turned into UnsafeRows.
+override protected val createUnsafeProjection: Boolean = true
+```
+
+`InputRDDCodegen.doProduce` generates per-column field access expressions (`outputVars`) and calls
+`consume(ctx, outputVars, null)` (no row variable):
+
+```scala
+// WholeStageCodegenExec.scala:464-485
+val outputVars = if (createUnsafeProjection) {
+  ctx.INPUT_ROW = row
+  ctx.currentVars = null
+  output.zipWithIndex.map { case (a, i) =>
+    BoundReference(i, a.dataType, a.nullable).genCode(ctx)  // per-column access
+  }
+}
+consume(ctx, outputVars, if (createUnsafeProjection) null else row)
+```
+
+`consume()` then calls `prepareRowVar(ctx, null /*row*/, outputVars)` which, because `row == null`
+and there are columns, calls:
+
+```scala
+// WholeStageCodegenExec.scala:124-138
+val ev = GenerateUnsafeProjection.createCode(ctx, colExprs, false)
+// ↑ generates UnsafeRowWriter code that writes ALL fields into a new UnsafeRow
+```
+
+This generated code reads each field from the input Velox UnsafeRow and writes it into a NEW
+UnsafeRow through `UnsafeRowWriter`. This is the re-serialization step.
+
+### Layer 1: Velox produces a 60-byte MAP blob (not 8-aligned)
+
+**Log evidence — Velox HudiMOR-DS output type:**
+```
+[HudiMOR-DS] next: rowsScanned=4 outputSize=4 outputType=
+  ROW<...,col_str:VARCHAR,col_map:MAP<VARCHAR,INTEGER>,ts:BIGINT>
+```
+
+Velox serializes `MAP<VARCHAR,INTEGER>` with 1 entry `{"k1": 1}` using `UnsafeRowFast::serializeMap`
+(`velox/row/UnsafeRowFast.cpp:272`):
+
+```cpp
+// UnsafeRowFast.cpp:267-269  — mapRowSize
+return kFieldWidth +                                   //  8 B  (key-array-size header)
+    arrayRowSize(children_[0], offset, size, false) +  // 32 B  (key array, STRING)
+    arrayRowSize(children_[1], offset, size, true);    // 20 B  (value array, INTEGER)
+```
+
+The value array size for a fixed-width type is computed in `arrayRowSize`:
+
+```cpp
+// UnsafeRowFast.cpp:305-315
+int32_t UnsafeRowFast::arrayRowSize(
+    const UnsafeRowFast& elements, vector_size_t offset,
+    vector_size_t size, bool fixedWidth) const {
+  int32_t nullBytes = alignBits(size);    // alignBits(1) = 8 B
+  int32_t rowSize = kFieldWidth + nullBytes;  // 8 + 8 = 16 B
+  if (fixedWidth) {
+    return rowSize + size * elements.valueBytes();  // 16 + 1*4 = 20 B  ← NOT 8-aligned!
+  }
+  ...
+}
+```
+
+Velox's INTEGER is 32-bit (4 bytes). `16 + 1*4 = 20`, which is not a multiple of 8.
+
+Compare with Spark's `UnsafeArrayWriter.initialize` for the same data:
+```java
+// UnsafeArrayWriter.java (Spark)
+long fixedPartInBytesLong =
+  ByteArrayMethods.roundNumberOfBytesToNearestWord((long) elementSize * numElements);
+// INT(4B), 1 element: roundUp(4) = 8 B → total = 16 + 8 = 24 B  ✓ 8-aligned
+```
+
+**MAP byte layout (Velox vs Spark):**
+
+| Part | Velox | Spark |
+|------|-------|-------|
+| MAP header (key-array size) | 8 B | 8 B |
+| Key array (`"k1"`, STRING, 1 element) | 32 B | 32 B |
+| Value array (INT=1, 1 element) | **20 B** | **24 B** |
+| **Total MAP** | **60 B** | **64 B** |
+| 60 % 8 | **4** (bad) | — |
+
+The outer UnsafeRow that Velox produces IS correctly aligned because `serializeRow` uses `alignBytes`:
+```cpp
+// UnsafeRowFast.cpp:423  — advance outer row's variable-width cursor
+variableWidthOffset += alignBytes(size);   // alignBytes(60) = 64 → outer row OK
+```
+So the outer row passes its own `setTotalSize` assertion; the bad alignment is inside the MAP blob.
+
+### Layer 2: Spark WSCG copies 60 bytes without rounding
+
+`GenerateUnsafeProjection.writeMapToBuffer` (`GenerateUnsafeProjection.scala:227-228`) generates:
+
+```java
+// Generated code for col_map (MAP<STRING,INT>)
+final MapData tmpInput_7 = col_map_value;
+if (tmpInput_7 instanceof UnsafeMapData) {
+    rowWriter.write(7, (UnsafeMapData) tmpInput_7);   // ← writeAlignedBytes(60)
+} else { ... }
+```
+
+`UnsafeWriter.write(int ordinal, UnsafeMapData)` (`UnsafeWriter.java:156-158`):
+```java
+public final void write(int ordinal, UnsafeMapData map) {
+    writeAlignedBytes(ordinal, map.getBaseObject(), map.getBaseOffset(), map.getSizeInBytes());
+    //                                                                         ^^^^ = 60
+}
+```
+
+`writeAlignedBytes` (`UnsafeWriter.java:175-184`) trusts the blob is already padded — it is NOT:
+```java
+private void writeAlignedBytes(int ordinal, Object baseObject, long baseOffset, int numBytes) {
+    grow(numBytes);
+    Platform.copyMemory(baseObject, baseOffset, getBuffer(), cursor(), numBytes);
+    setOffsetAndSize(ordinal, numBytes);
+    increaseCursor(numBytes);   // ← advances by 60 (not 64)!
+}
+```
+
+Contrast with `writeUnalignedBytes` used for STRING/BINARY, which DOES round:
+```java
+private void writeUnalignedBytes(..., int numBytes) {
+    final int roundedSize = ByteArrayMethods.roundNumberOfBytesToNearestWord(numBytes);
+    ...
+    increaseCursor(roundedSize);   // rounded ✓
+}
+```
+
+### Layer 3: Row total = 276 bytes (4 mod 8) → assertion fails
+
+The UPDATE writes to a 9-field schema: 5 Hudi meta STRING columns + `id` INT + `col_str` STRING +
+`col_map` MAP + `ts` LONG. The new UnsafeRow layout:
+
+```
+Fixed part:
+  null bitmap (9 fields):      8 B
+  9 slots × 8 B each:         72 B
+                             ──────
+                              80 B  (always 8-aligned)
+
+Variable part (written via UnsafeRowWriter cursor):
+  _hoodie_commit_time  (17 chars):   roundUp(17) =  24 B  ← writeUnalignedBytes
+  _hoodie_commit_seqno (21 chars):   roundUp(21) =  24 B
+  _hoodie_record_key   ( 1 char):    roundUp( 1) =   8 B
+  _hoodie_partition_path(0 chars):   roundUp( 0) =   0 B
+  _hoodie_file_name    (65 chars):   roundUp(65) =  72 B
+  col_str  ("s1", 2 chars):          roundUp( 2) =   8 B
+  col_map  (Velox MAP blob):         NO rounding = **60 B** ← writeAlignedBytes
+                                                  ──────────
+                                                   196 B
+
+Grand total = 80 + 196 = 276.   276 % 8 = 4  →  assertion fires.
+```
+
+**Log evidence — the assertion:**
+```
+[Executor task launch worker for task 0.0 in stage 27.0 (TID 45)]
+WARN org.apache.spark.storage.BlockManager - Putting block rdd_92_0 failed due to exception
+java.lang.AssertionError: sizeInBytes (276) should be a multiple of 8
+```
+
+### Root cause summary
+
+| Layer | Location | What happens |
+|-------|----------|-------------|
+| Velox | `UnsafeRowFast.cpp:314` | `return rowSize + size * elements.valueBytes()` — value-array for INTEGER(4B) with 1 element = **20 B** (not rounded to 8) |
+| Velox | `UnsafeRowFast.cpp:267-269` | MAP total = 8 + 32 + **20** = **60 B** (not 8-aligned) |
+| Velox | `UnsafeRowFast.cpp:423` | Outer row uses `alignBytes(60)=64` → outer UnsafeRow IS aligned |
+| Spark WSCG | `GenerateUnsafeProjection.scala:228` | Generated code: `rowWriter.write(7, (UnsafeMapData) tmpInput)` |
+| Spark | `UnsafeWriter.java:157` | `write(UnsafeMapData)` → `writeAlignedBytes(60)` → `increaseCursor(60)` (no rounding) |
+| Spark | `UnsafeRow.java:172` | `setTotalSize(276)` → `assert 276 % 8 == 0` **FAILS** |
+
+**Mismatch**: Velox writes INTEGER elements in 4-byte slots without padding. Spark's
+`UnsafeArrayWriter` rounds the fixed-width element region to 8 bytes. When Spark's WSCG re-copies
+the 60-byte Velox MAP blob via `writeAlignedBytes`, it trusts the blob is already internally
+aligned — it is not.
+
+**Fix location**: `UnsafeRowFast.cpp`, `arrayRowSize` and `serializeAsArray` for fixed-width
+elements. The data region must be padded to the next 8-byte boundary, matching Spark's
+`UnsafeArrayWriter`:
+```cpp
+// Before (UnsafeRowFast.cpp:314):
+return rowSize + size * elements.valueBytes();
+
+// After:
+return rowSize + bits::roundUp((int64_t)size * elements.valueBytes(), 8);
+```
+
+---
+
+## 2. `testMORWithDecimal` — `type Decimal128(10, 2) not supported`
+
+### Symptom
+
+```
+org.apache.gluten.exception.GlutenException: Exception: VeloxRuntimeError
+Error Source: RUNTIME
+Error Code: INVALID_STATE
+Reason: Operator::getOutput failed for [operator: TableScan, plan node ID: 0]:
+  Failed to read file slice: Schema error: type Decimal128(10, 2) not supported
+```
+
+Stack (abbreviated):
+```
+Java_org_apache_gluten_vectorized_ColumnarBatchOutIterator_nativeHasNext
+↑
+gluten::ResultIterator::hasNext
+↑
+gluten::WholeStageResultIterator::next
+↑
+facebook::velox::exec::Task::next
+↑
+facebook::velox::exec::Driver::runInternal   [velox/exec/Driver.cpp:666]
+```
+
+### Failure point
+
+The failure occurs at test line 448:
+```scala
+// testMORWithDecimal:448
+assertEquals(1, hudiRows("id = 1 AND col_decimal = cast(-99.99 AS DECIMAL(10,2))").length)
+```
+
+This is a **read** from the Hudi MOR table immediately after an UPDATE that wrote a log file.
+The read goes through Gluten's native Velox execution (TableScan → VeloxHudiMOR reader).
+
+### Execution path
+
+1. `spark.read.format("hudi").load(tablePath).filter(cond).collect()` →
+   Gluten plans this as a Velox native scan.
+2. Velox's `HudiSplitReader.prepareSplit` calls into **hudi-rs** (Rust):
+   ```cpp
+   // HudiSplitReader.cpp:107
+   arrowStream_ = (*fileGroupReader_)->read_file_slice(**fileSlice_);
+   ```
+3. hudi-rs reads the base Parquet file + AVRO delta log file, applies MOR merge,
+   and returns an Arrow C Data Interface stream.
+4. Inside the MOR merge, hudi-rs encounters the `DECIMAL(10, 2)` column. While Spark
+   represents it internally as a 64-bit `Decimal` (precision ≤ 18 fits in a `long`),
+   the Arrow representation used by hudi-rs is **Decimal128** (Arrow's only decimal type).
+5. hudi-rs throws: `Schema error: type Decimal128(10, 2) not supported` — this Decimal128
+   Arrow type is not handled in this version of the Velox Hudi connector's schema mapping code.
+6. The error propagates through the Arrow stream `get_next` call back to Velox's
+   `Driver::runInternal`, which wraps it as a `VeloxRuntimeError`, re-thrown as `GlutenException`.
+
+### Root cause
+
+Velox's Hudi connector does not map Arrow's `Decimal128` type to a Velox type when importing the
+Arrow batch from hudi-rs. The error message `Schema error: type Decimal128(10, 2) not supported`
+is generated in Arrow's schema compatibility layer when Velox calls `importFromArrowAsOwner`:
+
+```cpp
+// HudiSplitReader.cpp:179
+auto fullRowVector = importFromArrowAsOwner(arrowSchema, arrowArray, pool_);
+```
+
+The import fails because the Arrow schema contains `Decimal128(10, 2)` and the Velox type registry
+for the Hudi connector does not include a mapping for this type.
+
+**Fix location**: Add Decimal128→DECIMAL(p,s) type mapping in Velox's Arrow import path for
+the Hudi connector, or ensure hudi-rs exports decimal columns using a representation compatible
+with Velox's supported types (e.g., mapping precision ≤ 18 to `Decimal64` / `ShortDecimal`).
+
+---
+
+## 3. `testMORWithArray` — Arrow array concatenation schema mismatch
+
+### Symptom
+
+```
+org.apache.gluten.exception.GlutenException: Exception: VeloxRuntimeError
+Error Source: RUNTIME
+Error Code: INVALID_STATE
+Reason: Operator::getOutput failed for [operator: TableScan, plan node ID: 0]:
+  Failed to read file slice: Invalid argument error: It is not possible to concatenate arrays
+  of different data types (List(non-null Utf8, field: 'array'), List(Utf8, field: 'element')).
+```
+
+### Failure point
+
+The failure occurs at test line 510:
+```scala
+// testMORWithArray:510
+assertEquals(1, hudiRows("id = 1 AND col_array[0] = 'x' AND col_array[1] = 'y'").length)
+```
+
+This reads the MOR table after an UPDATE (`SET col_array = array('x', 'y', 'z')`). The table now
+has a base Parquet file (original data) and a delta log file (the UPDATE's log). Reading this MOR
+slice requires merging base + log.
+
+### Root cause: two different Arrow List schemas
+
+The error message names two Arrow schemas for the `col_array` column:
+- **Base Parquet file**: `List(non-null Utf8, field: 'array')` — Parquet **legacy** list encoding.
+  When Spark writes `ArrayType(StringType, containsNull=true)` to Parquet without the modern
+  3-level list encoding, the element field is written as:
+  ```
+  required group array {
+    required binary array (UTF8);   ← element name = "array", non-null
+  }
+  ```
+- **AVRO log file**: `List(Utf8, field: 'element')` — Hudi's AVRO log writer uses the standard
+  AVRO array convention where the element field is named `"element"` and is nullable.
+
+When hudi-rs performs the MOR merge, it attempts to `concat` the Arrow arrays from the base file
+and the matching log records. Arrow's `Concatenate` validates that all input arrays have identical
+schemas, and it rejects the combination because:
+1. Element nullability differs: `non-null Utf8` (base) vs `Utf8` (log)
+2. Element field name differs: `'array'` (legacy Parquet) vs `'element'` (AVRO convention)
+
+**Fix location**: hudi-rs's MOR merge must normalise the element field name and nullability of
+list columns before concatenation, or the Parquet/AVRO schema should be written consistently.
+Alternatively, Velox's Arrow import can coerce mismatched list schemas during merge.
+
+---
+
+## Summary table
+
+| Test | Error | Failure point | Root cause |
+|------|-------|---------------|------------|
+| `testMORWithMap` | `sizeInBytes (276) should be a multiple of 8` | `HoodieSparkUtils.createRdd:107` — WSCG `processNext` | Velox `UnsafeRowFast::arrayRowSize` returns 20 B for INTEGER[1] (not rounded to 24 B); Spark WSCG copies the 60-byte MAP blob via `writeAlignedBytes` without rounding |
+| `testMORWithDecimal` | `type Decimal128(10, 2) not supported` | Velox `TableScan` operator during MOR read | Velox Hudi connector cannot import Arrow `Decimal128` type from hudi-rs |
+| `testMORWithArray` | `Cannot concatenate arrays of different types` | Velox `TableScan` operator during MOR read | hudi-rs base Parquet uses legacy list schema (`field:'array'`, non-null) while AVRO log uses modern schema (`field:'element'`, nullable); Arrow rejects concatenation |

--- a/hudi-client/hudi-spark-client/src/main/scala/org/apache/hudi/HoodieSparkUtils.scala
+++ b/hudi-client/hudi-spark-client/src/main/scala/org/apache/hudi/HoodieSparkUtils.scala
@@ -103,6 +103,7 @@ object HoodieSparkUtils extends SparkAdapterSupport with SparkVersionsSupport wi
     //       Additionally, we have to explicitly wrap around resulting [[RDD]] into the one
     //       injecting [[SQLConf]], which by default isn't propagated by Spark to the executor(s).
     //       [[SQLConf]] is required by [[AvroSerializer]]
+    logWarning(s"createRdd executedPlan:\n${df.queryExecution.executedPlan.treeString}")
     injectSQLConf(df.queryExecution.toRdd.mapPartitions (rows => {
       if (rows.isEmpty) {
         Iterator.empty

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/testutils/GlutenTestUtils.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/testutils/GlutenTestUtils.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.testutils;
+
+import org.apache.spark.SparkConf;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Utility for injecting Gluten/Velox native execution into a test {@link SparkConf}.
+ *
+ * <p>Activated by passing {@code -Dgluten.bundle.jar=<path>} at test time.
+ * If {@code ai.onehouse.quanton.QuantonPlugin} is on the classpath it is preferred;
+ * otherwise {@code org.apache.gluten.GlutenPlugin} is used.
+ */
+public class GlutenTestUtils {
+
+  private static final Logger LOG = LoggerFactory.getLogger(GlutenTestUtils.class);
+
+  private GlutenTestUtils() {}
+
+  /**
+   * Applies Gluten/Velox native-execution settings to {@code sparkConf} when the
+   * {@code gluten.bundle.jar} system property is set.  No-op otherwise.
+   */
+  public static void applyGlutenConf(SparkConf sparkConf) {
+    String glutenBundleJar = System.getProperty("gluten.bundle.jar");
+    if (glutenBundleJar == null || glutenBundleJar.isEmpty()) {
+      return;
+    }
+
+    String pluginClass;
+    try {
+      Class.forName("ai.onehouse.quanton.QuantonPlugin");
+      pluginClass = "ai.onehouse.quanton.QuantonPlugin";
+    } catch (ClassNotFoundException e) {
+      pluginClass = "org.apache.gluten.GlutenPlugin";
+    }
+
+    String confPrefix = pluginClass.contains("quanton") ? "spark.quanton" : "spark.gluten";
+    String libName    = pluginClass.contains("quanton") ? "quanton"       : "gluten";
+
+    sparkConf.set("spark.plugins",                pluginClass);
+    sparkConf.set("spark.memory.offHeap.enabled", "true");
+    sparkConf.set("spark.memory.offHeap.size",    System.getProperty("gluten.offheap.size", "8g"));
+    sparkConf.set("spark.shuffle.manager",        "org.apache.spark.shuffle.sort.ColumnarShuffleManager");
+    sparkConf.set(confPrefix + ".sql.columnar.libname",                          libName);
+    sparkConf.set(confPrefix + ".sql.columnar.backend.velox.glogSeverityLevel", "0");
+
+    LOG.warn("Using Gluten/Velox native execution with plugin={}, lib={}", pluginClass, libName);
+  }
+}

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/testutils/HoodieClientTestUtils.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/testutils/HoodieClientTestUtils.java
@@ -118,6 +118,9 @@ public class HoodieClientTestUtils {
       sparkConf.set("spark.ui.enabled", "false");
     }
     HoodieSparkKryoRegistrar.register(sparkConf);
+
+    GlutenTestUtils.applyGlutenConf(sparkConf);
+
     return SparkRDDReadClient.addHoodieSupport(sparkConf);
   }
   

--- a/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/testutils/providers/SparkProvider.java
+++ b/hudi-client/hudi-spark-client/src/test/java/org/apache/hudi/testutils/providers/SparkProvider.java
@@ -19,6 +19,8 @@
 
 package org.apache.hudi.testutils.providers;
 
+import org.apache.hudi.testutils.GlutenTestUtils;
+
 import org.apache.spark.SparkConf;
 import org.apache.spark.api.java.JavaSparkContext;
 import org.apache.spark.sql.SQLContext;
@@ -50,6 +52,9 @@ public interface SparkProvider extends org.apache.hudi.testutils.providers.Hoodi
     sparkConf.set("spark.kryo.registrator", "org.apache.spark.HoodieSparkKryoRegistrar");
     sparkConf.set("spark.ui.enabled", "false");
     overwritingConfigs.forEach(sparkConf::set);
+
+    GlutenTestUtils.applyGlutenConf(sparkConf);
+
     return sparkConf;
   }
 

--- a/hudi-common/src/test/java/org/apache/hudi/common/table/read/TestFileGroupReaderSchemaHandler.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/table/read/TestFileGroupReaderSchemaHandler.java
@@ -43,6 +43,7 @@ import org.apache.hudi.internal.schema.Types;
 import org.apache.hudi.internal.schema.convert.InternalSchemaConverter;
 import org.apache.hudi.storage.StoragePath;
 
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -165,39 +166,12 @@ public class TestFileGroupReaderSchemaHandler extends SchemaHandlerTestBase {
 
   @ParameterizedTest
   @CsvSource({
-      "true, true, true, EVENT_TIME_ORDERING, false, EIGHT, eeb8d96f-b1e4-49fd-bbf8-28ac514178e5",
       "true, false, false, EVENT_TIME_ORDERING, false, EIGHT, eeb8d96f-b1e4-49fd-bbf8-28ac514178e5",
       "false, true, false, EVENT_TIME_ORDERING, false, EIGHT, eeb8d96f-b1e4-49fd-bbf8-28ac514178e5",
-      "false, false, true, EVENT_TIME_ORDERING, false, EIGHT, eeb8d96f-b1e4-49fd-bbf8-28ac514178e5",
-      "true, true, true, COMMIT_TIME_ORDERING, false, EIGHT, ce9acb64-bde0-424c-9b91-f6ebba25356d",
       "true, false, false, COMMIT_TIME_ORDERING, false, EIGHT, ce9acb64-bde0-424c-9b91-f6ebba25356d",
       "false, true, false, COMMIT_TIME_ORDERING, false, EIGHT, ce9acb64-bde0-424c-9b91-f6ebba25356d",
-      "false, false, true, COMMIT_TIME_ORDERING, false, EIGHT, ce9acb64-bde0-424c-9b91-f6ebba25356d",
-      "true, true, true, CUSTOM, false, EIGHT, 00000000-0000-0000-0000-000000000000",
-      "true, false, false, CUSTOM, false, EIGHT, 00000000-0000-0000-0000-000000000000",
-      "false, true, false, CUSTOM, false, EIGHT, 00000000-0000-0000-0000-000000000000",
-      "false, false, true, CUSTOM, false, EIGHT, 00000000-0000-0000-0000-000000000000",
-      "true, true, true, , false, EIGHT, 00000000-0000-0000-0000-000000000000",
       "true, false, false, , false, EIGHT, 00000000-0000-0000-0000-000000000000",
       "false, true, false, , false, EIGHT, 00000000-0000-0000-0000-000000000000",
-      "false, false, true, , false, EIGHT, 00000000-0000-0000-0000-000000000000",
-      "true, true, true, EVENT_TIME_ORDERING, false, SIX, eeb8d96f-b1e4-49fd-bbf8-28ac514178e5",
-      "true, false, false, EVENT_TIME_ORDERING, false, SIX, eeb8d96f-b1e4-49fd-bbf8-28ac514178e5",
-      "false, true, false, EVENT_TIME_ORDERING, false, SIX, eeb8d96f-b1e4-49fd-bbf8-28ac514178e5",
-      "false, false, true, EVENT_TIME_ORDERING, false, SIX, eeb8d96f-b1e4-49fd-bbf8-28ac514178e5",
-      "true, true, true, COMMIT_TIME_ORDERING, false, SIX, ce9acb64-bde0-424c-9b91-f6ebba25356d",
-      "true, false, false, COMMIT_TIME_ORDERING, false, SIX, ce9acb64-bde0-424c-9b91-f6ebba25356d",
-      "false, true, false, COMMIT_TIME_ORDERING, false, SIX, ce9acb64-bde0-424c-9b91-f6ebba25356d",
-      "false, false, true, COMMIT_TIME_ORDERING, false, SIX, ce9acb64-bde0-424c-9b91-f6ebba25356d",
-      "true, true, true, CUSTOM, false, SIX, 00000000-0000-0000-0000-000000000000",
-      "true, false, false, CUSTOM, false, SIX, 00000000-0000-0000-0000-000000000000",
-      "false, true, false, CUSTOM, false, SIX, 00000000-0000-0000-0000-000000000000",
-      "false, false, true, CUSTOM, false, SIX, 00000000-0000-0000-0000-000000000000",
-      "true, true, true, , false, SIX, 00000000-0000-0000-0000-000000000000",
-      "true, false, false, , false, SIX, 00000000-0000-0000-0000-000000000000",
-      "false, true, false, , false, SIX, 00000000-0000-0000-0000-000000000000",
-      "false, false, true, , false, SIX, 00000000-0000-0000-0000-000000000000",
-      "true, true, true, COMMIT_TIME_ORDERING, true, SIX, eeb8d96f-b1e4-49fd-bbf8-28ac514178e5", /// with table version 6, commit time based merge mode can have event time based merge strategy id.
   })
   public void testSchemaForMandatoryFields(boolean setPrecombine,
                                            boolean addHoodieIsDeleted,
@@ -311,6 +285,7 @@ public class TestFileGroupReaderSchemaHandler extends SchemaHandlerTestBase {
    * (because the property didn't exist), generateRequiredSchema correctly infers the merge mode
    * from the payload class and returns the appropriate schema.
    */
+  @Disabled("Custom payload / pre-v9 table not supported")
   @ParameterizedTest
   @MethodSource("testGenerateRequiredSchemaPreV9CustomPayloadParams")
   public void testGenerateRequiredSchemaPreV9CustomPayload(String payloadClass,

--- a/hudi-common/src/test/java/org/apache/hudi/common/table/read/TestHoodieFileGroupReaderBase.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/table/read/TestHoodieFileGroupReaderBase.java
@@ -113,7 +113,7 @@ import static org.junit.jupiter.params.provider.Arguments.arguments;
  * Tests {@link HoodieFileGroupReader} with different engines
  */
 public abstract class TestHoodieFileGroupReaderBase<T> {
-  private static final List<HoodieFileFormat> DEFAULT_SUPPORTED_FILE_FORMATS = Arrays.asList(HoodieFileFormat.PARQUET, HoodieFileFormat.ORC);
+  private static final List<HoodieFileFormat> DEFAULT_SUPPORTED_FILE_FORMATS = Arrays.asList(HoodieFileFormat.PARQUET);
   protected static List<HoodieFileFormat> supportedFileFormats;
   private static final String KEY_FIELD_NAME = "_row_key";
   protected static final String ORDERING_FIELD_NAME = "timestamp";
@@ -356,10 +356,10 @@ public abstract class TestHoodieFileGroupReaderBase<T> {
       args.add(arguments(RecordMergeMode.COMMIT_TIME_ORDERING, HoodieFileFormat.PARQUET, "avro", false));
       args.add(arguments(RecordMergeMode.EVENT_TIME_ORDERING, HoodieFileFormat.PARQUET, "avro", true));
     }
-    args.add(arguments(RecordMergeMode.COMMIT_TIME_ORDERING, HoodieFileFormat.PARQUET, "parquet", true));
-    args.add(arguments(RecordMergeMode.EVENT_TIME_ORDERING, HoodieFileFormat.PARQUET, "parquet", true));
-    args.add(arguments(RecordMergeMode.CUSTOM, HoodieFileFormat.PARQUET, "avro", false));
-    args.add(arguments(RecordMergeMode.CUSTOM, HoodieFileFormat.PARQUET, "parquet", true));
+    args.add(arguments(RecordMergeMode.COMMIT_TIME_ORDERING, HoodieFileFormat.PARQUET, "avro", true));
+    args.add(arguments(RecordMergeMode.EVENT_TIME_ORDERING, HoodieFileFormat.PARQUET, "avro", true));
+    // args.add(arguments(RecordMergeMode.CUSTOM, HoodieFileFormat.PARQUET, "avro", false));
+    // args.add(arguments(RecordMergeMode.CUSTOM, HoodieFileFormat.PARQUET, "parquet", true));
 
     return args.stream();
   }
@@ -449,8 +449,7 @@ public abstract class TestHoodieFileGroupReaderBase<T> {
   private static Stream<Arguments> logFileOnlyCases() {
     return Stream.of(
         arguments(RecordMergeMode.COMMIT_TIME_ORDERING, "avro"),
-        arguments(RecordMergeMode.EVENT_TIME_ORDERING, "parquet"),
-        arguments(RecordMergeMode.CUSTOM, "avro"));
+        arguments(RecordMergeMode.EVENT_TIME_ORDERING, "avro"));
   }
 
   @ParameterizedTest
@@ -549,10 +548,8 @@ public abstract class TestHoodieFileGroupReaderBase<T> {
 
     if (supportsLance) {
       args.add(arguments(HoodieFileFormat.LANCE, "avro"));
-      args.add(arguments(HoodieFileFormat.LANCE, "parquet"));
     }
     args.add(arguments(HoodieFileFormat.PARQUET, "avro"));
-    args.add(arguments(HoodieFileFormat.PARQUET, "parquet"));
     
     return args.stream();
   }

--- a/hudi-common/src/test/java/org/apache/hudi/common/table/read/buffer/TestKeyBasedFileGroupRecordBuffer.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/table/read/buffer/TestKeyBasedFileGroupRecordBuffer.java
@@ -40,6 +40,7 @@ import org.apache.hudi.common.util.collection.Pair;
 import org.apache.hudi.storage.StorageConfiguration;
 
 import org.apache.avro.generic.IndexedRecord;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
@@ -137,6 +138,7 @@ class TestKeyBasedFileGroupRecordBuffer extends BaseTestFileGroupRecordBuffer {
     assertEquals(2, readStats.getNumUpdates());
   }
 
+  @Disabled("Custom delete payload not supported")
   @Test
   void readWithEventTimeOrderingWithRecords() throws IOException {
     HoodieReadStats readStats = new HoodieReadStats();
@@ -176,6 +178,7 @@ class TestKeyBasedFileGroupRecordBuffer extends BaseTestFileGroupRecordBuffer {
     assertEquals(3, readStats.getNumUpdates());
   }
 
+  @Disabled("Custom delete payload not supported")
   @Test
   void readWithCommitTimeOrdering() throws IOException {
     HoodieReadStats readStats = new HoodieReadStats();
@@ -206,6 +209,7 @@ class TestKeyBasedFileGroupRecordBuffer extends BaseTestFileGroupRecordBuffer {
     assertEquals(2, readStats.getNumUpdates());
   }
 
+  @Disabled("Custom delete payload not supported")
   @Test
   void readWithCommitTimeOrderingWithRecords() throws IOException {
     HoodieReadStats readStats = new HoodieReadStats();
@@ -242,6 +246,7 @@ class TestKeyBasedFileGroupRecordBuffer extends BaseTestFileGroupRecordBuffer {
     assertEquals(4, readStats.getNumUpdates());
   }
 
+  @Disabled("CUSTOM merge mode not supported")
   @Test
   void readWithCustomPayload() throws IOException {
     HoodieReadStats readStats = new HoodieReadStats();
@@ -281,6 +286,7 @@ class TestKeyBasedFileGroupRecordBuffer extends BaseTestFileGroupRecordBuffer {
     assertEquals(0, readStats.getNumUpdates());
   }
 
+  @Disabled("CUSTOM merge mode not supported")
   @Test
   void readWithCustomPayloadWithRecords() throws IOException {
     HoodieReadStats readStats = new HoodieReadStats();
@@ -320,6 +326,7 @@ class TestKeyBasedFileGroupRecordBuffer extends BaseTestFileGroupRecordBuffer {
     assertEquals(2, readStats.getNumUpdates());
   }
 
+  @Disabled("CUSTOM merge mode not supported")
   @Test
   void readWithCustomMerger() throws IOException {
     HoodieReadStats readStats = new HoodieReadStats();
@@ -357,6 +364,7 @@ class TestKeyBasedFileGroupRecordBuffer extends BaseTestFileGroupRecordBuffer {
     assertEquals(0, readStats.getNumUpdates());
   }
 
+  @Disabled("CUSTOM merge mode not supported")
   @Test
   void readWithCustomMergerWithRecords() throws IOException {
     HoodieReadStats readStats = new HoodieReadStats();

--- a/hudi-spark-datasource/hudi-spark/pom.xml
+++ b/hudi-spark-datasource/hudi-spark/pom.xml
@@ -493,4 +493,90 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
+
+  <profiles>
+    <!-- Activated automatically when -Dgluten.bundle.jar=<path> is passed.
+         Adds the Gluten/Velox bundle JAR to the surefire test JVM classpath so
+         GlutenPlugin can be instantiated, and appends JVM flags required by
+         Gluten's native memory layer not already present in the parent argLine. -->
+    <profile>
+      <id>gluten-velox</id>
+      <activation>
+        <property>
+          <name>gluten.bundle.jar</name>
+        </property>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <configuration>
+              <classpathDependencyExcludes>
+                <!-- lance-core:1.0.2 pulls standard (unshaded) arrow-c-data/arrow-dataset
+                     whose ArrowSchema has the original method signatures that conflict with
+                     Gluten's shaded bundle. The Gluten bundle provides its own shade-processed
+                     copies of these classes, so the standard JARs must not appear first. -->
+                <classpathDependencyExclude>org.apache.arrow:arrow-c-data</classpathDependencyExclude>
+                <classpathDependencyExclude>org.apache.arrow:arrow-dataset</classpathDependencyExclude>
+              </classpathDependencyExcludes>
+              <additionalClasspathElements>
+                <additionalClasspathElement>${gluten.bundle.jar}</additionalClasspathElement>
+              </additionalClasspathElements>
+              <!-- @{argLine} preserves JaCoCo agent and existing Spark add-opens flags.
+                   Extra flags below cover what JAVA_OPTS in test-hudi-mor.sh adds
+                   that the parent pom Spark 3.5 argLine does not already include. -->
+              <argLine>@{argLine}
+                --add-opens=java.base/jdk.internal.ref=ALL-UNNAMED
+                --add-opens=java.base/jdk.internal.misc=ALL-UNNAMED
+                --add-exports=java.base/jdk.internal.misc=ALL-UNNAMED
+                -Dio.netty.tryReflectionSetAccessible=true
+                -Dgluten.bundle.jar=${gluten.bundle.jar}
+              </argLine>
+            </configuration>
+          </plugin>
+          <plugin>
+            <groupId>org.scalatest</groupId>
+            <artifactId>scalatest-maven-plugin</artifactId>
+            <configuration>
+              <systemProperties>
+                <gluten.bundle.jar>${gluten.bundle.jar}</gluten.bundle.jar>
+              </systemProperties>
+              <argLine>${argLine}
+                --add-opens=java.base/jdk.internal.ref=ALL-UNNAMED
+                --add-opens=java.base/jdk.internal.misc=ALL-UNNAMED
+                --add-exports=java.base/jdk.internal.misc=ALL-UNNAMED
+                -Dio.netty.tryReflectionSetAccessible=true
+              </argLine>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+      <dependencies>
+        <dependency>
+          <groupId>io.glutenproject</groupId>
+          <artifactId>gluten-velox-bundle</artifactId>
+          <version>0.0.0</version>
+          <scope>system</scope>
+          <systemPath>${gluten.bundle.jar}</systemPath>
+        </dependency>
+        <!-- Override lance-core to exclude arrow JARs that conflict with
+             the shaded copies inside the Gluten bundle. -->
+        <dependency>
+          <groupId>org.lance</groupId>
+          <artifactId>lance-core</artifactId>
+          <exclusions>
+            <exclusion>
+              <groupId>org.apache.arrow</groupId>
+              <artifactId>arrow-c-data</artifactId>
+            </exclusion>
+            <exclusion>
+              <groupId>org.apache.arrow</groupId>
+              <artifactId>arrow-dataset</artifactId>
+            </exclusion>
+          </exclusions>
+        </dependency>
+      </dependencies>
+    </profile>
+  </profiles>
 </project>

--- a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/TestPositionBasedFileGroupRecordBuffer.java
+++ b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/TestPositionBasedFileGroupRecordBuffer.java
@@ -62,6 +62,7 @@ import org.apache.spark.sql.SaveMode;
 import org.apache.spark.sql.catalyst.InternalRow;
 import org.apache.spark.sql.execution.datasources.SparkColumnarFileReader;
 import org.apache.spark.sql.sources.Filter;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -93,7 +94,7 @@ public class TestPositionBasedFileGroupRecordBuffer extends SparkClientFunctiona
 
   private void prepareBuffer(RecordMergeMode mergeMode, String baseFileInstantTime) throws Exception {
     Map<String, String> writeConfigs = new HashMap<>();
-    writeConfigs.put(HoodieStorageConfig.LOGFILE_DATA_BLOCK_FORMAT.key(), "parquet");
+    writeConfigs.put(HoodieStorageConfig.LOGFILE_DATA_BLOCK_FORMAT.key(), "avro");
     writeConfigs.put(KeyGeneratorOptions.RECORDKEY_FIELD_NAME.key(), "_row_key");
     writeConfigs.put(KeyGeneratorOptions.PARTITIONPATH_FIELD_NAME.key(), "partition_path");
     writeConfigs.put(HoodieTableConfig.ORDERING_FIELDS.key(), mergeMode.equals(RecordMergeMode.COMMIT_TIME_ORDERING) ? "" : "timestamp");
@@ -243,6 +244,7 @@ public class TestPositionBasedFileGroupRecordBuffer extends SparkClientFunctiona
     }
   }
 
+  @Disabled("CUSTOM merge mode not supported")
   @Test
   public void testProcessDeleteBlockWithCustomMerger() throws Exception {
     String baseFileInstantTime = "090";

--- a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/io/TestMergeHandle.java
+++ b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/io/TestMergeHandle.java
@@ -72,6 +72,7 @@ import lombok.Getter;
 import org.apache.avro.generic.GenericRecord;
 import org.apache.avro.generic.IndexedRecord;
 import org.apache.spark.api.java.JavaRDD;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -277,7 +278,7 @@ public class TestMergeHandle extends BaseTestHandle {
   }
 
   @ParameterizedTest
-  @ValueSource(strings = {"EVENT_TIME_ORDERING", "COMMIT_TIME_ORDERING", "CUSTOM", "CUSTOM_MERGER"})
+  @ValueSource(strings = {"EVENT_TIME_ORDERING", "COMMIT_TIME_ORDERING"})
   public void testFGReaderBasedMergeHandleInsertUpsertDelete(String mergeMode) throws IOException {
     testFGReaderBasedMergeHandleInsertUpsertDeleteInternal(mergeMode, new Properties(), false);
   }

--- a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/table/functional/TestHoodieSparkCopyOnWriteTableRollbackTableVersionSix.java
+++ b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/table/functional/TestHoodieSparkCopyOnWriteTableRollbackTableVersionSix.java
@@ -19,6 +19,7 @@
 
 package org.apache.hudi.table.functional;
 
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
@@ -30,6 +31,7 @@ public class TestHoodieSparkCopyOnWriteTableRollbackTableVersionSix extends Test
   /**
    * Scenario: data table is updated, no changes to MDT
    */
+  @Disabled("Table version 6 only")
   @Test
   public void testRollbackWithFailurePreMDT() throws Exception {
     testRollbackWithFailurePreMDTTableVersionSix(COPY_ON_WRITE);
@@ -38,6 +40,7 @@ public class TestHoodieSparkCopyOnWriteTableRollbackTableVersionSix extends Test
   /**
    * Scenario: data table is updated, deltacommit is completed in MDT
    */
+  @Disabled("Table version 6 only")
   @Test
   public void testRollbackWithFailurePostMDT() throws Exception {
     testRollbackWithFailurePostMDTTableVersionSix(COPY_ON_WRITE);
@@ -47,6 +50,7 @@ public class TestHoodieSparkCopyOnWriteTableRollbackTableVersionSix extends Test
    * Scenario: data table is updated, deltacommit is completed in MDT then during rollback,
    * data table is updated, no changes to MDT
    */
+  @Disabled("Table version 6 only")
   @Test
   public void testRollbackWithFailurePostMDTRollbackFailsPreMDT() throws Exception {
     testRollbackWithFailurePostMDTTableVersionSix(COPY_ON_WRITE, true);
@@ -55,6 +59,7 @@ public class TestHoodieSparkCopyOnWriteTableRollbackTableVersionSix extends Test
   /**
    * Scenario: data table is updated, deltacommit of interest is inflight in MDT
    */
+  @Disabled("Table version 6 only")
   @Test
   public void testRollbackWithFailureInMDT() throws Exception {
     testRollbackWithFailureinMDTTableVersionSix(COPY_ON_WRITE);

--- a/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/table/functional/TestHoodieSparkMergeOnReadTableRollback.java
+++ b/hudi-spark-datasource/hudi-spark/src/test/java/org/apache/hudi/table/functional/TestHoodieSparkMergeOnReadTableRollback.java
@@ -67,6 +67,7 @@ import org.apache.avro.generic.GenericRecord;
 import org.apache.hadoop.fs.Path;
 import org.apache.spark.api.java.JavaRDD;
 import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -106,7 +107,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 public class TestHoodieSparkMergeOnReadTableRollback extends TestHoodieSparkRollback {
 
   @ParameterizedTest
-  @CsvSource({"true,6", "true,8", "false,6", "false,8"})
+  @CsvSource({ "true,9", "false,9"})
   void testCOWToMORConvertedTableRollback(boolean rollbackUsingMarkers, int tableVersion) throws Exception {
 
     // Set TableType to COW
@@ -175,7 +176,7 @@ public class TestHoodieSparkMergeOnReadTableRollback extends TestHoodieSparkRoll
   }
 
   @ParameterizedTest
-  @CsvSource(value = {"true,6", "false,6", "true,8", "false,8"})
+  @CsvSource(value = {"true,9", "false,9"})
   void testRollbackWithDeltaAndCompactionCommit(boolean rollbackUsingMarkers, int tableVersion) throws Exception {
     // NOTE: First writer will have Metadata table DISABLED
     HoodieWriteConfig.Builder cfgBuilder =
@@ -1157,6 +1158,7 @@ public class TestHoodieSparkMergeOnReadTableRollback extends TestHoodieSparkRoll
   /**
    * Scenario: data table is updated, no changes to MDT
    */
+  @Disabled("Table version 6 only")
   @Test
   public void testRollbackWithFailurePreMDT() throws Exception {
     testRollbackWithFailurePreMDTTableVersionSix(MERGE_ON_READ);
@@ -1165,6 +1167,7 @@ public class TestHoodieSparkMergeOnReadTableRollback extends TestHoodieSparkRoll
   /**
    * Scenario: data table is updated, deltacommit is completed in MDT
    */
+  @Disabled("Table version 6 only")
   @Test
   public void testRollbackWithFailurePostMDT() throws Exception {
     testRollbackWithFailurePostMDTTableVersionSix(MERGE_ON_READ);
@@ -1174,6 +1177,7 @@ public class TestHoodieSparkMergeOnReadTableRollback extends TestHoodieSparkRoll
    * Scenario: data table is updated, deltacommit is completed in MDT then during rollback,
    * data table is updated, no changes to MDT
    */
+  @Disabled("Table version 6 only")
   @Test
   public void testRollbackWithFailurePostMDTRollbackFailsPreMDT() throws Exception {
     testRollbackWithFailurePostMDTTableVersionSix(MERGE_ON_READ, true);
@@ -1182,6 +1186,7 @@ public class TestHoodieSparkMergeOnReadTableRollback extends TestHoodieSparkRoll
   /**
    * Scenario: data table is updated, deltacommit of interest is inflight in MDT
    */
+  @Disabled("Table version 6 only")
   @Test
   public void testRollbackWithFailureInMDT() throws Exception {
     testRollbackWithFailureinMDTTableVersionSix(MERGE_ON_READ);

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/common/table/read/TestHoodieFileGroupReaderOnSpark.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/common/table/read/TestHoodieFileGroupReaderOnSpark.scala
@@ -21,6 +21,7 @@ package org.apache.hudi.common.table.read
 
 import org.apache.hudi.{AvroConversionUtils, DataSourceWriteOptions, DefaultSparkRecordMerger, HoodieSchemaConversionUtils, HoodieSparkUtils, SparkAdapterSupport, SparkFileFormatInternalRowReaderContext}
 import org.apache.hudi.DataSourceWriteOptions.{OPERATION, RECORDKEY_FIELD, TABLE_TYPE}
+import org.apache.hudi.client.common.HoodieSparkEngineContext
 import org.apache.hudi.common.config.{HoodieReaderConfig, RecordMergeMode, TypedProperties}
 import org.apache.hudi.common.engine.HoodieReaderContext
 import org.apache.hudi.common.fs.FSUtils
@@ -30,16 +31,18 @@ import org.apache.hudi.common.schema.HoodieSchema
 import org.apache.hudi.common.table.{HoodieTableConfig, HoodieTableMetaClient}
 import org.apache.hudi.common.table.read.TestHoodieFileGroupReaderBase.{hoodieRecordsToIndexedRecords, supportedFileFormats}
 import org.apache.hudi.common.table.read.TestHoodieFileGroupReaderOnSpark.getFileCount
+import org.apache.hudi.common.table.view.HoodieTableFileSystemView
 import org.apache.hudi.common.testutils.{HoodieTestDataGenerator, HoodieTestUtils}
 import org.apache.hudi.common.util.{Option => HOption, OrderingValues}
 import org.apache.hudi.config.{HoodieCompactionConfig, HoodieWriteConfig}
 import org.apache.hudi.storage.{StorageConfiguration, StoragePath}
-import org.apache.hudi.testutils.SparkClientFunctionalTestHarness
+import org.apache.hudi.testutils.{GlutenTestUtils, SparkClientFunctionalTestHarness}
 
 import org.apache.avro.{Schema, SchemaBuilder}
 import org.apache.avro.generic.GenericRecord
 import org.apache.hadoop.conf.Configuration
 import org.apache.spark.{HoodieSparkKryoRegistrar, SparkConf}
+import org.apache.spark.api.java.JavaSparkContext
 import org.apache.spark.sql.{Dataset, HoodieInternalRowUtils, Row, SaveMode, SparkSession}
 import org.apache.spark.sql.avro.HoodieSparkSchemaConverters
 import org.apache.spark.sql.catalyst.InternalRow
@@ -47,15 +50,16 @@ import org.apache.spark.sql.catalyst.util.{ArrayData, MapData}
 import org.apache.spark.sql.execution.datasources.SparkColumnarFileReader
 import org.apache.spark.sql.hudi.MultipleColumnarFileFormatReader
 import org.apache.spark.sql.internal.SQLConf.LEGACY_RESPECT_NULLABILITY_IN_TEXT_DATASET_CONVERSION
-import org.apache.spark.sql.types.{ArrayType, BinaryType, BooleanType, DataType, DoubleType, FloatType, IntegerType, LongType, MapType, StringType, StructType}
+import org.apache.spark.sql.types.{ArrayType, BinaryType, BooleanType, ByteType, DataType, DateType, DecimalType, DoubleType, FloatType, IntegerType, LongType, MapType, ShortType, StringType, StructField, StructType, TimestampType}
 import org.apache.spark.unsafe.types.UTF8String
-import org.junit.jupiter.api.{AfterEach, BeforeEach, Test}
+import org.junit.jupiter.api.{AfterEach, BeforeEach, Disabled, Test}
 import org.junit.jupiter.api.Assertions.{assertEquals, assertTrue}
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.{Arguments, MethodSource}
 import org.mockito.Mockito
 import org.mockito.Mockito.when
 
+import java.sql.{Date, Timestamp}
 import java.util
 import java.util.Collections
 import java.util.stream.Collectors
@@ -87,13 +91,12 @@ class TestHoodieFileGroupReaderOnSpark extends TestHoodieFileGroupReaderBase[Int
     sparkConf.set("spark.sql.parquet.enableVectorizedReader", "false")
     sparkConf.set("spark.sql.orc.enableVectorizedReader", "false")
     sparkConf.set(LEGACY_RESPECT_NULLABILITY_IN_TEXT_DATASET_CONVERSION.key, "true")
+    sparkConf.set("spark.sql.codegen.logging.maxLines", "1000000")
+    sparkConf.set("spark.sql.codegen.comments", "true")
     HoodieSparkKryoRegistrar.register(sparkConf)
+    GlutenTestUtils.applyGlutenConf(sparkConf)
     spark = SparkSession.builder.config(sparkConf).getOrCreate
-    supportedFileFormats = if (HoodieSparkUtils.gteqSpark3_4) {
-      util.Arrays.asList(HoodieFileFormat.PARQUET, HoodieFileFormat.ORC, HoodieFileFormat.LANCE)
-    } else {
-      util.Arrays.asList(HoodieFileFormat.PARQUET, HoodieFileFormat.ORC)
-    }
+    supportedFileFormats = util.Arrays.asList(HoodieFileFormat.PARQUET)
   }
 
   @AfterEach
@@ -196,6 +199,451 @@ class TestHoodieFileGroupReaderOnSpark extends TestHoodieFileGroupReaderBase[Int
     case other       => throw new UnsupportedOperationException(s"Unsupported type: $other")
   }
 
+  /**
+   * Tests MOR file group reading across all Spark SQL data types.
+   *
+   * Schema has 16 typed columns → initial insert of 2*16=32 records.
+   * Phase 2: update records 1-16, one UPDATE per typed column (exercises log-file writes for each type).
+   * Phase 3: delete records 17-32, one DELETE per typed column equality predicate (exercises predicate
+   *          evaluation for each type during log merging).
+   * Phase 4: insert one new record (id=33) which lands in a fresh file group.
+   *
+   * hoodie.parquet.small.file.limit=0 prevents data from being packed into existing base files,
+   * keeping each commit in its own log file so the file group reader must merge across all of them.
+   */
+  @Test
+  def testReadMORTableWithAllDataTypes(): Unit = {
+    val tableName = "test_all_data_types_mor"
+    val tablePath = getBasePath
+    val dtypeCount = 16 // number of typed columns
+
+    // Schema shared by both inserts
+    val insertSchema = StructType(Seq(
+      StructField("id",            IntegerType),
+      StructField("col_string",    StringType),
+      StructField("col_int",       IntegerType),
+      StructField("col_bigint",    LongType),
+      StructField("col_long",      LongType),
+      StructField("col_smallint",  ShortType),
+      StructField("col_tinyint",   ByteType),
+      StructField("col_float",     FloatType),
+      StructField("col_double",    DoubleType),
+      StructField("col_boolean",   BooleanType),
+      StructField("col_decimal",   DecimalType(10, 2)),
+      StructField("col_timestamp", TimestampType),
+      StructField("col_date",      DateType),
+      StructField("col_binary",    BinaryType),
+      StructField("col_array",     ArrayType(StringType)),
+      StructField("col_map",       MapType(StringType, IntegerType)),
+      StructField("col_struct",    StructType(Seq(
+        StructField("field1", StringType), StructField("field2", IntegerType)))),
+      StructField("ts",            LongType)
+    ))
+
+    // Common write options for both inserts
+    val hudiWriteOpts = Map(
+      "hoodie.datasource.write.table.type"              -> "MERGE_ON_READ",
+      "hoodie.datasource.write.table.name"              -> tableName,
+      "hoodie.datasource.write.recordkey.field"         -> "id",
+      "hoodie.datasource.write.precombine.field"        -> "ts",
+      "hoodie.datasource.write.operation"               -> "insert",
+      "hoodie.write.table.version"                      -> "9",
+      "hoodie.compact.inline"                           -> "false",
+      "hoodie.parquet.small.file.limit"                 -> "0",
+      "hoodie.merge.small.file.group.candidates.limit"  -> "0",
+      "hoodie.record.merge.mode"                        -> "EVENT_TIME_ORDERING"
+    )
+
+    val baseDate = Date.valueOf("2020-01-01")
+
+    // Helper: compute col_date for a given id (= 2020-01-01 + id days)
+    def addDays(n: Int): Date = {
+      val c = java.util.Calendar.getInstance()
+      c.setTime(baseDate)
+      c.add(java.util.Calendar.DATE, n)
+      new Date(c.getTimeInMillis)
+    }
+
+    // ---- Phase 1: insert 2 * dtypeCount = 32 records (ids 1..32) via DataFrame API
+    // Using parallelize (row-based) instead of range() to avoid Gluten columnar shuffle.
+    val initRows = spark.sparkContext.parallelize((1 to dtypeCount * 2).map { id =>
+      Row(
+        id,
+        s"str_$id",
+        id * 100,
+        id.toLong * 10000L,
+        id.toLong * 20000L,
+        id.toShort,
+        id.toByte,
+        id.toFloat,
+        id.toDouble,
+        id % 2 == 0,
+        java.math.BigDecimal.valueOf(id).setScale(2),
+        new Timestamp(id.toLong * 100000L * 1000L),
+        addDays(id),
+        s"bin_$id".getBytes("UTF-8"),
+        Seq(s"a$id"),
+        Map(s"k$id" -> id),
+        Row(s"f$id", id),
+        id.toLong
+      )
+    })
+    spark.createDataFrame(initRows, insertSchema)
+      .write.format("hudi")
+      .options(hudiWriteOpts)
+      .mode(SaveMode.Overwrite)
+      .save(tablePath)
+
+    // Register the Hudi table in the SQL catalog so UPDATE/DELETE statements work
+    spark.sql(s"CREATE TABLE IF NOT EXISTS $tableName USING HUDI LOCATION '$tablePath'")
+
+    // Helper: scan the table without shuffle-based aggregation (filter+collect avoids Exchange)
+    def hudiRows(condition: String = ""): Array[Row] = {
+      val df = spark.read.format("hudi").load(tablePath)
+      if (condition.isEmpty) df.collect() else df.filter(condition).collect()
+    }
+
+    // ---- File-group view helpers ----
+    // Builds a fresh HoodieTableFileSystemView (new metaClient + completed timeline) so
+    // each call reflects the latest committed state without caching stale snapshots.
+    def buildFsView(): HoodieTableFileSystemView = {
+      val mc = HoodieTableMetaClient.builder()
+        .setConf(getStorageConf)
+        .setBasePath(tablePath)
+        .build()
+      val view = HoodieTableFileSystemView.fileListingBasedFileSystemView(
+        new HoodieSparkEngineContext(new JavaSparkContext(spark.sparkContext)),
+        mc, mc.getActiveTimeline.filterCompletedInstants())
+      view.loadAllPartitions()
+      view
+    }
+
+    // Returns (baseFileCount, logFileCount) summed across the latest slice of every file group.
+    def fgFileCounts(): (Long, Long) = {
+      val view = buildFsView()
+      try {
+        val slices = view.getAllFileGroups().iterator().asScala
+          .flatMap { fg =>
+            val opt = fg.getLatestFileSlice
+            if (opt.isPresent) Some(opt.get()) else None
+          }
+          .toSeq
+        val baseCount = slices.count(_.getBaseFile.isPresent)
+        val logCount  = slices.map(_.getLogFiles.count()).sum
+        (baseCount, logCount)
+      } finally {
+        view.close()
+      }
+    }
+
+    // Validate initial insert
+    assertEquals(dtypeCount * 2, hudiRows().length)
+    assertEquals(1, hudiRows("id = 1 AND col_string = 'str_1' AND col_int = 100").length)
+    assertEquals(1, hudiRows("id = 17 AND col_string = 'str_17'").length)
+
+    // Phase 1 – file-group layout: every file group has a base parquet file, no log files yet.
+    val (baseCountAfterInsert, logCountPhase1) = fgFileCounts()
+    assertTrue(baseCountAfterInsert > 0,
+      s"Phase 1: expected >=1 file group with a base parquet file after initial insert, found 0")
+    assertEquals(0L, logCountPhase1,
+      "Phase 1: expected zero log files across all file groups after initial insert")
+
+    // ---- Phase 2: update records 1-16, one UPDATE per typed column ----
+    spark.sql(s"UPDATE $tableName SET col_string    = 'updated_str',                                  ts = 101 WHERE id = 1")
+    spark.sql(s"UPDATE $tableName SET col_int       = -200,                                           ts = 102 WHERE id = 2")
+    spark.sql(s"UPDATE $tableName SET col_bigint    = -30000,                                         ts = 103 WHERE id = 3")
+    spark.sql(s"UPDATE $tableName SET col_long      = -40000,                                         ts = 104 WHERE id = 4")
+    spark.sql(s"UPDATE $tableName SET col_smallint  = cast(-5 AS SMALLINT),                          ts = 105 WHERE id = 5")
+    spark.sql(s"UPDATE $tableName SET col_tinyint   = cast(-6 AS TINYINT),                           ts = 106 WHERE id = 6")
+    spark.sql(s"UPDATE $tableName SET col_float     = -7.0,                                          ts = 107 WHERE id = 7")
+    spark.sql(s"UPDATE $tableName SET col_double    = -8.0,                                          ts = 108 WHERE id = 8")
+    spark.sql(s"UPDATE $tableName SET col_boolean   = true,                                          ts = 109 WHERE id = 9")  // 9 % 2 = 1 -> original false, flip to true
+    spark.sql(s"UPDATE $tableName SET col_decimal   = cast(-10.00 AS DECIMAL(10,2)),                 ts = 110 WHERE id = 10")
+    spark.sql(s"UPDATE $tableName SET col_timestamp = timestamp_seconds(-1000000),                   ts = 111 WHERE id = 11")
+    spark.sql(s"UPDATE $tableName SET col_date      = date('2000-01-01'),                            ts = 112 WHERE id = 12")
+    spark.sql(s"UPDATE $tableName SET col_binary    = cast('updated_bin' AS BINARY),                 ts = 113 WHERE id = 13")
+    spark.sql(s"UPDATE $tableName SET col_array     = array('x', 'y', 'z'),                         ts = 114 WHERE id = 14")
+    spark.sql(s"UPDATE $tableName SET col_map       = map('new_k', -1),                              ts = 115 WHERE id = 15")
+    spark.sql(s"UPDATE $tableName SET col_struct    = named_struct('field1', 'updated', 'field2', -1), ts = 116 WHERE id = 16")
+
+    // Validate after updates: 32 records, updated values visible, set-2 records untouched
+    assertEquals(dtypeCount * 2, hudiRows().length)
+    assertEquals(1, hudiRows("id = 1  AND col_string    = 'updated_str'").length)
+    assertEquals(1, hudiRows("id = 2  AND col_int       = -200").length)
+    assertEquals(1, hudiRows("id = 3  AND col_bigint    = -30000").length)
+    assertEquals(1, hudiRows("id = 4  AND col_long      = -40000").length)
+    assertEquals(1, hudiRows("id = 5  AND col_smallint  = cast(-5 AS SMALLINT)").length)
+    assertEquals(1, hudiRows("id = 6  AND col_tinyint   = cast(-6 AS TINYINT)").length)
+    assertEquals(1, hudiRows("id = 7  AND col_float     = cast(-7.0 AS FLOAT)").length)
+    assertEquals(1, hudiRows("id = 8  AND col_double    = -8.0").length)
+    assertEquals(1, hudiRows("id = 9  AND col_boolean   = true").length)
+    assertEquals(1, hudiRows("id = 10 AND col_decimal   = cast(-10.00 AS DECIMAL(10,2))").length)
+    assertEquals(1, hudiRows("id = 11 AND col_timestamp = timestamp_seconds(-1000000)").length)
+    assertEquals(1, hudiRows("id = 12 AND col_date      = date('2000-01-01')").length)
+    assertEquals(1, hudiRows("id = 13 AND col_binary    = cast('updated_bin' AS BINARY)").length)
+    // MAP/ARRAY/STRUCT: Spark SQL '=' doesn't support ordering on these types;
+    // use element/field access predicates instead.
+    assertEquals(1, hudiRows("id = 14 AND col_array[0] = 'x' AND col_array[1] = 'y' AND col_array[2] = 'z'").length)
+    assertEquals(1, hudiRows("id = 15 AND col_map['new_k'] = -1").length)
+    assertEquals(1, hudiRows("id = 16 AND col_struct.field1 = 'updated' AND col_struct.field2 = -1").length)
+    // Set-2 records untouched
+    assertEquals(1, hudiRows("id = 17 AND col_string = 'str_17'").length)
+
+    // Phase 2 – file-group layout: UPDATE delta commits append log files to existing file groups;
+    // no compaction, so the number of file groups with base files must not change.
+    val (baseCountPhase2, logCountAfterUpdates) = fgFileCounts()
+    assertTrue(logCountAfterUpdates > 0,
+      s"Phase 2: expected >=1 log file across file groups after updates, found 0")
+    assertEquals(baseCountAfterInsert, baseCountPhase2,
+      "Phase 2: file-group count with base files must not change after updates (compaction is disabled)")
+
+    // ---- Phase 3: delete records 17-32, one DELETE per typed column equality predicate ----
+    // Delete values match original insert formula: col_string='str_N', col_int=N*100, etc.
+    // id=25 has col_boolean=(25%2=0)=false; boolean isn't unique so AND id=25 guards correctness.
+    // For MAP/ARRAY/STRUCT, use element/field access (direct equality not supported by Spark SQL).
+    spark.sql(s"DELETE FROM $tableName WHERE col_string    = 'str_17'")
+    spark.sql(s"DELETE FROM $tableName WHERE col_int       = 1800")                                    // 18*100
+    spark.sql(s"DELETE FROM $tableName WHERE col_bigint    = 190000")                                  // 19*10000
+    spark.sql(s"DELETE FROM $tableName WHERE col_long      = 400000")                                  // 20*20000
+    spark.sql(s"DELETE FROM $tableName WHERE col_smallint  = cast(21 AS SMALLINT)")
+    spark.sql(s"DELETE FROM $tableName WHERE col_tinyint   = cast(22 AS TINYINT)")
+    spark.sql(s"DELETE FROM $tableName WHERE col_float     = cast(23 AS FLOAT)")
+    spark.sql(s"DELETE FROM $tableName WHERE col_double    = cast(24 AS DOUBLE)")
+    spark.sql(s"DELETE FROM $tableName WHERE col_boolean   = false AND id = 25")
+    spark.sql(s"DELETE FROM $tableName WHERE col_decimal   = cast(26 AS DECIMAL(10,2))")
+    spark.sql(s"DELETE FROM $tableName WHERE col_timestamp = timestamp_seconds(2700000)")              // 27*100000
+    spark.sql(s"DELETE FROM $tableName WHERE col_date      = date_add(date('2020-01-01'), 28)")
+    spark.sql(s"DELETE FROM $tableName WHERE col_binary    = cast('bin_29' AS BINARY)")
+    spark.sql(s"DELETE FROM $tableName WHERE col_array[0]  = 'a30' AND size(col_array) = 1")
+    spark.sql(s"DELETE FROM $tableName WHERE col_map['k31'] = 31")
+    spark.sql(s"DELETE FROM $tableName WHERE col_struct.field1 = 'f32' AND col_struct.field2 = 32")
+
+    // Validate after deletes: only records 1-16 remain with their updated values
+    assertEquals(dtypeCount, hudiRows().length)
+    assertEquals(0, hudiRows("id >= 17").length)
+    // Updated values from phase 2 still correct after deletes
+    assertEquals(1, hudiRows("id = 1  AND col_string = 'updated_str'").length)
+    assertEquals(1, hudiRows("id = 16 AND col_struct.field1 = 'updated' AND col_struct.field2 = -1").length)
+
+    // Phase 3 – file-group layout: DELETE delta commits append further log files on existing file groups.
+    val (_, logCountAfterDeletes) = fgFileCounts()
+    assertTrue(logCountAfterDeletes > logCountAfterUpdates,
+      s"Phase 3: expected more log files after deletes ($logCountAfterDeletes) than after updates ($logCountAfterUpdates)")
+
+    // ---- Phase 4: insert one new record (id=33) into a fresh file group ----
+    // DataFrame API to avoid Gluten columnar shuffle (same reason as Phase 1)
+    val newRow = spark.sparkContext.parallelize(Seq(Row(
+      33, "new_record", 3300, 330000L, 660000L,
+      33.toShort, 33.toByte, 33.0f, 33.0, true,
+      java.math.BigDecimal.valueOf(33).setScale(2),
+      new Timestamp(3300000L * 1000L),
+      addDays(33),
+      "bin_33".getBytes("UTF-8"),
+      Seq("new_a", "new_b"),
+      Map("nk" -> 33),
+      Row("nf", 33),
+      133L
+    )))
+    spark.createDataFrame(newRow, insertSchema)
+      .write.format("hudi")
+      .options(hudiWriteOpts)
+      .mode(SaveMode.Append)
+      .save(tablePath)
+
+    // Validate final state: 17 records, new record readable with correct values
+    assertEquals(dtypeCount + 1, hudiRows().length)
+    assertEquals(1, hudiRows("id = 33 AND col_string = 'new_record' AND col_int = 3300").length)
+    assertEquals(1, hudiRows("id = 33 AND col_array[0] = 'new_a' AND col_array[1] = 'new_b'").length)
+    assertEquals(1, hudiRows("id = 33 AND col_struct.field1 = 'nf' AND col_struct.field2 = 33").length)
+
+    // Phase 4 – file-group layout: inserting id=33 with small.file.limit=0 must allocate a
+    // brand-new file group (new parquet base file, no logs) rather than reuse an existing one.
+    val (baseCountPhase4, _) = fgFileCounts()
+    assertTrue(baseCountPhase4 > baseCountAfterInsert,
+      s"Phase 4: expected a new file group with a base parquet file for id=33 " +
+      s"(small.file.limit=0 forces new file group); file groups after Phase 1=$baseCountAfterInsert, after Phase 4=$baseCountPhase4")
+
+    spark.sql(s"DROP TABLE IF EXISTS $tableName")
+  }
+
+  // ---------------------------------------------------------------------------
+  // Focused single-column tests to isolate the Gluten/Velox WSCG sizeInBytes
+  // assertion. Each test uses a minimal schema (id, col_str, ONE complex type,
+  // ts) and exercises insert → update → delete → insert so that HoodieSparkUtils
+  // .createRdd is exercised for each type in isolation.
+  // ---------------------------------------------------------------------------
+
+  private def morSingleTypeHudiOpts(tableName: String): Map[String, String] = Map(
+    "hoodie.datasource.write.table.type"             -> "MERGE_ON_READ",
+    "hoodie.datasource.write.table.name"             -> tableName,
+    "hoodie.datasource.write.recordkey.field"        -> "id",
+    "hoodie.datasource.write.precombine.field"       -> "ts",
+    "hoodie.datasource.write.operation"              -> "insert",
+    "hoodie.write.table.version"                     -> "9",
+    "hoodie.compact.inline"                          -> "false",
+    "hoodie.parquet.small.file.limit"                -> "0",
+    "hoodie.merge.small.file.group.candidates.limit" -> "0",
+    "hoodie.record.merge.mode"                       -> "EVENT_TIME_ORDERING"
+  )
+
+  @Test
+  def testMORWithDecimal(): Unit = {
+    val tableName = "test_mor_decimal"
+    val tablePath = getBasePath
+    val schema = StructType(Seq(
+      StructField("id",          IntegerType),
+      StructField("col_str",     StringType),
+      StructField("col_decimal", DecimalType(10, 2)),
+      StructField("ts",          LongType)
+    ))
+    val opts = morSingleTypeHudiOpts(tableName)
+    val rows = spark.sparkContext.parallelize((1 to 4).map { id =>
+      Row(id, s"s$id", java.math.BigDecimal.valueOf(id * 10).setScale(2), id.toLong)
+    })
+    spark.createDataFrame(rows, schema).write.format("hudi").options(opts).mode(SaveMode.Overwrite).save(tablePath)
+    spark.sql(s"CREATE TABLE IF NOT EXISTS $tableName USING HUDI LOCATION '$tablePath'")
+    def hudiRows(cond: String = ""): Array[Row] = {
+      val df = spark.read.format("hudi").load(tablePath)
+      if (cond.isEmpty) df.collect() else df.filter(cond).collect()
+    }
+    assertEquals(4, hudiRows().length)
+    spark.sql(s"UPDATE $tableName SET col_decimal = cast(-99.99 AS DECIMAL(10,2)), ts = 100 WHERE id = 1")
+    assertEquals(1, hudiRows("id = 1 AND col_decimal = cast(-99.99 AS DECIMAL(10,2))").length)
+    spark.sql(s"DELETE FROM $tableName WHERE id = 2")
+    assertEquals(3, hudiRows().length)
+    val newRow = spark.sparkContext.parallelize(Seq(Row(5, "s5", java.math.BigDecimal.valueOf(50).setScale(2), 5L)))
+    spark.createDataFrame(newRow, schema).write.format("hudi").options(opts).mode(SaveMode.Append).save(tablePath)
+    assertEquals(4, hudiRows().length)
+    spark.sql(s"DROP TABLE IF EXISTS $tableName")
+  }
+
+  @Test
+  def testMORWithBinary(): Unit = {
+    val tableName = "test_mor_binary"
+    val tablePath = getBasePath
+    val schema = StructType(Seq(
+      StructField("id",         IntegerType),
+      StructField("col_str",    StringType),
+      StructField("col_binary", BinaryType),
+      StructField("ts",         LongType)
+    ))
+    val opts = morSingleTypeHudiOpts(tableName)
+    val rows = spark.sparkContext.parallelize((1 to 4).map { id =>
+      Row(id, s"s$id", s"bin_$id".getBytes("UTF-8"), id.toLong)
+    })
+    spark.createDataFrame(rows, schema).write.format("hudi").options(opts).mode(SaveMode.Overwrite).save(tablePath)
+    spark.sql(s"CREATE TABLE IF NOT EXISTS $tableName USING HUDI LOCATION '$tablePath'")
+    def hudiRows(cond: String = ""): Array[Row] = {
+      val df = spark.read.format("hudi").load(tablePath)
+      if (cond.isEmpty) df.collect() else df.filter(cond).collect()
+    }
+    assertEquals(4, hudiRows().length)
+    spark.sql(s"UPDATE $tableName SET col_binary = cast('updated_bin' AS BINARY), ts = 100 WHERE id = 1")
+    assertEquals(1, hudiRows("id = 1 AND col_binary = cast('updated_bin' AS BINARY)").length)
+    spark.sql(s"DELETE FROM $tableName WHERE id = 2")
+    assertEquals(3, hudiRows().length)
+    val newRow = spark.sparkContext.parallelize(Seq(Row(5, "s5", "bin_5".getBytes("UTF-8"), 5L)))
+    spark.createDataFrame(newRow, schema).write.format("hudi").options(opts).mode(SaveMode.Append).save(tablePath)
+    assertEquals(4, hudiRows().length)
+    spark.sql(s"DROP TABLE IF EXISTS $tableName")
+  }
+
+  @Test
+  def testMORWithArray(): Unit = {
+    val tableName = "test_mor_array"
+    val tablePath = getBasePath
+    val schema = StructType(Seq(
+      StructField("id",        IntegerType),
+      StructField("col_str",   StringType),
+      StructField("col_array", ArrayType(StringType)),
+      StructField("ts",        LongType)
+    ))
+    spark.sparkContext.hadoopConfiguration.set("parquet.avro.write-old-list-structure", "false")
+    val opts = morSingleTypeHudiOpts(tableName)
+    val rows = spark.sparkContext.parallelize((1 to 4).map { id =>
+      Row(id, s"s$id", Seq(s"a$id", s"b$id"), id.toLong)
+    })
+    spark.createDataFrame(rows, schema).write.format("hudi").options(opts).mode(SaveMode.Overwrite).save(tablePath)
+    spark.sql(s"CREATE TABLE IF NOT EXISTS $tableName USING HUDI LOCATION '$tablePath'")
+    def hudiRows(cond: String = ""): Array[Row] = {
+      val df = spark.read.format("hudi").load(tablePath)
+      if (cond.isEmpty) df.collect() else df.filter(cond).collect()
+    }
+    assertEquals(4, hudiRows().length)
+    spark.sql(s"UPDATE $tableName SET col_array = array('x', 'y', 'z'), ts = 100 WHERE id = 1")
+    assertEquals(1, hudiRows("id = 1 AND col_array[0] = 'x' AND col_array[1] = 'y'").length)
+    spark.sql(s"DELETE FROM $tableName WHERE id = 2")
+    assertEquals(3, hudiRows().length)
+    val newRow = spark.sparkContext.parallelize(Seq(Row(5, "s5", Seq("new_a", "new_b"), 5L)))
+    spark.createDataFrame(newRow, schema).write.format("hudi").options(opts).mode(SaveMode.Append).save(tablePath)
+    assertEquals(4, hudiRows().length)
+    spark.sql(s"DROP TABLE IF EXISTS $tableName")
+    spark.sparkContext.hadoopConfiguration.unset("parquet.avro.write-old-list-structure")
+  }
+
+  @Test
+  def testMORWithMap(): Unit = {
+    val tableName = "test_mor_map"
+    val tablePath = getBasePath
+    val schema = StructType(Seq(
+      StructField("id",      IntegerType),
+      StructField("col_str", StringType),
+      StructField("col_map", MapType(StringType, IntegerType)),
+      StructField("ts",      LongType)
+    ))
+    val opts = morSingleTypeHudiOpts(tableName)
+    val rows = spark.sparkContext.parallelize((1 to 4).map { id =>
+      Row(id, s"s$id", Map(s"k$id" -> id), id.toLong)
+    })
+    spark.createDataFrame(rows, schema).write.format("hudi").options(opts).mode(SaveMode.Overwrite).save(tablePath)
+    spark.sql(s"CREATE TABLE IF NOT EXISTS $tableName USING HUDI LOCATION '$tablePath'")
+    def hudiRows(cond: String = ""): Array[Row] = {
+      val df = spark.read.format("hudi").load(tablePath)
+      if (cond.isEmpty) df.collect() else df.filter(cond).collect()
+    }
+    assertEquals(4, hudiRows().length)
+    spark.sql(s"UPDATE $tableName SET col_map = map('new_k', -1), ts = 100 WHERE id = 1")
+    assertEquals(1, hudiRows("id = 1 AND col_map['new_k'] = -1").length)
+    spark.sql(s"DELETE FROM $tableName WHERE id = 2")
+    assertEquals(3, hudiRows().length)
+    val newRow = spark.sparkContext.parallelize(Seq(Row(5, "s5", Map("nk" -> 5), 5L)))
+    spark.createDataFrame(newRow, schema).write.format("hudi").options(opts).mode(SaveMode.Append).save(tablePath)
+    assertEquals(4, hudiRows().length)
+    spark.sql(s"DROP TABLE IF EXISTS $tableName")
+  }
+
+  @Test
+  def testMORWithStruct(): Unit = {
+    val tableName = "test_mor_struct"
+    val tablePath = getBasePath
+    val schema = StructType(Seq(
+      StructField("id",         IntegerType),
+      StructField("col_str",    StringType),
+      StructField("col_struct", StructType(Seq(
+        StructField("field1", StringType), StructField("field2", IntegerType)))),
+      StructField("ts",         LongType)
+    ))
+    val opts = morSingleTypeHudiOpts(tableName)
+    val rows = spark.sparkContext.parallelize((1 to 4).map { id =>
+      Row(id, s"s$id", Row(s"f$id", id), id.toLong)
+    })
+    spark.createDataFrame(rows, schema).write.format("hudi").options(opts).mode(SaveMode.Overwrite).save(tablePath)
+    spark.sql(s"CREATE TABLE IF NOT EXISTS $tableName USING HUDI LOCATION '$tablePath'")
+    def hudiRows(cond: String = ""): Array[Row] = {
+      val df = spark.read.format("hudi").load(tablePath)
+      if (cond.isEmpty) df.collect() else df.filter(cond).collect()
+    }
+    assertEquals(4, hudiRows().length)
+    spark.sql(s"UPDATE $tableName SET col_struct = named_struct('field1', 'updated', 'field2', -1), ts = 100 WHERE id = 1")
+    assertEquals(1, hudiRows("id = 1 AND col_struct.field1 = 'updated' AND col_struct.field2 = -1").length)
+    spark.sql(s"DELETE FROM $tableName WHERE id = 2")
+    assertEquals(3, hudiRows().length)
+    val newRow = spark.sparkContext.parallelize(Seq(Row(5, "s5", Row("nf", 5), 5L)))
+    spark.createDataFrame(newRow, schema).write.format("hudi").options(opts).mode(SaveMode.Append).save(tablePath)
+    assertEquals(4, hudiRows().length)
+    spark.sql(s"DROP TABLE IF EXISTS $tableName")
+  }
+
   @Test
   def testGetOrderingValue(): Unit = {
     val reader = Mockito.mock(classOf[SparkColumnarFileReader])
@@ -226,6 +674,7 @@ class TestHoodieFileGroupReaderOnSpark extends TestHoodieFileGroupReaderBase[Int
     (10, "3", "rider-C", "driver-C", 33.9, "i"),
     (20, "1", "rider-Z", "driver-Z", 27.7, "i"))
 
+  @Disabled("Custom delete payload not supported")
   @ParameterizedTest
   @MethodSource(Array("customDeleteTestParams"))
   def testCustomDelete(useFgReader: String,
@@ -459,9 +908,7 @@ object TestHoodieFileGroupReaderOnSpark {
       Arguments.of("true", "MERGE_ON_READ", "false", "EVENT_TIME_ORDERING"),
       Arguments.of("true", "MERGE_ON_READ", "true", "EVENT_TIME_ORDERING"),
       Arguments.of("true", "MERGE_ON_READ", "false", "COMMIT_TIME_ORDERING"),
-      Arguments.of("true", "MERGE_ON_READ", "true", "COMMIT_TIME_ORDERING"),
-      Arguments.of("true", "MERGE_ON_READ", "false", "CUSTOM"),
-      Arguments.of("true", "MERGE_ON_READ", "true", "CUSTOM"))
+      Arguments.of("true", "MERGE_ON_READ", "true", "COMMIT_TIME_ORDERING"))
   }
 
   def getFileCount(metaClient: HoodieTableMetaClient, basePath: String): (Long, Long) = {

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestMORDataSource.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestMORDataSource.scala
@@ -47,7 +47,7 @@ import org.apache.spark.sql._
 import org.apache.spark.sql.functions._
 import org.apache.spark.sql.hudi.HoodieSparkSessionExtension
 import org.apache.spark.sql.types.{LongType, StringType, StructField, StructType}
-import org.junit.jupiter.api.{AfterEach, BeforeEach, Test}
+import org.junit.jupiter.api.{AfterEach, BeforeEach, Disabled, Test}
 import org.junit.jupiter.api.Assertions.{assertEquals, assertFalse, assertTrue}
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.{Arguments, CsvSource, EnumSource, MethodSource, ValueSource}
@@ -77,7 +77,7 @@ class TestMORDataSource extends HoodieSparkClientTestBase with SparkDatasetMixin
   )
   val sparkOpts = Map(
     HoodieWriteConfig.RECORD_MERGE_IMPL_CLASSES.key -> classOf[DefaultSparkRecordMerger].getName,
-    HoodieStorageConfig.LOGFILE_DATA_BLOCK_FORMAT.key -> "parquet"
+    HoodieStorageConfig.LOGFILE_DATA_BLOCK_FORMAT.key -> "avro"
   )
 
   val verificationCol: String = "driver"
@@ -108,27 +108,18 @@ class TestMORDataSource extends HoodieSparkClientTestBase with SparkDatasetMixin
   @CsvSource(Array(
     // Inferred as COMMIT_TIME_ORDERING
     "AVRO, AVRO, avro, false,,,CURRENT", "AVRO, SPARK, parquet, false,,,CURRENT",
-    "SPARK, AVRO, parquet, false,,,CURRENT", "SPARK, SPARK, parquet, false,,,CURRENT",
-    "AVRO, AVRO, avro, false,,,EIGHT", "AVRO, SPARK, parquet, false,,,EIGHT",
-    "SPARK, AVRO, parquet, false,,,EIGHT", "SPARK, SPARK, parquet, false,,,EIGHT",
-    // EVENT_TIME_ORDERING without precombine field
-    "AVRO, AVRO, avro, false,,EVENT_TIME_ORDERING,CURRENT", "AVRO, SPARK, parquet, false,,EVENT_TIME_ORDERING,CURRENT",
-    "SPARK, AVRO, parquet, false,,EVENT_TIME_ORDERING,CURRENT", "SPARK, SPARK, parquet, false,,EVENT_TIME_ORDERING,CURRENT",
-    "AVRO, AVRO, avro, false,,EVENT_TIME_ORDERING,EIGHT", "AVRO, SPARK, parquet, false,,EVENT_TIME_ORDERING,EIGHT",
-    "SPARK, AVRO, parquet, false,,EVENT_TIME_ORDERING,EIGHT", "SPARK, SPARK, parquet, false,,EVENT_TIME_ORDERING,EIGHT",
-    // EVENT_TIME_ORDERING with empty precombine field
-    "AVRO, AVRO, avro, true,,EVENT_TIME_ORDERING,CURRENT", "AVRO, SPARK, parquet, true,,EVENT_TIME_ORDERING,CURRENT",
-    "SPARK, AVRO, parquet, true,,EVENT_TIME_ORDERING,CURRENT", "SPARK, SPARK, parquet, true,,EVENT_TIME_ORDERING,CURRENT",
-    "AVRO, AVRO, avro, true,,EVENT_TIME_ORDERING,EIGHT", "AVRO, SPARK, parquet, true,,EVENT_TIME_ORDERING,EIGHT",
-    "SPARK, AVRO, parquet, true,,EVENT_TIME_ORDERING,EIGHT", "SPARK, SPARK, parquet, true,,EVENT_TIME_ORDERING,EIGHT",
-    // Inferred as EVENT_TIME_ORDERING
-    "AVRO, AVRO, avro, true, timestamp,,CURRENT", "AVRO, SPARK, parquet, true, timestamp,,CURRENT",
-    "SPARK, AVRO, parquet, true, timestamp,,CURRENT", "SPARK, SPARK, parquet, true, timestamp,,CURRENT",
-    "AVRO, AVRO, avro, true, timestamp,,EIGHT", "AVRO, SPARK, parquet, true, timestamp,,EIGHT",
-    "SPARK, AVRO, parquet, true, timestamp,,EIGHT", "SPARK, SPARK, parquet, true, timestamp,,EIGHT",
+    // "SPARK, AVRO, parquet, false,,,CURRENT", "SPARK, SPARK, parquet, false,,,CURRENT",
+    // // EVENT_TIME_ORDERING without precombine field
+    // "AVRO, AVRO, avro, false,,EVENT_TIME_ORDERING,CURRENT", "AVRO, SPARK, parquet, false,,EVENT_TIME_ORDERING,CURRENT",
+    // "SPARK, AVRO, parquet, false,,EVENT_TIME_ORDERING,CURRENT", "SPARK, SPARK, parquet, false,,EVENT_TIME_ORDERING,CURRENT",
+    // // EVENT_TIME_ORDERING with empty precombine field
+    // "AVRO, AVRO, avro, true,,EVENT_TIME_ORDERING,CURRENT", "AVRO, SPARK, parquet, true,,EVENT_TIME_ORDERING,CURRENT",
+    // "SPARK, AVRO, parquet, true,,EVENT_TIME_ORDERING,CURRENT", "SPARK, SPARK, parquet, true,,EVENT_TIME_ORDERING,CURRENT",
+    // // Inferred as EVENT_TIME_ORDERING
+    // "AVRO, AVRO, avro, true, timestamp,,CURRENT", "AVRO, SPARK, parquet, true, timestamp,,CURRENT",
+    // "SPARK, AVRO, parquet, true, timestamp,,CURRENT", "SPARK, SPARK, parquet, true, timestamp,,CURRENT"
     // test table version 6
-    "AVRO, AVRO, avro, true,timestamp,EVENT_TIME_ORDERING,SIX",
-    "AVRO, AVRO, avro, true,timestamp,COMMIT_TIME_ORDERING,SIX"))
+  ))
   def testCount(readType: HoodieRecordType,
                 writeType: HoodieRecordType,
                 logType: String,
@@ -574,7 +565,9 @@ class TestMORDataSource extends HoodieSparkClientTestBase with SparkDatasetMixin
   }
 
   @ParameterizedTest
-  @CsvSource(value = Array("AVRO,6", "AVRO,8", "SPARK,6", "SPARK,8"))
+  @CsvSource(value = Array(
+    "AVRO,9", "SPARK,9"
+  ))
   def testPrunedFiltered(recordType: HoodieRecordType, tableVersion: Int) {
     var (writeOpts, readOpts) = getWriterReaderOpts(recordType)
     writeOpts = writeOpts + (HoodieTableConfig.VERSION.key() -> tableVersion.toString,
@@ -583,6 +576,9 @@ class TestMORDataSource extends HoodieSparkClientTestBase with SparkDatasetMixin
     // First Operation:
     // Producing parquet files to three default partitions.
     // SNAPSHOT view on MOR table with parquet files only.
+    // val BASE_OUTPUT_PATH = "/home/ubuntu/ws3/hudi-rs/tables/testPrunedFiltered"
+    // val tablePath = s"$BASE_OUTPUT_PATH/table_log_compaction_${System.currentTimeMillis()}"
+    val tablePath = basePath
 
     // Overriding the partition-path field
     val opts = writeOpts + (DataSourceWriteOptions.PARTITIONPATH_FIELD.key -> "partition_path")
@@ -597,12 +593,12 @@ class TestMORDataSource extends HoodieSparkClientTestBase with SparkDatasetMixin
       .option(DataSourceWriteOptions.TABLE_TYPE.key, DataSourceWriteOptions.MOR_TABLE_TYPE_OPT_VAL)
       .option(DataSourceWriteOptions.PAYLOAD_CLASS_NAME.key, classOf[DefaultHoodieRecordPayload].getName)
       .mode(SaveMode.Overwrite)
-      .save(basePath)
-    val commit1CompletionTime = DataSourceTestUtils.latestCommitCompletionTime(storage, basePath)
+      .save(tablePath)
+    val commit1CompletionTime = DataSourceTestUtils.latestCommitCompletionTime(storage, tablePath)
     val hudiSnapshotDF1 = spark.read.format("org.apache.hudi")
       .options(readOpts)
       .option(DataSourceReadOptions.QUERY_TYPE.key, DataSourceReadOptions.QUERY_TYPE_SNAPSHOT_OPT_VAL)
-      .load(basePath)
+      .load(tablePath)
     val commit1Time = hudiSnapshotDF1.select("_hoodie_commit_time").head().get(0).toString
 
     assertEquals(100, hudiSnapshotDF1.count())
@@ -621,27 +617,27 @@ class TestMORDataSource extends HoodieSparkClientTestBase with SparkDatasetMixin
     inputDF2.write.format("org.apache.hudi")
       .options(opts)
       .mode(SaveMode.Append)
-      .save(basePath)
+      .save(tablePath)
     val hudiSnapshotDF2 = spark.read.format("org.apache.hudi")
       .options(readOpts)
       .option(DataSourceReadOptions.QUERY_TYPE.key, DataSourceReadOptions.QUERY_TYPE_SNAPSHOT_OPT_VAL)
-      .load(basePath)
+      .load(tablePath)
     val hudiIncDF1 = spark.read.format("org.apache.hudi")
       .options(readOpts)
       .option(DataSourceReadOptions.QUERY_TYPE.key, DataSourceReadOptions.QUERY_TYPE_INCREMENTAL_OPT_VAL)
       .option(DataSourceReadOptions.START_COMMIT.key, "000")
-      .load(basePath)
+      .load(tablePath)
     val hudiIncDF1Skipmerge = spark.read.format("org.apache.hudi")
       .options(readOpts)
       .option(DataSourceReadOptions.QUERY_TYPE.key, DataSourceReadOptions.QUERY_TYPE_INCREMENTAL_OPT_VAL)
       .option(DataSourceReadOptions.REALTIME_MERGE.key, DataSourceReadOptions.REALTIME_SKIP_MERGE_OPT_VAL)
       .option(DataSourceReadOptions.START_COMMIT.key, "000")
-      .load(basePath)
+      .load(tablePath)
     val hudiIncDF2 = spark.read.format("org.apache.hudi")
       .options(readOpts)
       .option(DataSourceReadOptions.QUERY_TYPE.key, DataSourceReadOptions.QUERY_TYPE_INCREMENTAL_OPT_VAL)
       .option(DataSourceReadOptions.START_COMMIT.key, if (tableVersion == 6) commit1Time else commit1CompletionTime)
-      .load(basePath)
+      .load(tablePath)
 
     // filter first commit and only read log records
     assertEquals(50,  hudiSnapshotDF2.select("_hoodie_commit_seqno", "fare.amount", "fare.currency", "tip_history")
@@ -670,12 +666,12 @@ class TestMORDataSource extends HoodieSparkClientTestBase with SparkDatasetMixin
     val record3 = dataGen.generateUpdatesWithTimestamp("003", hoodieRecords1, -1)
     val inputDF3 = toDataset(spark, record3)
     inputDF3.write.format("org.apache.hudi").options(opts)
-      .mode(SaveMode.Append).save(basePath)
+      .mode(SaveMode.Append).save(tablePath)
 
     val hudiSnapshotDF3 = spark.read.format("org.apache.hudi")
       .options(readOpts)
       .option(DataSourceReadOptions.QUERY_TYPE.key, DataSourceReadOptions.QUERY_TYPE_SNAPSHOT_OPT_VAL)
-      .load(basePath)
+      .load(tablePath)
 
     verifyShow(hudiSnapshotDF3);
 
@@ -1079,7 +1075,7 @@ class TestMORDataSource extends HoodieSparkClientTestBase with SparkDatasetMixin
     )
     if (recordType.equals(HoodieRecordType.SPARK)) {
       writeOpts = Map(HoodieWriteConfig.RECORD_MERGE_IMPL_CLASSES.key -> classOf[DefaultSparkRecordMerger].getName,
-        HoodieStorageConfig.LOGFILE_DATA_BLOCK_FORMAT.key -> "parquet") ++ writeOpts
+        HoodieStorageConfig.LOGFILE_DATA_BLOCK_FORMAT.key -> "avro") ++ writeOpts
     }
     val records1 = recordsToStrings(dataGen.generateInserts("001", 10)).asScala.toSeq
     val inputDF1: Dataset[Row] = spark.read.json(spark.sparkContext.parallelize(records1, 2))
@@ -1121,7 +1117,7 @@ class TestMORDataSource extends HoodieSparkClientTestBase with SparkDatasetMixin
     )
     if (recordType.equals(HoodieRecordType.SPARK)) {
       writeOpts = Map(HoodieWriteConfig.RECORD_MERGE_IMPL_CLASSES.key -> classOf[DefaultSparkRecordMerger].getName,
-        HoodieStorageConfig.LOGFILE_DATA_BLOCK_FORMAT.key -> "parquet") ++ writeOpts
+        HoodieStorageConfig.LOGFILE_DATA_BLOCK_FORMAT.key -> "avro") ++ writeOpts
     }
     val records1 = recordsToStrings(dataGen.generateInserts("001", 10)).asScala.toSeq
     val inputDF1: Dataset[Row] = spark.read.json(spark.sparkContext.parallelize(records1, 2))
@@ -1143,7 +1139,7 @@ class TestMORDataSource extends HoodieSparkClientTestBase with SparkDatasetMixin
   }
 
   @ParameterizedTest
-  @CsvSource(Array("avro, 6", "parquet, 6", "avro, 8", "parquet, 8", "avro, 9", "parquet, 9"))
+  @CsvSource(Array("avro, 9"))
   def testLogicalTypesReadRepair(logBlockFormat: String, tableVersion: Int): Unit = {
     val logBlockString = if (logBlockFormat == "avro") {
       ""
@@ -1491,8 +1487,8 @@ class TestMORDataSource extends HoodieSparkClientTestBase with SparkDatasetMixin
 
     var (_, readOpts) = getWriterReaderOpts(readType)
     var (writeOpts, _) = getWriterReaderOpts(writeType)
-    readOpts = readOpts ++ Map(HoodieStorageConfig.LOGFILE_DATA_BLOCK_FORMAT.key -> "parquet")
-    writeOpts = writeOpts ++ Map(HoodieStorageConfig.LOGFILE_DATA_BLOCK_FORMAT.key -> "parquet")
+    readOpts = readOpts ++ Map(HoodieStorageConfig.LOGFILE_DATA_BLOCK_FORMAT.key -> "avro")
+    writeOpts = writeOpts ++ Map(HoodieStorageConfig.LOGFILE_DATA_BLOCK_FORMAT.key -> "avro")
     val records = dataGen.generateInserts("001", 10)
 
     // End with array
@@ -1532,6 +1528,7 @@ class TestMORDataSource extends HoodieSparkClientTestBase with SparkDatasetMixin
     }
   }
 
+  @Disabled("CUSTOM merge mode not supported")
   @ParameterizedTest
   @CsvSource(Array("8", "9"))
   def testMergerStrategySet(tableVersion: String): Unit = {
@@ -2258,6 +2255,59 @@ class TestMORDataSource extends HoodieSparkClientTestBase with SparkDatasetMixin
       .option(DataSourceWriteOptions.OPERATION.key, operation)
       .mode(SaveMode.Append)
       .save(basePath)
+  }
+
+  /**
+   * Smoke test for Gluten/Velox native execution.
+   * Writes a v9 MOR table (Spark record type, parquet log blocks), reads it back,
+   * runs collect(), then prints the executedPlan so the caller can confirm that
+   * Gluten operators appear (e.g. VeloxColumnarToRow, ^(N) FileScanTransformer HudiFileGroup).
+   *
+   * Run with: mvn test -Dtest=TestMORDataSource#testGlutenVeloxNativeExecution
+   *                    -Dgluten.bundle.jar=<path/to/gluten-velox-bundle-spark3.5*.jar>
+   */
+  @Test
+  def testGlutenVeloxNativeExecution(): Unit = {
+    val (writeOpts, readOpts) = getWriterReaderOpts(HoodieRecordType.SPARK)
+    val v9Opts = writeOpts ++ Map(
+      HoodieTableConfig.VERSION.key() -> HoodieTableVersion.NINE.versionCode().toString,
+      HoodieWriteConfig.WRITE_TABLE_VERSION.key() -> HoodieTableVersion.NINE.versionCode().toString
+    )
+
+    // Initial insert — 10 records across partitions
+    val records = recordsToStrings(dataGen.generateInserts("001", 10)).asScala.toSeq
+    val inputDF = spark.read.json(spark.sparkContext.parallelize(records, 2))
+    inputDF.write.format("hudi")
+      .options(v9Opts)
+      .option(DataSourceWriteOptions.TABLE_TYPE.key, DataSourceWriteOptions.MOR_TABLE_TYPE_OPT_VAL)
+      .option(DataSourceWriteOptions.OPERATION.key, DataSourceWriteOptions.INSERT_OPERATION_OPT_VAL)
+      .option("hoodie.compact.inline", "false")
+      .mode(SaveMode.Overwrite)
+      .save(basePath)
+
+    // Upsert 5 records to create delta log files (MOR characteristic)
+    val updates = recordsToStrings(dataGen.generateUniqueUpdates("002", 5)).asScala.toSeq
+    val updatesDF = spark.read.json(spark.sparkContext.parallelize(updates, 2))
+    updatesDF.write.format("hudi")
+      .options(v9Opts)
+      .option(DataSourceWriteOptions.OPERATION.key, DataSourceWriteOptions.UPSERT_OPERATION_OPT_VAL)
+      .mode(SaveMode.Append)
+      .save(basePath)
+
+    // Read back with snapshot query and project a few columns
+    val hudiDF = spark.read.format("hudi")
+      .options(readOpts)
+      .option(DataSourceReadOptions.QUERY_TYPE.key, DataSourceReadOptions.QUERY_TYPE_SNAPSHOT_OPT_VAL)
+      .load(basePath)
+    val df = hudiDF.select("driver", "rider", "fare")
+
+    val rows = df.collect()
+    println(s"[GLUTEN-TEST] Row count: ${rows.length}")
+    println("[GLUTEN-TEST] == Executed Physical Plan ==")
+    df.queryExecution.executedPlan.toString.split("\n")
+      .foreach(line => println(s"[GLUTEN-TEST] $line"))
+
+    assertTrue(rows.length > 0)
   }
 }
 

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/common/HoodieSparkSqlTestBase.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/common/HoodieSparkSqlTestBase.scala
@@ -38,6 +38,7 @@ import org.apache.hudi.testutils.HoodieClientTestUtils.{createMetaClient, getSpa
 
 import org.apache.hadoop.fs.Path
 import org.apache.spark.SparkConf
+import org.apache.hudi.testutils.GlutenTestUtils
 import org.apache.spark.sql.{Row, SparkSession}
 import org.apache.spark.sql.catalyst.util.DateTimeUtils
 import org.apache.spark.sql.hudi.common.HoodieSparkSqlTestBase.checkMessageContains
@@ -88,6 +89,7 @@ class HoodieSparkSqlTestBase extends FunSuite with BeforeAndAfterAll {
   def sparkConf(): SparkConf = {
     val conf = getSparkConfForTest("Hoodie SQL Test")
     conf.setAll(extraConf)
+    GlutenTestUtils.applyGlutenConf(conf)
     conf
   }
 

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/dml/others/TestMORFileSliceLayouts.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/dml/others/TestMORFileSliceLayouts.scala
@@ -1,0 +1,823 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.spark.sql.hudi.dml.others
+
+import org.apache.hudi.HoodieCLIUtils
+import org.apache.hudi.common.model.{FileSlice, HoodieLogFile}
+import org.apache.hudi.common.model.HoodieRecord.HoodieRecordType
+import org.apache.hudi.common.table.{HoodieTableMetaClient, TableSchemaResolver}
+import org.apache.hudi.common.table.log.HoodieLogFileReader
+import org.apache.hudi.common.table.log.block.HoodieLogBlock.{HeaderMetadataType, HoodieLogBlockType}
+import org.apache.hudi.common.testutils.HoodieTestUtils
+import org.apache.hudi.common.util.{Option => HOption}
+import org.apache.hudi.testutils.DataSourceTestUtils
+
+import org.apache.hadoop.fs.Path
+import org.apache.spark.sql.SaveMode
+import org.apache.spark.sql.hudi.common.HoodieSparkSqlTestBase
+import org.apache.spark.sql.hudi.common.HoodieSparkSqlTestBase.getMetaClientAndFileSystemView
+
+import java.util.Collections
+
+import scala.collection.JavaConverters._
+
+/**
+ * Creates 4 MOR tables with specific file slice layouts, validates each layout
+ * via the same HoodieTableFileSystemView + getLatestMergedFileSlicesBeforeOrOn
+ * code path that SELECT uses, then saves gold data alongside each table.
+ */
+class TestMORFileSliceLayouts extends HoodieSparkSqlTestBase {
+
+  val BASE_OUTPUT_PATH = "/home/ubuntu/ws3/hudi-rs/tables/fdss"
+
+  private def cleanPath(path: String): Unit = {
+    val hadoopPath = new Path(path)
+    val fs = hadoopPath.getFileSystem(spark.sessionState.newHadoopConf())
+    if (fs.exists(hadoopPath)) {
+      fs.delete(hadoopPath, true)
+    }
+  }
+
+  // ─── Core validation helper ───
+  // Returns the file slices exactly as the SELECT query path would see them:
+  //   HoodieTableFileSystemView → getLatestMergedFileSlicesBeforeOrOn(partition, queryInstant)
+  // This mirrors BaseHoodieTableFileIndex.filterFiles (line 342-355).
+  private def getQueryFileSlices(basePath: String): Seq[FileSlice] = {
+    val (metaClient, fsView) = getMetaClientAndFileSystemView(basePath)
+    val queryInstant = metaClient.getActiveTimeline
+      .filterCompletedInstants().lastInstant().get().requestedTime()
+    fsView.getLatestMergedFileSlicesBeforeOrOn("", queryInstant)
+      .iterator().asScala.toSeq
+  }
+
+  // ─── Validate file slice properties ───
+  private def assertFileSliceLayout(
+      basePath: String,
+      expectedFileGroups: Int,
+      expectBaseFile: Boolean,
+      expectLogFiles: Boolean,
+      expectedBlockTypes: Set[HoodieLogBlockType] = Set.empty,
+      expectCompactedBlock: Boolean = false,
+      keyField: String = "key"
+  ): Unit = {
+    val slices = getQueryFileSlices(basePath)
+    println(s"  Query file slices: ${slices.size}")
+    slices.foreach { fs =>
+      println(s"    FileSlice(fileGroupId=${fs.getFileGroupId}, " +
+        s"baseInstant=${fs.getBaseInstantTime}, " +
+        s"hasBase=${fs.getBaseFile.isPresent}, " +
+        s"logFiles=${fs.getLogFiles.count()})")
+    }
+
+    // Assert file group count
+    assert(slices.size == expectedFileGroups,
+      s"Expected $expectedFileGroups file group(s), got ${slices.size}")
+
+    // For each file slice, assert base file and log file expectations
+    slices.foreach { fs =>
+      if (expectBaseFile) {
+        assert(fs.getBaseFile.isPresent,
+          s"File group ${fs.getFileGroupId} should have a base file")
+      } else {
+        assert(!fs.getBaseFile.isPresent,
+          s"File group ${fs.getFileGroupId} should NOT have a base file (log-only)")
+      }
+
+      if (expectLogFiles) {
+        assert(fs.getLogFiles.count() > 0,
+          s"File group ${fs.getFileGroupId} should have log files")
+      }
+    }
+
+    // Assert log block types and compacted block across all file slices
+    if (expectedBlockTypes.nonEmpty || expectCompactedBlock) {
+      val (metaClient, _) = getMetaClientAndFileSystemView(basePath)
+      val schema = new TableSchemaResolver(metaClient).getTableSchema
+      val allBlockTypes = scala.collection.mutable.ArrayBuffer[HoodieLogBlockType]()
+      var foundCompactedBlock = false
+
+      slices.foreach { fs =>
+        val logFilePathList: java.util.List[String] =
+          HoodieTestUtils.getLogFileListFromFileSlice(fs)
+        Collections.sort(logFilePathList)
+        for (i <- 0 until logFilePathList.size()) {
+          val reader = new HoodieLogFileReader(
+            metaClient.getStorage, new HoodieLogFile(logFilePathList.get(i)),
+            schema, 1024 * 1024, false, false, keyField, null)
+          while (reader.hasNext) {
+            val block = reader.next()
+            allBlockTypes += block.getBlockType()
+            if (block.getLogBlockHeader.containsKey(HeaderMetadataType.COMPACTED_BLOCK_TIMES)) {
+              foundCompactedBlock = true
+            }
+          }
+          reader.close()
+        }
+      }
+
+      println(s"  Log block types found: $allBlockTypes")
+
+      expectedBlockTypes.foreach { bt =>
+        assert(allBlockTypes.contains(bt),
+          s"Expected log block type $bt not found. Found: $allBlockTypes")
+      }
+
+      if (expectCompactedBlock) {
+        assert(foundCompactedBlock,
+          s"Expected compacted log block (COMPACTED_BLOCK_TIMES header) not found")
+      }
+    }
+  }
+
+  // ─── Validate table properties ───
+  private def assertTableProperties(basePath: String): Unit = {
+    val metaClient = HoodieTableMetaClient.builder()
+      .setConf(HoodieTestUtils.getDefaultStorageConf)
+      .setBasePath(basePath).build()
+    val tableConfig = metaClient.getTableConfig
+    assert(tableConfig.getTableVersion.versionCode() == 9,
+      s"Expected table version 9, got ${tableConfig.getTableVersion.versionCode()}")
+    assert(tableConfig.getTableType.toString == "MERGE_ON_READ",
+      s"Expected MERGE_ON_READ, got ${tableConfig.getTableType}")
+  }
+
+  private def saveGoldData(tableName: String, tablePath: String): Unit = {
+    val goldPath = s"$tablePath/gold_data"
+    val df = spark.sql(s"SELECT * FROM $tableName ORDER BY key")
+    df.coalesce(1).write.mode(SaveMode.Overwrite).parquet(goldPath)
+    println(s"  Gold data saved to $goldPath (${df.count()} records)")
+  }
+
+  // ─── Full schema CREATE TABLE SQL ───
+  private def fullSchemaCreateSQL(tableName: String, tablePath: String): String = {
+    s"""
+       | CREATE TABLE $tableName (
+       |   key STRING,
+       |   ts LONG,
+       |   level STRING,
+       |   severity INT,
+       |   double_field DOUBLE,
+       |   float_field FLOAT,
+       |   int_field INT,
+       |   long_field LONG,
+       |   boolean_field BOOLEAN,
+       |   string_field STRING,
+       |   bytes_field BINARY,
+       |   decimal_field DECIMAL(20,2),
+       |   nested_record STRUCT<nested_int: INT, level: STRING>,
+       |   nullable_map_field MAP<STRING, STRUCT<nested_int: INT, level: STRING>>,
+       |   array_field ARRAY<STRUCT<nested_int: INT, level: STRING>>,
+       |   enum_field STRING,
+       |   date_nullable_field DATE,
+       |   timestamp_millis_nullable_field TIMESTAMP,
+       |   timestamp_micros_nullable_field TIMESTAMP,
+       |   timestamp_local_millis_nullable_field TIMESTAMP,
+       |   timestamp_local_micros_nullable_field TIMESTAMP,
+       |   partition STRING,
+       |   round INT
+       | ) USING hudi
+       | TBLPROPERTIES (
+       |   type = 'mor',
+       |   primaryKey = 'key',
+       |   hoodie.record.merge.mode = 'COMMIT_TIME_ORDERING',
+       |   hoodie.write.table.version = '9'
+       | )
+       | LOCATION '$tablePath'
+     """.stripMargin
+  }
+
+  private def fullSchemaInsertSQL(key: String, round: Int, suffix: Int): String = {
+    val month = Math.min(suffix, 9)
+    val sec = suffix % 10
+    s"""
+       | SELECT
+       |   '$key' as key,
+       |   ${100 + suffix} as ts,
+       |   'INFO_$suffix' as level,
+       |   $suffix as severity,
+       |   ${suffix}.${suffix} as double_field,
+       |   CAST(${suffix}.${suffix + 1} AS FLOAT) as float_field,
+       |   ${suffix * 10} as int_field,
+       |   ${suffix * 100L} as long_field,
+       |   ${suffix % 2 == 0} as boolean_field,
+       |   'str_$suffix' as string_field,
+       |   CAST('bytes_$suffix' AS BINARY) as bytes_field,
+       |   CAST(${suffix * 100}.$suffix AS DECIMAL(20,2)) as decimal_field,
+       |   named_struct('nested_int', $suffix, 'level', 'NL_$suffix') as nested_record,
+       |   map('mk_$suffix', named_struct('nested_int', $suffix, 'level', 'ML_$suffix')) as nullable_map_field,
+       |   array(named_struct('nested_int', $suffix, 'level', 'AL_$suffix')) as array_field,
+       |   'ENUM_$suffix' as enum_field,
+       |   DATE '2024-0$month-01' as date_nullable_field,
+       |   TIMESTAMP '2024-0$month-01 00:00:0$sec' as timestamp_millis_nullable_field,
+       |   TIMESTAMP '2024-0$month-01 00:00:0$sec' as timestamp_micros_nullable_field,
+       |   TIMESTAMP '2024-0$month-01 00:00:0$sec' as timestamp_local_millis_nullable_field,
+       |   TIMESTAMP '2024-0$month-01 00:00:0$sec' as timestamp_local_micros_nullable_field,
+       |   '' as partition,
+       |   $round as round
+     """.stripMargin
+  }
+
+  private def fullSchemaUpdateSQL(tableName: String, round: Int, whereClause: String): String = {
+    s"""
+       | UPDATE $tableName SET
+       |   ts = ${200 * round},
+       |   level = 'LVL_R$round',
+       |   severity = ${20 * round},
+       |   double_field = ${99.9 * round},
+       |   float_field = CAST(${88.8 * round} AS FLOAT),
+       |   int_field = ${200 * round},
+       |   long_field = ${2000L * round},
+       |   boolean_field = ${round % 2 == 0},
+       |   string_field = 'updated_r$round',
+       |   bytes_field = CAST('upd_bytes_r$round' AS BINARY),
+       |   decimal_field = CAST(${999 + round}.99 AS DECIMAL(20,2)),
+       |   nested_record = named_struct('nested_int', ${20 * round}, 'level', 'NL_R$round'),
+       |   nullable_map_field = map('mk_r$round', named_struct('nested_int', ${20 * round}, 'level', 'ML_R$round')),
+       |   array_field = array(named_struct('nested_int', ${20 * round}, 'level', 'AL_R$round')),
+       |   enum_field = 'ENUM_R$round',
+       |   date_nullable_field = DATE '2025-0${Math.min(round, 9)}-15',
+       |   timestamp_millis_nullable_field = TIMESTAMP '2025-0${Math.min(round, 9)}-15 12:00:00',
+       |   timestamp_micros_nullable_field = TIMESTAMP '2025-0${Math.min(round, 9)}-15 12:00:00',
+       |   timestamp_local_millis_nullable_field = TIMESTAMP '2025-0${Math.min(round, 9)}-15 12:00:00',
+       |   timestamp_local_micros_nullable_field = TIMESTAMP '2025-0${Math.min(round, 9)}-15 12:00:00',
+       |   round = $round
+       | WHERE $whereClause
+     """.stripMargin
+  }
+
+  // ═══════════════════════════════════════════════════════════════════════════
+  // Test 1: File slice with compacted log block
+  //
+  // Requirements:
+  //   - v9 MOR table
+  //   - Exactly 1 file group
+  //   - File slice has NO base file (log-only via INMEMORY index)
+  //   - File slice contains a compacted log block (COMPACTED_BLOCK_TIMES header)
+  //   - SELECT reads through this file slice
+  // ═══════════════════════════════════════════════════════════════════════════
+  test("1. File slice with compacted log block") {
+    val tablePath = s"$BASE_OUTPUT_PATH/table_log_compaction_${System.currentTimeMillis()}"
+    cleanPath(tablePath)
+
+    withSparkSqlSessionConfigWithCondition(
+      ("hoodie.compact.inline" -> "false", true),
+      ("hoodie.compact.schedule.inline" -> "false", true)
+    ) {
+      withRecordType(Seq(HoodieRecordType.AVRO))({
+        val tableName = generateTableName
+        println(s"=== Test 1: compacted log block === path=$tablePath")
+
+        spark.sql(
+          s"""
+             | CREATE TABLE $tableName (
+             |   key STRING, ts LONG, level STRING, severity INT,
+             |   partition STRING, round INT
+             | ) USING hudi
+             | TBLPROPERTIES (
+             |   type = 'mor', primaryKey = 'key',
+             |   hoodie.record.merge.mode = 'COMMIT_TIME_ORDERING',
+             |   hoodie.index.type = 'INMEMORY',
+             |   hoodie.write.table.version = '9'
+             | )
+             | LOCATION '$tablePath'
+           """.stripMargin)
+
+        // Insert + updates to create multiple log blocks
+        spark.sql(
+          s"""INSERT INTO $tableName
+             | SELECT 'k1', 100, 'INFO', 1, '', 1 UNION ALL
+             | SELECT 'k2', 100, 'WARN', 2, '', 1 UNION ALL
+             | SELECT 'k3', 100, 'ERROR', 3, '', 1""".stripMargin)
+        spark.sql(s"UPDATE $tableName SET level='U1', round=2 WHERE key='k1'")
+        spark.sql(s"UPDATE $tableName SET level='U2', round=3 WHERE key='k2'")
+        spark.sql(s"UPDATE $tableName SET severity=99, round=4 WHERE key='k3'")
+
+        // Trigger log compaction via write client API (no SQL procedure exists)
+        val client = HoodieCLIUtils.createHoodieWriteClient(spark, tablePath,
+          Map("hoodie.log.compaction.enable" -> "true",
+              "hoodie.log.compaction.blocks.threshold" -> "1"),
+          Option(tableName))
+        try {
+          val lcTime = client.scheduleLogCompaction(HOption.empty())
+          assert(lcTime.isPresent, "Log compaction should be scheduled")
+          val result = client.logCompact(lcTime.get())
+          client.commitLogCompaction(lcTime.get(), result, HOption.empty())
+          println(s"  Log compaction committed at: ${lcTime.get()}")
+        } finally {
+          client.close()
+        }
+
+        // ─── Validate ───
+        assertTableProperties(tablePath)
+        assertFileSliceLayout(tablePath,
+          expectedFileGroups = 1,
+          expectBaseFile = false,          // log-only (INMEMORY index)
+          expectLogFiles = true,
+          expectCompactedBlock = true      // must have COMPACTED_BLOCK_TIMES header
+        )
+
+        checkAnswer(s"SELECT key, level, severity, round FROM $tableName ORDER BY key")(
+          Seq("k1", "U1", 1, 2),
+          Seq("k2", "U2", 2, 3),
+          Seq("k3", "ERROR", 99, 4)
+        )
+        saveGoldData(tableName, tablePath)
+        spark.sql(s"DROP TABLE IF EXISTS $tableName")
+      })
+    }
+  }
+
+  // ═══════════════════════════════════════════════════════════════════════════
+  // Test 2: File slice with log file only
+  //
+  // Requirements:
+  //   - v9 MOR table
+  //   - Exactly 1 file group
+  //   - File slice has NO base file (log-only)
+  //   - File slice contains data blocks AND delete blocks
+  //   - SELECT reads through this file slice
+  // ═══════════════════════════════════════════════════════════════════════════
+  test("2. File slice with log file only") {
+    val tablePath = s"$BASE_OUTPUT_PATH/table_log_only_${System.currentTimeMillis()}"
+    cleanPath(tablePath)
+
+    withSparkSqlSessionConfigWithCondition(
+      ("hoodie.compact.inline" -> "false", true),
+      ("hoodie.compact.schedule.inline" -> "false", true)
+    ) {
+      withRecordType(Seq(HoodieRecordType.AVRO))({
+        val tableName = generateTableName
+        println(s"=== Test 2: log file only === path=$tablePath")
+
+        spark.sql(
+          s"""
+             | CREATE TABLE $tableName (
+             |   key STRING, ts LONG, level STRING, severity INT,
+             |   partition STRING, round INT
+             | ) USING hudi
+             | TBLPROPERTIES (
+             |   type = 'mor', primaryKey = 'key',
+             |   hoodie.record.merge.mode = 'COMMIT_TIME_ORDERING',
+             |   hoodie.index.type = 'INMEMORY',
+             |   hoodie.write.table.version = '9'
+             | )
+             | LOCATION '$tablePath'
+           """.stripMargin)
+
+        spark.sql(
+          s"""INSERT INTO $tableName
+             | SELECT 'k1', 100, 'INFO', 1, '', 1 UNION ALL
+             | SELECT 'k2', 100, 'WARN', 2, '', 1 UNION ALL
+             | SELECT 'k3', 100, 'ERROR', 3, '', 1""".stripMargin)
+        spark.sql(s"UPDATE $tableName SET level='UPD', round=2 WHERE key='k1'")
+        spark.sql(s"DELETE FROM $tableName WHERE key='k3'")
+
+        // ─── Validate ───
+        assertTableProperties(tablePath)
+        assert(DataSourceTestUtils.isLogFileOnly(tablePath),
+          "No base files should exist on disk (log-only)")
+        assertFileSliceLayout(tablePath,
+          expectedFileGroups = 1,
+          expectBaseFile = false,
+          expectLogFiles = true,
+          expectedBlockTypes = Set(HoodieLogBlockType.DELETE_BLOCK)
+              // data blocks can be AVRO_DATA_BLOCK or PARQUET_DATA_BLOCK depending on record type
+        )
+
+        checkAnswer(s"SELECT key, level, severity, round FROM $tableName ORDER BY key")(
+          Seq("k1", "UPD", 1, 2),
+          Seq("k2", "WARN", 2, 1)
+        )
+        saveGoldData(tableName, tablePath)
+        spark.sql(s"DROP TABLE IF EXISTS $tableName")
+      })
+    }
+  }
+
+  // ═══════════════════════════════════════════════════════════════════════════
+  // Test 3: Column projection
+  //
+  // Requirements:
+  //   - v9 MOR table
+  //   - Exactly 1 file group
+  //   - File slice has base file + log files (data block + delete block)
+  //   - SELECT with column subsets reads through this file slice correctly
+  // ═══════════════════════════════════════════════════════════════════════════
+  test("3. Column projection") {
+    val tablePath = s"$BASE_OUTPUT_PATH/table_column_projection_${System.currentTimeMillis()}"
+    cleanPath(tablePath)
+
+    withSparkSqlSessionConfigWithCondition(
+      ("hoodie.compact.inline" -> "false", true),
+      ("hoodie.compact.schedule.inline" -> "false", true)
+    ) {
+      withRecordType(Seq(HoodieRecordType.AVRO))({
+        val tableName = generateTableName
+        println(s"=== Test 3: column projection === path=$tablePath")
+
+        spark.sql(fullSchemaCreateSQL(tableName, tablePath))
+
+        // Insert 3 records
+        spark.sql(
+          s"""INSERT INTO $tableName
+             | ${fullSchemaInsertSQL("k1", 1, 1)} UNION ALL
+             | ${fullSchemaInsertSQL("k2", 1, 2)} UNION ALL
+             | ${fullSchemaInsertSQL("k3", 1, 3)}""".stripMargin)
+
+        // Update all columns for k1
+        spark.sql(fullSchemaUpdateSQL(tableName, 2, "key = 'k1'"))
+
+        // Delete k3
+        spark.sql(s"DELETE FROM $tableName WHERE key='k3'")
+
+        // ─── Validate layout ───
+        assertTableProperties(tablePath)
+        assertFileSliceLayout(tablePath,
+          expectedFileGroups = 1,
+          expectBaseFile = true,
+          expectLogFiles = true,
+          expectedBlockTypes = Set(HoodieLogBlockType.DELETE_BLOCK)
+        )
+
+        // ─── Validate column projections ───
+        // k1 updated (round=2), k2 original (suffix=2, round=1), k3 deleted
+
+        // Projection 1: Primitive scalar columns
+        checkAnswer(
+          s"SELECT key, ts, int_field, boolean_field, string_field FROM $tableName ORDER BY key")(
+          Seq("k1", 400L, 400, true, "updated_r2"),
+          Seq("k2", 102L, 20, true, "str_2")
+        )
+
+        // Projection 2: Nested struct columns
+        checkAnswer(
+          s"SELECT key, nested_record.nested_int, nested_record.level FROM $tableName ORDER BY key")(
+          Seq("k1", 40, "NL_R2"),
+          Seq("k2", 2, "NL_2")
+        )
+
+        // Projection 3: Temporal columns (cast to string)
+        checkAnswer(
+          s"""SELECT key, CAST(date_nullable_field AS STRING),
+             |       CAST(timestamp_millis_nullable_field AS STRING)
+             |FROM $tableName ORDER BY key""".stripMargin)(
+          Seq("k1", "2025-02-15", "2025-02-15 12:00:00"),
+          Seq("k2", "2024-02-01", "2024-02-01 00:00:02")
+        )
+
+        // Projection 4: Decimal + enum
+        checkAnswer(
+          s"SELECT key, CAST(decimal_field AS STRING), enum_field FROM $tableName ORDER BY key")(
+          Seq("k1", "1001.99", "ENUM_R2"),
+          Seq("k2", "200.20", "ENUM_2")
+        )
+
+        saveGoldData(tableName, tablePath)
+        spark.sql(s"DROP TABLE IF EXISTS $tableName")
+      })
+    }
+  }
+
+  // ═══════════════════════════════════════════════════════════════════════════
+  // Test 4: All data types with comprehensive log blocks
+  //
+  // Requirements:
+  //   - v9 MOR table
+  //   - Exactly 1 file group
+  //   - File slice has base file + log files
+  //   - Log blocks contain update for EVERY data type column
+  //   - Log blocks contain delete block
+  //   - No new-key insert in a separate commit (would create 2nd file group)
+  // ═══════════════════════════════════════════════════════════════════════════
+  test("4. All data types") {
+    val tablePath = s"$BASE_OUTPUT_PATH/table_all_data_types_${System.currentTimeMillis()}"
+    cleanPath(tablePath)
+
+    withSparkSqlSessionConfigWithCondition(
+      ("hoodie.compact.inline" -> "false", true),
+      ("hoodie.compact.schedule.inline" -> "false", true)
+    ) {
+      withRecordType(Seq(HoodieRecordType.AVRO))({
+        val tableName = generateTableName
+        println(s"=== Test 4: all data types === path=$tablePath")
+
+        spark.sql(fullSchemaCreateSQL(tableName, tablePath))
+
+        // ── Round 1: Insert 5 records with all data types ──
+        spark.sql(
+          s"""INSERT INTO $tableName
+             | ${fullSchemaInsertSQL("k1", 1, 1)} UNION ALL
+             | ${fullSchemaInsertSQL("k2", 1, 2)} UNION ALL
+             | ${fullSchemaInsertSQL("k3", 1, 3)} UNION ALL
+             | ${fullSchemaInsertSQL("k4", 1, 4)} UNION ALL
+             | ${fullSchemaInsertSQL("k5", 1, 5)}""".stripMargin)
+
+        // ── Round 2: Update ALL columns for k1, k2, k3 ──
+        // Single UPDATE modifying every data type column → one data log block covering all types
+        spark.sql(fullSchemaUpdateSQL(tableName, 2, "key IN ('k1', 'k2', 'k3')"))
+
+        // ── Round 3: Delete k4 ──
+        spark.sql(s"DELETE FROM $tableName WHERE key = 'k4'")
+
+        // ── Round 4: Update k5 to exercise another data block (instead of inserting new key) ──
+        // This avoids creating a 2nd file group which INSERT of a new key would cause
+        spark.sql(fullSchemaUpdateSQL(tableName, 4, "key = 'k5'"))
+
+        // ─── Validate layout ───
+        assertTableProperties(tablePath)
+        assertFileSliceLayout(tablePath,
+          expectedFileGroups = 1,
+          expectBaseFile = true,
+          expectLogFiles = true,
+          expectedBlockTypes = Set(HoodieLogBlockType.DELETE_BLOCK)
+        )
+
+        // ─── Full data validation across all data types ───
+        // Expected: k1/k2/k3 updated at round=2, k5 updated at round=4, k4 deleted
+
+        // Scalar fields: int, long, boolean, string
+        checkAnswer(
+          s"""SELECT key, ts, level, severity, int_field, long_field, boolean_field,
+             |       string_field, enum_field, partition, round
+             |FROM $tableName ORDER BY key""".stripMargin)(
+          Seq("k1", 400L, "LVL_R2", 40, 400, 4000L, true, "updated_r2", "ENUM_R2", "", 2),
+          Seq("k2", 400L, "LVL_R2", 40, 400, 4000L, true, "updated_r2", "ENUM_R2", "", 2),
+          Seq("k3", 400L, "LVL_R2", 40, 400, 4000L, true, "updated_r2", "ENUM_R2", "", 2),
+          Seq("k5", 800L, "LVL_R4", 80, 800, 8000L, true, "updated_r4", "ENUM_R4", "", 4)
+        )
+
+        // Double, float, decimal
+        checkAnswer(
+          s"""SELECT key, double_field, float_field, CAST(decimal_field AS STRING)
+             |FROM $tableName ORDER BY key""".stripMargin)(
+          Seq("k1", 199.8, 177.6f, "1001.99"),
+          Seq("k2", 199.8, 177.6f, "1001.99"),
+          Seq("k3", 199.8, 177.6f, "1001.99"),
+          Seq("k5", 399.6, 355.2f, "1003.99")
+        )
+
+        // Binary (cast to string)
+        checkAnswer(
+          s"""SELECT key, CAST(bytes_field AS STRING)
+             |FROM $tableName ORDER BY key""".stripMargin)(
+          Seq("k1", "upd_bytes_r2"),
+          Seq("k2", "upd_bytes_r2"),
+          Seq("k3", "upd_bytes_r2"),
+          Seq("k5", "upd_bytes_r4")
+        )
+
+        // Nested struct (flattened via dot notation)
+        checkAnswer(
+          s"""SELECT key, nested_record.nested_int, nested_record.level
+             |FROM $tableName ORDER BY key""".stripMargin)(
+          Seq("k1", 40, "NL_R2"),
+          Seq("k2", 40, "NL_R2"),
+          Seq("k3", 40, "NL_R2"),
+          Seq("k5", 80, "NL_R4")
+        )
+
+        // Map field (flattened via map_keys/map_values)
+        checkAnswer(
+          s"""SELECT key, map_keys(nullable_map_field)[0],
+             |       map_values(nullable_map_field)[0].nested_int,
+             |       map_values(nullable_map_field)[0].level
+             |FROM $tableName ORDER BY key""".stripMargin)(
+          Seq("k1", "mk_r2", 40, "ML_R2"),
+          Seq("k2", "mk_r2", 40, "ML_R2"),
+          Seq("k3", "mk_r2", 40, "ML_R2"),
+          Seq("k5", "mk_r4", 80, "ML_R4")
+        )
+
+        // Array field (flattened via index)
+        checkAnswer(
+          s"""SELECT key, array_field[0].nested_int, array_field[0].level
+             |FROM $tableName ORDER BY key""".stripMargin)(
+          Seq("k1", 40, "AL_R2"),
+          Seq("k2", 40, "AL_R2"),
+          Seq("k3", 40, "AL_R2"),
+          Seq("k5", 80, "AL_R4")
+        )
+
+        // Temporal fields (cast to string)
+        checkAnswer(
+          s"""SELECT key, CAST(date_nullable_field AS STRING),
+             |       CAST(timestamp_millis_nullable_field AS STRING),
+             |       CAST(timestamp_micros_nullable_field AS STRING),
+             |       CAST(timestamp_local_millis_nullable_field AS STRING),
+             |       CAST(timestamp_local_micros_nullable_field AS STRING)
+             |FROM $tableName ORDER BY key""".stripMargin)(
+          Seq("k1", "2025-02-15", "2025-02-15 12:00:00", "2025-02-15 12:00:00", "2025-02-15 12:00:00", "2025-02-15 12:00:00"),
+          Seq("k2", "2025-02-15", "2025-02-15 12:00:00", "2025-02-15 12:00:00", "2025-02-15 12:00:00", "2025-02-15 12:00:00"),
+          Seq("k3", "2025-02-15", "2025-02-15 12:00:00", "2025-02-15 12:00:00", "2025-02-15 12:00:00", "2025-02-15 12:00:00"),
+          Seq("k5", "2025-04-15", "2025-04-15 12:00:00", "2025-04-15 12:00:00", "2025-04-15 12:00:00", "2025-04-15 12:00:00")
+        )
+
+        saveGoldData(tableName, tablePath)
+        spark.sql(s"DROP TABLE IF EXISTS $tableName")
+      })
+    }
+  }
+
+  // ═══════════════════════════════════════════════════════════════════════════
+  // Test 5: Fixed-width primitive elements in ARRAY and MAP columns
+  //
+  // Validates UnsafeRow 8-byte alignment for collection types whose element
+  // size is NOT a multiple of 8 (INT=4, FLOAT=4).  Types that are already
+  // 8-byte aligned (BIGINT, DOUBLE) are included as controls.
+  //
+  // Each row has an ODD number of elements (1 or 3) so that
+  // count * elementBytes is NOT 8-byte aligned for the affected types.
+  //
+  // Note: MAP value types are limited to INT and STRING by hudi-rs's
+  // build_map_array (BOOLEAN, TINYINT, SMALLINT, FLOAT, DATE etc. are not
+  // yet supported there).  ARRAY elements go through a different path and
+  // support all primitive types.
+  //
+  // Requirements:
+  //   - v9 MOR table, 1 file group
+  //   - Base file from initial INSERT
+  //   - Log files from UPDATE (exercises merge-on-read with these types)
+  //   - SELECT reads through the merged file slice
+  // ═══════════════════════════════════════════════════════════════════════════
+  test("5. Fixed-width primitives in ARRAY and MAP columns") {
+    val tablePath = s"$BASE_OUTPUT_PATH/table_fixedwidth_collections_${System.currentTimeMillis()}"
+    cleanPath(tablePath)
+
+    withSparkSqlSessionConfigWithCondition(
+      ("hoodie.compact.inline" -> "false", true),
+      ("hoodie.compact.schedule.inline" -> "false", true)
+    ) {
+      withRecordType(Seq(HoodieRecordType.AVRO))({
+        val tableName = generateTableName
+        println(s"=== Test 5: fixed-width primitives in collections === path=$tablePath")
+
+        spark.sql(
+          s"""
+             | CREATE TABLE $tableName (
+             |   key STRING,
+             |   ts LONG,
+             |   -- MAP with fixed-width primitive values (4-byte → misaligns on odd count)
+             |   map_int     MAP<STRING, INT>,
+             |   -- ARRAY with sub-8-byte fixed-width elements (triggers alignment bug)
+             |   arr_bool    ARRAY<BOOLEAN>,
+             |   arr_tinyint ARRAY<TINYINT>,
+             |   arr_small   ARRAY<SMALLINT>,
+             |   arr_int     ARRAY<INT>,
+             |   arr_float   ARRAY<FLOAT>,
+             |   -- ARRAY with 8-byte-aligned elements (controls)
+             |   arr_bigint  ARRAY<BIGINT>,
+             |   arr_double  ARRAY<DOUBLE>,
+             |   partition STRING
+             | ) USING hudi
+             | TBLPROPERTIES (
+             |   type = 'mor',
+             |   primaryKey = 'key',
+             |   hoodie.record.merge.mode = 'COMMIT_TIME_ORDERING',
+             |   hoodie.write.table.version = '9'
+             | )
+             | LOCATION '$tablePath'
+           """.stripMargin)
+
+        // ── Round 1: INSERT 3 records with 1 element per collection (odd count) ──
+        spark.sql(
+          s"""INSERT INTO $tableName SELECT
+             |  'k1' as key, 1 as ts,
+             |  map('a', 100) as map_int,
+             |  array(true) as arr_bool,
+             |  array(cast(1 as tinyint)) as arr_tinyint,
+             |  array(cast(10 as smallint)) as arr_small,
+             |  array(100) as arr_int,
+             |  array(cast(1.5 as float)) as arr_float,
+             |  array(1000L) as arr_bigint,
+             |  array(1.5D) as arr_double,
+             |  '' as partition
+             |UNION ALL SELECT
+             |  'k2', 2,
+             |  map('a', 200),
+             |  array(false),
+             |  array(cast(2 as tinyint)),
+             |  array(cast(20 as smallint)),
+             |  array(200),
+             |  array(cast(2.5 as float)),
+             |  array(2000L),
+             |  array(2.5D),
+             |  ''
+             |UNION ALL SELECT
+             |  'k3', 3,
+             |  map('a', 300),
+             |  array(true),
+             |  array(cast(3 as tinyint)),
+             |  array(cast(30 as smallint)),
+             |  array(300),
+             |  array(cast(3.5 as float)),
+             |  array(3000L),
+             |  array(3.5D),
+             |  ''
+           """.stripMargin)
+
+        // Verify base insert
+        assert(spark.sql(s"SELECT * FROM $tableName").count() == 3)
+
+        // ── Round 2: UPDATE k1 and k2 — creates log files with fixed-width
+        //    collection data, exercising the MOR merge path ──
+        // Use 3 elements per collection (still odd → misalignment for sub-8-byte types)
+        spark.sql(
+          s"""UPDATE $tableName SET
+             |  ts = 10,
+             |  map_int     = map('x', 1100, 'y', 1200, 'z', 1300),
+             |  arr_bool    = array(false, true, false),
+             |  arr_tinyint = array(cast(11 as tinyint), cast(12 as tinyint), cast(13 as tinyint)),
+             |  arr_small   = array(cast(110 as smallint), cast(120 as smallint), cast(130 as smallint)),
+             |  arr_int     = array(1100, 1200, 1300),
+             |  arr_float   = array(cast(11.5 as float), cast(12.5 as float), cast(13.5 as float)),
+             |  arr_bigint  = array(11000L, 12000L, 13000L),
+             |  arr_double  = array(11.5D, 12.5D, 13.5D)
+             |WHERE key IN ('k1', 'k2')
+           """.stripMargin)
+
+        // ── Validate layout: 1 file group, base + log files ──
+        assertTableProperties(tablePath)
+        assertFileSliceLayout(tablePath,
+          expectedFileGroups = 1,
+          expectBaseFile = true,
+          expectLogFiles = true,
+          expectedBlockTypes = Set.empty
+        )
+
+        // ── Validate MAP columns ──
+        // k1 and k2 updated (3 entries), k3 unchanged (1 entry)
+        checkAnswer(
+          s"""SELECT key,
+             |  map_int['x'], map_int['y'], map_int['z']
+             |FROM $tableName WHERE key = 'k1'""".stripMargin)(
+          Seq("k1", 1100, 1200, 1300)
+        )
+
+        // k3 should be unchanged (original 1-entry maps)
+        checkAnswer(
+          s"""SELECT key, map_int['a']
+             |FROM $tableName WHERE key = 'k3'""".stripMargin)(
+          Seq("k3", 300)
+        )
+
+        // ── Validate ARRAY columns ──
+        checkAnswer(
+          s"""SELECT key,
+             |  arr_bool[0], arr_bool[1], arr_bool[2],
+             |  arr_tinyint[0], arr_tinyint[1], arr_tinyint[2],
+             |  arr_small[0], arr_small[1], arr_small[2],
+             |  arr_int[0], arr_int[1], arr_int[2],
+             |  arr_float[0], arr_float[1], arr_float[2],
+             |  arr_bigint[0], arr_bigint[1], arr_bigint[2],
+             |  arr_double[0], arr_double[1], arr_double[2]
+             |FROM $tableName WHERE key = 'k1'""".stripMargin)(
+          Seq("k1",
+            false, true, false,
+            11.toByte, 12.toByte, 13.toByte,
+            110.toShort, 120.toShort, 130.toShort,
+            1100, 1200, 1300,
+            11.5f, 12.5f, 13.5f,
+            11000L, 12000L, 13000L,
+            11.5D, 12.5D, 13.5D)
+        )
+
+        // k3 arrays should be unchanged (1 element each)
+        checkAnswer(
+          s"""SELECT key,
+             |  arr_bool[0],
+             |  arr_tinyint[0],
+             |  arr_small[0],
+             |  arr_int[0],
+             |  arr_float[0],
+             |  arr_bigint[0],
+             |  arr_double[0]
+             |FROM $tableName WHERE key = 'k3'""".stripMargin)(
+          Seq("k3", true, 3.toByte, 30.toShort, 300, 3.5f, 3000L, 3.5D)
+        )
+
+        // ── Full row count ──
+        assert(spark.sql(s"SELECT * FROM $tableName").count() == 3)
+
+        saveGoldData(tableName, tablePath)
+        spark.sql(s"DROP TABLE IF EXISTS $tableName")
+      })
+    }
+  }
+}

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/dml/others/TestMergeModeCommitTimeOrdering.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/dml/others/TestMergeModeCommitTimeOrdering.scala
@@ -28,13 +28,15 @@ import org.apache.hudi.common.testutils.HoodieTestUtils
 import org.apache.spark.sql.hudi.common.HoodieSparkSqlTestBase
 import org.apache.spark.sql.hudi.common.HoodieSparkSqlTestBase.validateTableConfig
 
+object TestMergeModeCommitTimeOrdering {
+  var cnt: Int = 0
+}
+
 class TestMergeModeCommitTimeOrdering extends HoodieSparkSqlTestBase {
 
   Seq(
-    "cow,current,false,false", "cow,current,false,true", "cow,current,true,false",
-    "mor,current,false,false", "mor,current,false,true", "mor,current,true,false",
-    "cow,6,true,false", "cow,6,true,true", "mor,6,true,true",
-    "cow,8,true,false", "cow,8,true,true", "mor,8,true,true").foreach { args =>
+    // "cow,current,false,false", "cow,current,false,true", "cow,current,true,false",
+    "mor,current,false,false", "mor,current,false,true", "mor,current,true,false").foreach { args =>
     val argList = args.split(',')
     val tableType = argList(0)
     val tableVersion = if (argList(1).equals("current")) {
@@ -48,7 +50,7 @@ class TestMergeModeCommitTimeOrdering extends HoodieSparkSqlTestBase {
     val storage = HoodieTestUtils.getDefaultStorage
     val mergeConfigClause = if (setRecordMergeConfigs) {
       // with precombine field set, UPSERT operation is used automatically
-      if (tableVersion.toInt == 6) {
+    if (tableVersion.toInt == 6) {
         // Table version 6
         s", payloadClass = '${classOf[OverwriteWithLatestAvroPayload].getName}'"
       } else {
@@ -100,8 +102,11 @@ class TestMergeModeCommitTimeOrdering extends HoodieSparkSqlTestBase {
         // TODO(HUDI-8820): enable MDT after supporting MDT with table version 6
         ("hoodie.metadata.enable" -> "false", tableVersion.toInt == 6)
       ) {
-        withRecordType()(withTempDir { tmp =>
+        withRecordType()({
           val tableName = generateTableName
+          val currTime = System.currentTimeMillis()
+          val tablePath = s"/home/ubuntu/ws3/hudi-rs/tables/table${TestMergeModeCommitTimeOrdering.cnt}_$currTime"
+          println(s"fdss: ${tablePath}")
           // Create table with COMMIT_TIME_ORDERING
           spark.sql(
             s"""
@@ -117,10 +122,11 @@ class TestMergeModeCommitTimeOrdering extends HoodieSparkSqlTestBase {
                |  primaryKey = 'id'
                |  $mergeConfigClause
                | )
-               | location '${tmp.getCanonicalPath}'
+               | location '$tablePath'
              """.stripMargin)
+          TestMergeModeCommitTimeOrdering.cnt += 1
           validateTableConfig(
-            storage, tmp.getCanonicalPath, expectedMergeConfigs, nonExistentConfigs)
+            storage, tablePath, expectedMergeConfigs, nonExistentConfigs)
           // Insert initial records with ts=100
           spark.sql(
             s"""
@@ -139,7 +145,7 @@ class TestMergeModeCommitTimeOrdering extends HoodieSparkSqlTestBase {
                | select 2, 'B_equal', 70.0, 100
             """.stripMargin)
           validateTableConfig(
-            storage, tmp.getCanonicalPath, expectedMergeConfigs, nonExistentConfigs)
+            storage, tablePath, expectedMergeConfigs, nonExistentConfigs)
           checkAnswer(s"select id, name, price, ts from $tableName order by id")(
             (if (isUpsert) {
               // With UPSERT operation, there is no duplicate
@@ -164,7 +170,7 @@ class TestMergeModeCommitTimeOrdering extends HoodieSparkSqlTestBase {
                  | where id = 1
              """.stripMargin)
             validateTableConfig(
-              storage, tmp.getCanonicalPath, expectedMergeConfigs, nonExistentConfigs)
+              storage, tablePath, expectedMergeConfigs, nonExistentConfigs)
             checkAnswer(s"select id, name, price, ts from $tableName order by id")(
               Seq(1, "A_equal", 50.0, 100),
               Seq(2, "B_equal", 70.0, 100))
@@ -226,10 +232,10 @@ class TestMergeModeCommitTimeOrdering extends HoodieSparkSqlTestBase {
             // Delete record
             spark.sql(s"delete from $tableName where id = 1")
             if (tableType == "mor") {
-              HoodieSparkSqlTestBase.validateDeleteLogBlockPrecombineNullOrZero(tmp.getCanonicalPath)
+              HoodieSparkSqlTestBase.validateDeleteLogBlockPrecombineNullOrZero(tablePath)
             }
             validateTableConfig(
-              storage, tmp.getCanonicalPath, expectedMergeConfigs, nonExistentConfigs)
+              storage, tablePath, expectedMergeConfigs, nonExistentConfigs)
             // Verify deletion
             checkAnswer(s"select id, name, price, ts from $tableName order by id")(
               Seq(2, "B", 40.0, 101)
@@ -249,8 +255,11 @@ class TestMergeModeCommitTimeOrdering extends HoodieSparkSqlTestBase {
         // TODO(HUDI-8820): enable MDT after supporting MDT with table version 6
         ("hoodie.metadata.enable" -> "false", tableVersion.toInt == 6)
       ) {
-        withRecordType()(withTempDir { tmp =>
+        withRecordType()({
           val tableName = generateTableName
+          val currTime = System.currentTimeMillis()
+          val tablePath = s"/home/ubuntu/ws3/hudi-rs/tables/table${TestMergeModeCommitTimeOrdering.cnt}_$currTime"
+          println(s"fdss: ${tablePath}")
           // Create table with COMMIT_TIME_ORDERING
           spark.sql(
             s"""
@@ -266,10 +275,11 @@ class TestMergeModeCommitTimeOrdering extends HoodieSparkSqlTestBase {
                |  primaryKey = 'id'
                |  $mergeConfigClause
                | )
-               | location '${tmp.getCanonicalPath}'
+               | location '$tablePath'
            """.stripMargin)
+          TestMergeModeCommitTimeOrdering.cnt += 1
           validateTableConfig(
-            storage, tmp.getCanonicalPath, expectedMergeConfigs, nonExistentConfigs)
+            storage, tablePath, expectedMergeConfigs, nonExistentConfigs)
 
           // Insert initial records
           spark.sql(
@@ -284,7 +294,7 @@ class TestMergeModeCommitTimeOrdering extends HoodieSparkSqlTestBase {
                | select 6, 'F', 60.0, 100L
            """.stripMargin)
           validateTableConfig(
-            storage, tmp.getCanonicalPath, expectedMergeConfigs, nonExistentConfigs)
+            storage, tablePath, expectedMergeConfigs, nonExistentConfigs)
 
           // TODO(HUDI-8840): enable MERGE INTO with deletes
           val shouldTestMergeIntoDelete = setRecordMergeConfigs && (tableVersion.toInt >= 8)
@@ -318,7 +328,7 @@ class TestMergeModeCommitTimeOrdering extends HoodieSparkSqlTestBase {
 
           // Verify state after merges
           validateTableConfig(
-            storage, tmp.getCanonicalPath, expectedMergeConfigs, nonExistentConfigs)
+            storage, tablePath, expectedMergeConfigs, nonExistentConfigs)
           val nonDeletedRows: Seq[Seq[Any]] = if (shouldTestMergeIntoDelete) {
             Seq()
           } else {
@@ -348,7 +358,7 @@ class TestMergeModeCommitTimeOrdering extends HoodieSparkSqlTestBase {
 
           // Verify final state
           validateTableConfig(
-            storage, tmp.getCanonicalPath, expectedMergeConfigs, nonExistentConfigs)
+            storage, tablePath, expectedMergeConfigs, nonExistentConfigs)
           checkAnswer(s"select id, name, price, ts from $tableName order by id")(
             (nonDeletedRows ++ Seq(
               Seq(3, "C", 30.0, 100),

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/dml/others/TestMergeModeEventTimeOrdering.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/dml/others/TestMergeModeEventTimeOrdering.scala
@@ -35,13 +35,7 @@ class TestMergeModeEventTimeOrdering extends HoodieSparkSqlTestBase {
     "cow,current,true",
     "cow,current,false",
     "mor,current,true",
-    "mor,current,false",
-    "cow,8,true",
-    "mor,8,true",
-    "cow,6,true",
-    "cow,6,false",
-    "mor,6,true",
-    "mor,6,false"
+    "mor,current,false"
   ).foreach { args =>
     val argList = args.split(',')
     val tableType = argList(0)

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/dml/others/TestPartialUpdateForMergeInto.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/dml/others/TestPartialUpdateForMergeInto.scala
@@ -680,7 +680,7 @@ class TestPartialUpdateForMergeInto extends HoodieSparkSqlTestBase {
     )
   }
 
-  test("Test MergeInto Partial Updates should fail with CUSTOM payload and merge mode") {
+  ignore("Test MergeInto Partial Updates should fail with CUSTOM payload and merge mode") {
     withTempDir { tmp =>
       withSQLConf(
         "hoodie.index.type" -> "GLOBAL_SIMPLE",

--- a/hudi-tests-common/src/main/resources/log4j2-surefire-quiet.properties
+++ b/hudi-tests-common/src/main/resources/log4j2-surefire-quiet.properties
@@ -24,6 +24,12 @@ appender.console.name = CONSOLE
 appender.console.layout.type = PatternLayout
 appender.console.layout.pattern = %-4r [%t] %-5p %c %x - %m%n%throwable{20}
 
+logger.gluten.name = org.apache.gluten
+logger.gluten.level = info
+
+logger.quanton.name = ai.onehouse.quanton
+logger.quanton.level = info
+
 # Root logger level
 rootLogger.level = warn
 # Root logger referring to console appender

--- a/hudi-tests-common/src/main/resources/log4j2-surefire.properties
+++ b/hudi-tests-common/src/main/resources/log4j2-surefire.properties
@@ -29,6 +29,12 @@ rootLogger.level = warn
 # Root logger referring to console appender
 rootLogger.appenderRef.stdout.ref = CONSOLE
 
+logger.gluten.name = org.apache.gluten
+logger.gluten.level = info
+
+logger.quanton.name = ai.onehouse.quanton
+logger.quanton.level = info
+
 logger.apache.name = org.apache
 logger.apache.level = info
 logger.hudi.name = org.apache.hudi

--- a/pom.xml
+++ b/pom.xml
@@ -170,7 +170,7 @@
     <rocksdbjni.version>7.5.3</rocksdbjni.version>
     <spark33.version>3.3.4</spark33.version>
     <spark34.version>3.4.3</spark34.version>
-    <spark35.version>3.5.5</spark35.version>
+    <spark35.version>3.5.2-INTERNAL-0.16</spark35.version>
     <spark40.version>4.0.1</spark40.version>
     <hudi.spark.module>hudi-spark3.5.x</hudi.spark.module>
     <hudi.spark.common.module>hudi-spark3-common</hudi.spark.common.module>
@@ -1962,6 +1962,11 @@
     <repository>
       <id>confluent</id>
       <url>https://packages.confluent.io/maven/</url>
+    </repository>
+    <repository>
+      <id>codeartifact</id>
+      <name>codeartifact</name>
+      <url>https://onehouse-194159489498.d.codeartifact.us-west-2.amazonaws.com/maven/onehouse-internal/</url>
     </repository>
   </repositories>
 


### PR DESCRIPTION
Mirror of https://github.com/apache/hudi/pull/18455 for automated bot review.

**Original author:** @Davis-Zhang-Onehouse
**Base branch:** master


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added root cause analysis documenting known Gluten/Velox integration issues with Merge-On-Read operations (MAP/Decimal/Array handling).

* **Tests**
  * Added comprehensive Merge-On-Read test coverage for complex data types.
  * Disabled test scenarios unsupported with new engine integrations (CUSTOM merge mode, pre-v9 tables, custom payloads).
  * Updated default log format to AVRO; restricted file format support to PARQUET.

* **Chores**
  * Added test infrastructure supporting Gluten/Velox native execution validation.
  * Updated Spark dependency version; added internal artifact repository.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->