### PR TITLE
[OSS PR #18065] feat(schema): Add support to write shredded variants for HoodieRecordType.AVRO

### DIFF
--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/io/storage/row/HoodieRowParquetWriteSupport.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/io/storage/row/HoodieRowParquetWriteSupport.java
@@ -83,6 +83,9 @@ import scala.Enumeration;
 import scala.Function1;
 
 import static org.apache.hudi.common.config.HoodieStorageConfig.PARQUET_FIELD_ID_WRITE_ENABLED;
+import static org.apache.hudi.common.config.HoodieStorageConfig.PARQUET_VARIANT_ALLOW_READING_SHREDDED;
+import static org.apache.hudi.common.config.HoodieStorageConfig.PARQUET_VARIANT_FORCE_SHREDDING_SCHEMA_FOR_TEST;
+import static org.apache.hudi.common.config.HoodieStorageConfig.PARQUET_VARIANT_WRITE_SHREDDING_ENABLED;
 import static org.apache.hudi.config.HoodieWriteConfig.ALLOW_OPERATION_METADATA_FIELD;
 import static org.apache.hudi.config.HoodieWriteConfig.AVRO_SCHEMA_STRING;
 import static org.apache.hudi.config.HoodieWriteConfig.INTERNAL_SCHEMA_STRING;
@@ -115,6 +118,8 @@ public class HoodieRowParquetWriteSupport extends WriteSupport<InternalRow> {
   private static final String MAP_REPEATED_NAME = "key_value";
   private static final String MAP_KEY_NAME = "key";
   private static final String MAP_VALUE_NAME = "value";
+  private static final String SPARK_VARIANT_WRITE_SHREDDING_ENABLED = "spark.sql.variant.writeShredding.enabled";
+  private static final String SPARK_VARIANT_ALLOW_READING_SHREDDED = "spark.sql.variant.allowReadingShredded";
 
   @Getter
   private final Configuration hadoopConf;
@@ -133,6 +138,8 @@ public class HoodieRowParquetWriteSupport extends WriteSupport<InternalRow> {
    * For non-shredded cases, this is identical to structType.
    */
   private final StructType shreddedSchema;
+  private final boolean variantWriteShreddingEnabled;
+  private final String variantForceShreddingSchemaForTest;
   private RecordConsumer recordConsumer;
 
   public HoodieRowParquetWriteSupport(Configuration conf, StructType structType, Option<BloomFilter> bloomFilterOpt, HoodieConfig config) {
@@ -141,6 +148,16 @@ public class HoodieRowParquetWriteSupport extends WriteSupport<InternalRow> {
     hadoopConf.set("spark.sql.parquet.writeLegacyFormat", writeLegacyFormatEnabled);
     hadoopConf.set("spark.sql.parquet.outputTimestampType", config.getStringOrDefault(HoodieStorageConfig.PARQUET_OUTPUT_TIMESTAMP_TYPE));
     hadoopConf.set("spark.sql.parquet.fieldId.write.enabled", config.getStringOrDefault(PARQUET_FIELD_ID_WRITE_ENABLED));
+
+    // Variant shredding configs
+    this.variantWriteShreddingEnabled = config.getBooleanOrDefault(PARQUET_VARIANT_WRITE_SHREDDING_ENABLED);
+    this.variantForceShreddingSchemaForTest = config.getString(PARQUET_VARIANT_FORCE_SHREDDING_SCHEMA_FOR_TEST);
+    hadoopConf.setBoolean(SPARK_VARIANT_WRITE_SHREDDING_ENABLED, variantWriteShreddingEnabled);
+    hadoopConf.setBoolean(SPARK_VARIANT_ALLOW_READING_SHREDDED, config.getBooleanOrDefault(PARQUET_VARIANT_ALLOW_READING_SHREDDED));
+    if (variantForceShreddingSchemaForTest != null && !variantForceShreddingSchemaForTest.isEmpty()) {
+      hadoopConf.set("spark.sql.variant.forceShreddingSchemaForTest", variantForceShreddingSchemaForTest);
+    }
+
     this.writeLegacyListFormat = Boolean.parseBoolean(writeLegacyFormatEnabled)
         || Boolean.parseBoolean(config.getStringOrDefault(AvroWriteSupport.WRITE_OLD_LIST_STRUCTURE, "false"));
     this.structType = structType;
@@ -164,15 +181,34 @@ public class HoodieRowParquetWriteSupport extends WriteSupport<InternalRow> {
   /**
    * Generates a shredded schema from the given structType and hoodieSchema.
    * <p>
-   * For Variant fields that are configured for shredding (based on HoodieSchema.Variant.isShredded()),
-   * the VariantType is replaced with a shredded struct schema. This method recursively processes
-   * nested struct fields to handle Variant fields at any depth.
+   * For Variant fields that are configured for shredding (based on HoodieSchema.Variant.isShredded()), the VariantType is replaced with a shredded struct schema.
+   * <p>
+   * Shredding behavior is controlled by:
+   * <ul>
+   *   <li>{@code hoodie.parquet.variant.write.shredding.enabled} - Master switch for shredding (default: true).
+   *       When false, no shredding happens regardless of schema configuration.</li>
+   *   <li>{@code hoodie.parquet.variant.force.shredding.schema.for.test} - When set, forces this DDL schema
+   *       as the typed_value schema for ALL variant columns, overriding schema-driven shredding.</li>
+   * </ul>
+   *
+   * This method recursively processes nested struct fields to handle Variant fields at any depth.
    *
    * @param structType The original Spark StructType
    * @param hoodieSchema The HoodieSchema containing shredding information
    * @return A StructType with shredded Variant fields replaced by their shredded schemas
    */
   private StructType generateShreddedSchema(StructType structType, HoodieSchema hoodieSchema) {
+    // If write shredding is disabled, skip shredding entirely
+    if (!variantWriteShreddingEnabled) {
+      return structType;
+    }
+
+    // Parse forced shredding schema if configured
+    StructType forcedShreddingSchema = null;
+    if (variantForceShreddingSchemaForTest != null && !variantForceShreddingSchemaForTest.isEmpty()) {
+      forcedShreddingSchema = StructType.fromDDL(variantForceShreddingSchemaForTest);
+    }
+
     StructField[] fields = structType.fields();
     StructField[] shreddedFields = new StructField[fields.length];
     boolean hasShredding = false;
@@ -180,6 +216,16 @@ public class HoodieRowParquetWriteSupport extends WriteSupport<InternalRow> {
     for (int i = 0; i < fields.length; i++) {
       StructField field = fields[i];
       DataType dataType = field.dataType();
+
+      // If a forced shredding schema is configured, use it for all variant columns
+      if (forcedShreddingSchema != null
+          && SparkAdapterSupport$.MODULE$.sparkAdapter().isVariantType(dataType)) {
+        StructType markedShreddedStruct = SparkAdapterSupport$.MODULE$.sparkAdapter()
+            .generateVariantWriteShreddingSchema(forcedShreddingSchema, true, false);
+        shreddedFields[i] = new StructField(field.name(), markedShreddedStruct, field.nullable(), field.metadata());
+        hasShredding = true;
+        continue;
+      }
 
       // Get the HoodieSchema for this field (if available)
       // Use getNonNullType() to unwrap nullable unions (e.g., ["null", "string"] -> "string")
@@ -189,7 +235,6 @@ public class HoodieRowParquetWriteSupport extends WriteSupport<InternalRow> {
           .map(HoodieSchemaField::schema)
           .orElse(null);
 
-      // Check if this is a Variant field that should be shredded
       if (SparkAdapterSupport$.MODULE$.sparkAdapter().isVariantType(dataType)) {
         if (fieldHoodieSchema != null && fieldHoodieSchema.getType() == HoodieSchemaType.VARIANT) {
           HoodieSchema.Variant variantSchema = (HoodieSchema.Variant) fieldHoodieSchema;

--- a/hudi-client/hudi-spark-client/src/main/scala/org/apache/spark/sql/HoodieInternalRowUtils.scala
+++ b/hudi-client/hudi-spark-client/src/main/scala/org/apache/spark/sql/HoodieInternalRowUtils.scala
@@ -22,6 +22,7 @@ import org.apache.hudi.avro.HoodieAvroUtils.{createFullName, toJavaDate}
 import org.apache.hudi.exception.HoodieException
 import org.apache.hudi.common.schema.HoodieSchema
 import org.apache.hudi.HoodieSchemaConversionUtils.convertHoodieSchemaToStructType
+import org.apache.hudi.HoodieSparkUtils.sparkAdapter
 import org.apache.spark.sql.HoodieCatalystExpressionUtils.generateUnsafeProjection
 import org.apache.spark.sql.HoodieUnsafeRowUtils.{NestedFieldPath, composeNestedFieldPath}
 import org.apache.spark.sql.catalyst.expressions.{SpecificInternalRow, UnsafeArrayData, UnsafeProjection, UnsafeRow}
@@ -398,9 +399,45 @@ object HoodieInternalRowUtils {
         (fieldUpdater, ordinal, value) =>
           fieldUpdater.set(ordinal, CatalystTypeConverters.convertToCatalyst(java.sql.Date.valueOf(value.toString)))
 
+      // Handle conversion from VariantType to variant struct representation
+      case (newStructType: StructType, _) if sparkAdapter.isVariantType(prevDataType) && looksLikeVariantStruct(newStructType) =>
+        (fieldUpdater, ordinal, value) => {
+          if (value == null) {
+            fieldUpdater.setNullAt(ordinal)
+          } else {
+            val row = sparkAdapter.convertVariantToStruct(value, newStructType)
+            fieldUpdater.set(ordinal, row)
+          }
+        }
+
+      // Handle conversion from variant struct representation to VariantType
+      case (_, prevStructType: StructType) if sparkAdapter.isVariantType(newDataType) && looksLikeVariantStruct(prevStructType) =>
+        (fieldUpdater, ordinal, value) => {
+          if (value == null) {
+            fieldUpdater.setNullAt(ordinal)
+          } else {
+            val row = value.asInstanceOf[InternalRow]
+            val variant = sparkAdapter.convertStructToVariant(row, prevStructType)
+            fieldUpdater.set(ordinal, variant)
+          }
+        }
+
       case (_, _) =>
         throw new IllegalArgumentException(s"$prevDataType and $newDataType are incompatible")
     }
+  }
+
+  /**
+   * Checks if a StructType looks like a variant representation (has value and metadata binary fields).
+   * This is a structural check that doesn't rely on metadata, useful during schema reconciliation
+   * when toggling between shredded/unshredded formats or merging data with different representations.
+   */
+  private def looksLikeVariantStruct(structType: StructType): Boolean = {
+    structType.fields.length >= 2 &&
+      structType.fieldNames.contains("value") &&
+      structType.fieldNames.contains("metadata") &&
+      structType("value").dataType == BinaryType &&
+      structType("metadata").dataType == BinaryType
   }
 
   private def lookupRenamedField(newFieldName: String,

--- a/hudi-client/hudi-spark-client/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/HoodieParquetReadSupport.scala
+++ b/hudi-client/hudi-spark-client/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/HoodieParquetReadSupport.scala
@@ -111,7 +111,8 @@ object HoodieParquetReadSupport {
   }
 
   private def isVariantGroup(group: GroupType): Boolean = {
-    group.containsField("value") &&
+    group.getFieldCount == 2 &&
+      group.containsField("value") &&
       group.containsField("metadata") &&
       group.getType("value").isPrimitive &&
       group.getType("metadata").isPrimitive &&

--- a/hudi-client/hudi-spark-client/src/main/scala/org/apache/spark/sql/hudi/SparkAdapter.scala
+++ b/hudi-client/hudi-spark-client/src/main/scala/org/apache/spark/sql/hudi/SparkAdapter.scala
@@ -483,4 +483,30 @@ trait SparkAdapter extends Serializable {
     shreddedStructType: StructType,
     writeStruct: Consumer[InternalRow]
   ): BiConsumer[SpecializedGetters, Integer]
+
+  /**
+   * Converts a Variant value to a struct representation (value and metadata binary fields).
+   * This is used during schema reconciliation when converting from VariantType to StructType.
+   *
+   * For Spark 4.x, extracts value and metadata bytes from VariantVal and creates an InternalRow.
+   * For Spark 3.x, this throws UnsupportedOperationException.
+   *
+   * @param variantValue The variant value object
+   * @param structType The target StructType with value and metadata fields
+   * @return InternalRow with value and metadata fields populated
+   */
+  def convertVariantToStruct(variantValue: Any, structType: StructType): InternalRow
+
+  /**
+   * Converts a struct representation (value and metadata binary fields) to a Variant value.
+   * This is used during schema reconciliation when converting from StructType to VariantType.
+   *
+   * For Spark 4.x, extracts value and metadata bytes from InternalRow and creates a VariantVal.
+   * For Spark 3.x, this throws UnsupportedOperationException.
+   *
+   * @param structRow The InternalRow with value and metadata fields
+   * @param structType The StructType of the struct
+   * @return Variant value object
+   */
+  def convertStructToVariant(structRow: InternalRow, structType: StructType): Any
 }

--- a/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieStorageConfig.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieStorageConfig.java
@@ -174,6 +174,36 @@ public class HoodieStorageConfig extends HoodieConfig {
       .withDocumentation("Control whether to write bloom filter or not. Default true. "
           + "We can set to false in non bloom index cases for CPU resource saving.");
 
+  public static final ConfigProperty<Boolean> PARQUET_VARIANT_WRITE_SHREDDING_ENABLED = ConfigProperty
+      .key("hoodie.parquet.variant.write.shredding.enabled")
+      .defaultValue(true)
+      .sinceVersion("1.1.0")
+      .withDocumentation("Controls whether variant columns are written in shredded format. "
+          + "When enabled (default), variant columns with shredding information in the schema will be written "
+          + "in shredded format with typed_value columns. When disabled, variant columns are always written "
+          + "in unshredded format regardless of the schema. "
+          + "Equivalent to Spark's spark.sql.variant.writeShredding.enabled.");
+
+  public static final ConfigProperty<String> PARQUET_VARIANT_FORCE_SHREDDING_SCHEMA_FOR_TEST = ConfigProperty
+      .key("hoodie.parquet.variant.force.shredding.schema.for.test")
+      .noDefaultValue()
+      .markAdvanced()
+      .sinceVersion("1.1.0")
+      .withDocumentation("Forces a specific shredding schema for all variant columns, intended for testing. "
+          + "The value should be a DDL-format schema string (e.g., 'a int, b string, c decimal(15, 1)'). "
+          + "When set and write shredding is enabled, this schema overrides the schema-driven shredding "
+          + "configuration for all variant columns. "
+          + "Equivalent to Spark's spark.sql.variant.forceShreddingSchemaForTest.");
+
+  public static final ConfigProperty<Boolean> PARQUET_VARIANT_ALLOW_READING_SHREDDED = ConfigProperty
+      .key("hoodie.parquet.variant.allow.reading.shredded")
+      .defaultValue(true)
+      .sinceVersion("1.1.0")
+      .withDocumentation("Controls whether shredded variant data can be read. "
+          + "When enabled (default), the reader will reconstruct variant values from shredded components. "
+          + "When disabled, only unshredded variant data can be read. "
+          + "Equivalent to Spark's spark.sql.variant.allowReadingShredded.");
+
   public static final ConfigProperty<Boolean> WRITE_UTC_TIMEZONE = ConfigProperty
       .key("hoodie.parquet.write.utc-timezone.enabled")
       .defaultValue(true)
@@ -495,6 +525,21 @@ public class HoodieStorageConfig extends HoodieConfig {
 
     public Builder parquetBloomFilterEnable(boolean parquetBloomFilterEnable) {
       storageConfig.setValue(PARQUET_WITH_BLOOM_FILTER_ENABLED, String.valueOf(parquetBloomFilterEnable));
+      return this;
+    }
+
+    public Builder parquetVariantWriteShreddingEnabled(boolean enabled) {
+      storageConfig.setValue(PARQUET_VARIANT_WRITE_SHREDDING_ENABLED, String.valueOf(enabled));
+      return this;
+    }
+
+    public Builder parquetVariantForceShreddingSchemaForTest(String schemaString) {
+      storageConfig.setValue(PARQUET_VARIANT_FORCE_SHREDDING_SCHEMA_FOR_TEST, schemaString);
+      return this;
+    }
+
+    public Builder parquetVariantAllowReadingShredded(boolean allowed) {
+      storageConfig.setValue(PARQUET_VARIANT_ALLOW_READING_SHREDDED, String.valueOf(allowed));
       return this;
     }
 

--- a/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieStorageConfig.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/config/HoodieStorageConfig.java
@@ -204,6 +204,16 @@ public class HoodieStorageConfig extends HoodieConfig {
           + "When disabled, only unshredded variant data can be read. "
           + "Equivalent to Spark's spark.sql.variant.allowReadingShredded.");
 
+  public static final ConfigProperty<String> PARQUET_VARIANT_SHREDDING_PROVIDER_CLASS = ConfigProperty
+      .key("hoodie.parquet.variant.shredding.provider.class")
+      .noDefaultValue()
+      .markAdvanced()
+      .sinceVersion("1.1.0")
+      .withDocumentation("Fully-qualified class name of the VariantShreddingProvider implementation "
+          + "used to shred variant values at write time in the Avro record path. "
+          + "The provider parses variant binary data and populates typed_value columns. "
+          + "When not set, the provider is auto-detected from the classpath.");
+
   public static final ConfigProperty<Boolean> WRITE_UTC_TIMEZONE = ConfigProperty
       .key("hoodie.parquet.write.utc-timezone.enabled")
       .defaultValue(true)

--- a/hudi-hadoop-common/src/main/java/org/apache/hudi/avro/HoodieAvroWriteSupport.java
+++ b/hudi-hadoop-common/src/main/java/org/apache/hudi/avro/HoodieAvroWriteSupport.java
@@ -20,22 +20,45 @@
 package org.apache.hudi.avro;
 
 import org.apache.hudi.common.bloom.BloomFilter;
+import org.apache.hudi.common.config.HoodieConfig;
+import org.apache.hudi.common.config.HoodieStorageConfig;
 import org.apache.hudi.common.schema.HoodieSchema;
+import org.apache.hudi.common.schema.HoodieSchemaField;
+import org.apache.hudi.common.schema.HoodieSchemaType;
+import org.apache.hudi.common.schema.HoodieSchemaUtils;
 import org.apache.hudi.common.util.CollectionUtils;
 import org.apache.hudi.common.util.Option;
+import org.apache.hudi.common.util.ReflectionUtils;
 import org.apache.hudi.common.util.StringUtils;
 
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericData;
+import org.apache.avro.generic.GenericRecord;
+import org.apache.avro.generic.IndexedRecord;
 import org.apache.parquet.avro.AvroWriteSupport;
 import org.apache.parquet.hadoop.api.WriteSupport;
 import org.apache.parquet.schema.MessageType;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Properties;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import static org.apache.hudi.common.config.HoodieStorageConfig.PARQUET_VARIANT_FORCE_SHREDDING_SCHEMA_FOR_TEST;
+import static org.apache.hudi.common.config.HoodieStorageConfig.PARQUET_VARIANT_SHREDDING_PROVIDER_CLASS;
+import static org.apache.hudi.common.config.HoodieStorageConfig.PARQUET_VARIANT_WRITE_SHREDDING_ENABLED;
 
 /**
- * Wrap AvroWriterSupport for plugging in the bloom filter.
+ * Wrap AvroWriterSupport for plugging in the bloom filter and variant shredding support.
+ *
+ * <p>When variant columns are configured for shredding (via {@link HoodieSchema.Variant#isShredded()}),
+ * this class transforms variant records at write time to populate {@code typed_value} columns
+ * by parsing variant binary data using a {@link VariantShreddingProvider} loaded via reflection.</p>
  */
 public class HoodieAvroWriteSupport<T> extends AvroWriteSupport<T> {
 
@@ -43,14 +66,206 @@ public class HoodieAvroWriteSupport<T> extends AvroWriteSupport<T> {
   private final Map<String, String> footerMetadata = new HashMap<>();
   protected final Properties properties;
 
+  /**
+   * Whether variant write shredding is enabled via config.
+   */
+  private final boolean variantWriteShreddingEnabled;
+
+  /**
+   * The effective (possibly shredded) HoodieSchema used for writing.
+   */
+  private final HoodieSchema effectiveHoodieSchema;
+
+  /**
+   * The effective Avro schema (derived from effectiveHoodieSchema).
+   */
+  private final Schema effectiveAvroSchema;
+
+  /**
+   * Indices of top-level variant fields that need shredding transformation.
+   * Empty array if no shredding is needed.
+   */
+  private final int[] shreddedVariantFieldIndices;
+
+  /**
+   * The shredded Avro sub-schema for each variant field at the corresponding index.
+   * Indexed by position in {@link #shreddedVariantFieldIndices}.
+   */
+  private final Schema[] shreddedVariantAvroSchemas;
+
+  /**
+   * The HoodieSchema.Variant for each variant field at the corresponding index.
+   * Indexed by position in {@link #shreddedVariantFieldIndices}.
+   */
+  private final HoodieSchema.Variant[] shreddedVariantHoodieSchemas;
+
+  /**
+   * Provider for variant shredding (loaded via reflection). Null if no shredding is needed.
+   */
+  private final VariantShreddingProvider shreddingProvider;
+
   public HoodieAvroWriteSupport(MessageType schema, HoodieSchema hoodieSchema, Option<BloomFilter> bloomFilterOpt,
                                 Properties properties) {
-    super(schema, hoodieSchema.toAvroSchema(), ConvertingGenericData.INSTANCE);
+    this(schema, hoodieSchema, generateEffectiveSchema(hoodieSchema, properties), bloomFilterOpt, properties);
+  }
+
+  private HoodieAvroWriteSupport(MessageType schema, HoodieSchema hoodieSchema, HoodieSchema effectiveSchema,
+                                 Option<BloomFilter> bloomFilterOpt, Properties properties) {
+    super(schema, effectiveSchema.toAvroSchema(), ConvertingGenericData.INSTANCE);
     this.bloomFilterWriteSupportOpt = bloomFilterOpt.map(HoodieBloomFilterAvroWriteSupport::new);
     this.properties = properties;
     String vectorMeta = HoodieSchema.buildVectorColumnsMetadataValue(hoodieSchema);
     if (!vectorMeta.isEmpty()) {
       footerMetadata.put(HoodieSchema.PARQUET_VECTOR_COLUMNS_METADATA_KEY, vectorMeta);
+    }
+
+    this.effectiveHoodieSchema = effectiveSchema;
+    this.effectiveAvroSchema = effectiveSchema.toAvroSchema();
+    this.variantWriteShreddingEnabled = Boolean.parseBoolean(
+        properties.getProperty(PARQUET_VARIANT_WRITE_SHREDDING_ENABLED.key(),
+            String.valueOf(PARQUET_VARIANT_WRITE_SHREDDING_ENABLED.defaultValue())));
+
+    // Identify variant fields that need shredding
+    List<Integer> variantIndices = new ArrayList<>();
+    List<Schema> variantAvroSchemas = new ArrayList<>();
+    List<HoodieSchema.Variant> variantHoodieSchemas = new ArrayList<>();
+
+    if (variantWriteShreddingEnabled && effectiveSchema.getType() == HoodieSchemaType.RECORD) {
+      List<HoodieSchemaField> fields = effectiveSchema.getFields();
+      for (int i = 0; i < fields.size(); i++) {
+        HoodieSchemaField field = fields.get(i);
+        HoodieSchema fieldSchema = field.schema();
+        // Unwrap nullable union to get the underlying type
+        if (fieldSchema.isNullable()) {
+          fieldSchema = fieldSchema.getNonNullType();
+        }
+        if (fieldSchema.getType() == HoodieSchemaType.VARIANT) {
+          HoodieSchema.Variant variant = (HoodieSchema.Variant) fieldSchema;
+          if (variant.isShredded() && variant.getTypedValueField().isPresent()) {
+            variantIndices.add(i);
+            // Get the Avro sub-schema for this variant field from the effective schema
+            Schema fieldAvroSchema = effectiveAvroSchema.getFields().get(i).schema();
+            // Unwrap nullable union
+            if (fieldAvroSchema.getType() == Schema.Type.UNION) {
+              fieldAvroSchema = getNonNullFromUnion(fieldAvroSchema);
+            }
+            variantAvroSchemas.add(fieldAvroSchema);
+            variantHoodieSchemas.add(variant);
+          }
+        }
+      }
+    }
+
+    this.shreddedVariantFieldIndices = variantIndices.stream().mapToInt(Integer::intValue).toArray();
+    this.shreddedVariantAvroSchemas = variantAvroSchemas.toArray(new Schema[0]);
+    this.shreddedVariantHoodieSchemas = variantHoodieSchemas.toArray(new HoodieSchema.Variant[0]);
+
+    // Load shredding provider via reflection if needed
+    if (shreddedVariantFieldIndices.length > 0) {
+      String providerClass = properties.getProperty(PARQUET_VARIANT_SHREDDING_PROVIDER_CLASS.key());
+      if (providerClass != null && !providerClass.isEmpty()) {
+        this.shreddingProvider = (VariantShreddingProvider) ReflectionUtils.loadClass(providerClass);
+      } else {
+        this.shreddingProvider = null;
+      }
+    } else {
+      this.shreddingProvider = null;
+    }
+  }
+
+  /**
+   * Generates the effective schema for writing, applying variant shredding configuration.
+   *
+   * <p>When shredding is disabled, shredded variant fields are replaced with unshredded
+   * variants (removing {@code typed_value}) so that the Parquet file does not contain
+   * unused typed_value columns.</p>
+   *
+   * <p>When shredding is enabled and a forced shredding schema is configured via
+   * {@link HoodieStorageConfig#PARQUET_VARIANT_FORCE_SHREDDING_SCHEMA_FOR_TEST},
+   * all variant fields are replaced with shredded variants using the forced schema.
+   * This handles the case where the input schema is unshredded but shredding is desired.</p>
+   *
+   * <p>When shredding is enabled without a forced schema, the schema is returned as-is
+   * (already-shredded variants stay shredded, unshredded variants stay unshredded).</p>
+   *
+   * @param hoodieSchema the original HoodieSchema
+   * @param properties   writer properties containing shredding configuration
+   * @return the effective schema to use for writing
+   */
+  public static HoodieSchema generateEffectiveSchema(HoodieSchema hoodieSchema, Properties properties) {
+    boolean shreddingEnabled = Boolean.parseBoolean(
+        properties.getProperty(PARQUET_VARIANT_WRITE_SHREDDING_ENABLED.key(),
+            String.valueOf(PARQUET_VARIANT_WRITE_SHREDDING_ENABLED.defaultValue())));
+
+    if (!shreddingEnabled) {
+      // Schemas from clustering/compaction may still be shredded (read from on-disk Parquet files
+      // written with shredding enabled), so we need to strip typed_value when shredding
+      // is disabled.
+      return unshreddVariantFields(hoodieSchema);
+    }
+
+    // Check if a forced shredding schema is configured
+    String forceShreddingSchema = properties.getProperty(
+        PARQUET_VARIANT_FORCE_SHREDDING_SCHEMA_FOR_TEST.key());
+    if (forceShreddingSchema != null && !forceShreddingSchema.isEmpty()) {
+      return applyForcedShreddingSchema(hoodieSchema, forceShreddingSchema);
+    }
+
+    // When enabled without forced schema, use the schema as-is
+    // (shredded variants stay shredded, unshredded variants stay unshredded)
+    return hoodieSchema;
+  }
+
+  /**
+   * Overloaded version accepting HoodieConfig for use by factories.
+   */
+  public static HoodieSchema generateEffectiveSchema(HoodieSchema hoodieSchema, HoodieConfig config) {
+    return generateEffectiveSchema(hoodieSchema, config.getProps());
+  }
+
+  @SuppressWarnings("unchecked")
+  @Override
+  public void write(T record) {
+    if (shreddedVariantFieldIndices.length > 0 && shreddingProvider != null) {
+      IndexedRecord inputRecord = (IndexedRecord) record;
+      GenericRecord shreddedRecord = new GenericData.Record(effectiveAvroSchema);
+
+      // Copy all fields, transforming variant fields that need shredding
+      List<Schema.Field> effectiveFields = effectiveAvroSchema.getFields();
+      Schema inputSchema = inputRecord.getSchema();
+
+      for (int i = 0; i < effectiveFields.size(); i++) {
+        Schema.Field effectiveField = effectiveFields.get(i);
+        String fieldName = effectiveField.name();
+        Schema.Field inputField = inputSchema.getField(fieldName);
+        if (inputField == null) {
+          continue;
+        }
+
+        int variantIdx = findVariantIndex(i);
+        if (variantIdx >= 0) {
+          // This is a shredded variant field - transform it
+          Object fieldValue = inputRecord.get(inputField.pos());
+          if (fieldValue instanceof GenericRecord) {
+            GenericRecord variantRecord = (GenericRecord) fieldValue;
+            GenericRecord shreddedVariant = shreddingProvider.shredVariantRecord(
+                variantRecord,
+                shreddedVariantAvroSchemas[variantIdx],
+                shreddedVariantHoodieSchemas[variantIdx]);
+            shreddedRecord.put(i, shreddedVariant);
+          } else {
+            // Null or unexpected type - copy as-is
+            shreddedRecord.put(i, fieldValue);
+          }
+        } else {
+          // Non-variant field - copy as-is
+          shreddedRecord.put(i, inputRecord.get(inputField.pos()));
+        }
+      }
+
+      super.write((T) shreddedRecord);
+    } else {
+      super.write(record);
     }
   }
 
@@ -72,6 +287,220 @@ public class HoodieAvroWriteSupport<T> extends AvroWriteSupport<T> {
 
   public void addFooterMetadata(String key, String value) {
     footerMetadata.put(key, value);
+  }
+
+  /**
+   * Finds the position in {@link #shreddedVariantFieldIndices} for the given effective field index,
+   * or -1 if this field is not a variant field that needs shredding.
+   */
+  private int findVariantIndex(int effectiveFieldIndex) {
+    for (int i = 0; i < shreddedVariantFieldIndices.length; i++) {
+      if (shreddedVariantFieldIndices[i] == effectiveFieldIndex) {
+        return i;
+      }
+    }
+    return -1;
+  }
+
+  private static final Pattern DECIMAL_PATTERN = Pattern.compile(
+      "decimal\\s*\\(\\s*(\\d+)\\s*,\\s*(\\d+)\\s*\\)");
+
+  /**
+   * Applies a forced shredding schema to all variant fields in the given schema.
+   * The forced schema DDL (e.g., {@code "a int, b string"}) defines the typed_value
+   * fields that will be added to each variant column.
+   */
+  private static HoodieSchema applyForcedShreddingSchema(HoodieSchema schema, String ddl) {
+    if (schema.getType() != HoodieSchemaType.RECORD) {
+      return schema;
+    }
+
+    Map<String, HoodieSchema> shreddedFields = parseShreddingDDL(ddl);
+
+    List<HoodieSchemaField> fields = schema.getFields();
+    List<HoodieSchemaField> newFields = new ArrayList<>();
+    boolean changed = false;
+
+    for (HoodieSchemaField field : fields) {
+      HoodieSchema fieldSchema = field.schema();
+      boolean wasNullable = fieldSchema.isNullable();
+      HoodieSchema unwrapped = wasNullable ? fieldSchema.getNonNullType() : fieldSchema;
+
+      if (unwrapped.getType() == HoodieSchemaType.VARIANT) {
+        HoodieSchema.Variant shreddedVariant = HoodieSchema.createVariantShreddedObject(
+            unwrapped.getAvroSchema().getName(),
+            unwrapped.getAvroSchema().getNamespace(),
+            unwrapped.getAvroSchema().getDoc(),
+            shreddedFields);
+        HoodieSchema replacement = wasNullable
+            ? HoodieSchema.createNullable(shreddedVariant) : shreddedVariant;
+        newFields.add(HoodieSchemaUtils.createNewSchemaField(field.makeNullable().withSchema(replacement)));
+        changed = true;
+      } else {
+        newFields.add(HoodieSchemaUtils.createNewSchemaField(field));
+      }
+    }
+
+    if (!changed) {
+      return schema;
+    }
+
+    return HoodieSchema.createRecord(
+        schema.getAvroSchema().getName(),
+        schema.getAvroSchema().getNamespace(),
+        schema.getAvroSchema().getDoc(),
+        newFields);
+  }
+
+  /**
+   * Parses a DDL-style shredding schema string (e.g., {@code "a int, b string, c decimal(15,1)"})
+   * into a map of field names to their HoodieSchema types.
+   */
+  private static Map<String, HoodieSchema> parseShreddingDDL(String ddl) {
+    Map<String, HoodieSchema> fields = new LinkedHashMap<>();
+    // Split on commas, but not those inside parentheses (for decimal(p,s))
+    List<String> fieldDefs = splitRespectingParentheses(ddl);
+    for (String fieldDef : fieldDefs) {
+      String trimmed = fieldDef.trim();
+      if (trimmed.isEmpty()) {
+        continue;
+      }
+      String[] parts = trimmed.split("\\s+", 2);
+      if (parts.length != 2) {
+        throw new IllegalArgumentException(
+            "Invalid shredding DDL field definition (expected 'name type'): " + trimmed);
+      }
+      fields.put(parts[0].trim(), parseSimpleType(parts[1].trim()));
+    }
+    return fields;
+  }
+
+  /**
+   * Splits a DDL string on commas, but respects commas inside parentheses.
+   * For example: "a int, b decimal(10,2), c string" -> ["a int", "b decimal(10,2)", "c string"]
+   */
+  private static List<String> splitRespectingParentheses(String input) {
+    List<String> result = new ArrayList<>();
+    StringBuilder current = new StringBuilder();
+    int parenDepth = 0;
+
+    for (int i = 0; i < input.length(); i++) {
+      char c = input.charAt(i);
+      if (c == '(') {
+        parenDepth++;
+        current.append(c);
+      } else if (c == ')') {
+        parenDepth--;
+        current.append(c);
+      } else if (c == ',' && parenDepth == 0) {
+        // Split here - this comma is not inside parentheses
+        result.add(current.toString());
+        current = new StringBuilder();
+      } else {
+        current.append(c);
+      }
+    }
+
+    // Add the last field
+    if (current.length() > 0) {
+      result.add(current.toString());
+    }
+
+    return result;
+  }
+
+  /**
+   * Parses a simple type name into a HoodieSchema.
+   * <a href="https://github.com/apache/parquet-format/blob/4b1c72c837bec5b792b2514f0057533030fcedf8/VariantShredding.md?plain=1#L81">Scope of type support</a>
+   * Supports common types: int, long, string, double, float, boolean, binary, decimal(p,s).
+   */
+  private static HoodieSchema parseSimpleType(String type) {
+    String lower = type.toLowerCase();
+    switch (lower) {
+      case "int":
+      case "integer":
+        return HoodieSchema.create(HoodieSchemaType.INT);
+      case "long":
+      case "bigint":
+        return HoodieSchema.create(HoodieSchemaType.LONG);
+      case "string":
+        return HoodieSchema.create(HoodieSchemaType.STRING);
+      case "double":
+        return HoodieSchema.create(HoodieSchemaType.DOUBLE);
+      case "float":
+        return HoodieSchema.create(HoodieSchemaType.FLOAT);
+      case "boolean":
+        return HoodieSchema.create(HoodieSchemaType.BOOLEAN);
+      case "binary":
+        return HoodieSchema.create(HoodieSchemaType.BYTES);
+      default:
+        // TODO: Support more types that's covered in Parquet Variant shredding spec #18070
+        Matcher m = DECIMAL_PATTERN.matcher(lower);
+        if (m.matches()) {
+          return HoodieSchema.createDecimal(
+              Integer.parseInt(m.group(1)), Integer.parseInt(m.group(2)));
+        }
+        throw new IllegalArgumentException("Unsupported shredding type: " + type);
+    }
+  }
+
+  /**
+   * Strips shredding from variant fields in the schema.
+   * Replaces shredded variant fields with unshredded variants (removing typed_value).
+   */
+  private static HoodieSchema unshreddVariantFields(HoodieSchema schema) {
+    if (schema.getType() != HoodieSchemaType.RECORD) {
+      return schema;
+    }
+
+    List<HoodieSchemaField> fields = schema.getFields();
+    List<HoodieSchemaField> newFields = new ArrayList<>();
+    boolean changed = false;
+
+    for (HoodieSchemaField field : fields) {
+      HoodieSchema fieldSchema = field.schema();
+      boolean wasNullable = fieldSchema.isNullable();
+      HoodieSchema unwrapped = wasNullable ? fieldSchema.getNonNullType() : fieldSchema;
+
+      if (unwrapped.getType() == HoodieSchemaType.VARIANT) {
+        HoodieSchema.Variant variant = (HoodieSchema.Variant) unwrapped;
+        if (variant.isShredded()) {
+          // Replace with unshredded variant
+          HoodieSchema.Variant unshredded = HoodieSchema.createVariant(
+              unwrapped.getAvroSchema().getName(),
+              unwrapped.getAvroSchema().getNamespace(),
+              unwrapped.getAvroSchema().getDoc());
+          HoodieSchema replacement = wasNullable ? HoodieSchema.createNullable(unshredded) : unshredded;
+          newFields.add(field.withSchema(replacement));
+          changed = true;
+          continue;
+        }
+      }
+      // field#pos() needs to be -1 when creating a new schema
+      newFields.add(HoodieSchemaUtils.createNewSchemaField(field));
+    }
+
+    if (!changed) {
+      return schema;
+    }
+
+    return HoodieSchema.createRecord(
+        schema.getAvroSchema().getName(),
+        schema.getAvroSchema().getNamespace(),
+        schema.getAvroSchema().getDoc(),
+        newFields);
+  }
+
+  /**
+   * Extracts the non-null type from a union schema.
+   */
+  private static Schema getNonNullFromUnion(Schema unionSchema) {
+    for (Schema type : unionSchema.getTypes()) {
+      if (type.getType() != Schema.Type.NULL) {
+        return type;
+      }
+    }
+    throw new IllegalArgumentException("Union schema does not contain a non-null type: " + unionSchema);
   }
 
   private static class HoodieBloomFilterAvroWriteSupport extends HoodieBloomFilterWriteSupport<String> {

--- a/hudi-hadoop-common/src/main/java/org/apache/hudi/avro/VariantShreddingProvider.java
+++ b/hudi-hadoop-common/src/main/java/org/apache/hudi/avro/VariantShreddingProvider.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.hudi.avro;
+
+import org.apache.hudi.common.schema.HoodieSchema;
+
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericRecord;
+
+/**
+ * Interface for shredding variant values at write time.
+ * <p>
+ * Implementations parse variant binary data (value + metadata bytes) and produce
+ * a shredded {@link GenericRecord} with typed_value columns populated according
+ * to the shredding schema.
+ * <p>
+ * This interface allows the variant binary parsing logic (which may depend on
+ * engine-specific libraries like Spark's variant module) to be loaded via reflection,
+ * keeping the core write support free of engine-specific dependencies.
+ */
+public interface VariantShreddingProvider {
+
+  /**
+   * Transform an unshredded variant GenericRecord into a shredded one.
+   * <p>
+   * The input record is expected to have:
+   * <ul>
+   *   <li>{@code value}: ByteBuffer containing the variant value binary</li>
+   *   <li>{@code metadata}: ByteBuffer containing the variant metadata binary</li>
+   * </ul>
+   * <p>
+   * The output record should conform to {@code shreddedSchema} and have:
+   * <ul>
+   *   <li>{@code value}: ByteBuffer or null (null when typed_value captures the full value)</li>
+   *   <li>{@code metadata}: ByteBuffer (always present)</li>
+   *   <li>{@code typed_value}: the typed representation extracted from the variant binary,
+   *       or null if the variant type does not match the typed_value schema</li>
+   * </ul>
+   *
+   * @param unshreddedVariant GenericRecord with {value: ByteBuffer, metadata: ByteBuffer}
+   * @param shreddedSchema    target Avro schema with {value: nullable ByteBuffer, metadata: ByteBuffer, typed_value: type}
+   * @param variantSchema     HoodieSchema.Variant containing the shredding schema information
+   * @return a GenericRecord conforming to shreddedSchema with typed_value populated where possible
+   */
+  GenericRecord shredVariantRecord(
+      GenericRecord unshreddedVariant,
+      Schema shreddedSchema,
+      HoodieSchema.Variant variantSchema);
+}

--- a/hudi-hadoop-common/src/test/java/org/apache/hudi/avro/TestHoodieAvroWriteSupportVariantShredding.java
+++ b/hudi-hadoop-common/src/test/java/org/apache/hudi/avro/TestHoodieAvroWriteSupportVariantShredding.java
@@ -1,0 +1,508 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.hudi.avro;
+
+import java.lang.reflect.Method;
+import java.util.Collections;
+import org.apache.avro.LogicalType;
+import org.apache.avro.LogicalTypes;
+import org.apache.avro.LogicalTypes.Decimal;
+import org.apache.hudi.common.config.HoodieConfig;
+import org.apache.hudi.common.schema.HoodieSchema;
+import org.apache.hudi.common.schema.HoodieSchemaField;
+import org.apache.hudi.common.schema.HoodieSchemaType;
+
+import org.apache.avro.Schema;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.stream.Stream;
+
+import static org.apache.hudi.common.config.HoodieStorageConfig.PARQUET_VARIANT_FORCE_SHREDDING_SCHEMA_FOR_TEST;
+import static org.apache.hudi.common.config.HoodieStorageConfig.PARQUET_VARIANT_WRITE_SHREDDING_ENABLED;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Tests for variant shredding functionality in HoodieAvroWriteSupport.
+ */
+public class TestHoodieAvroWriteSupportVariantShredding {
+
+  /**
+   * Test parseShreddingDDL with various valid inputs.
+   */
+  @ParameterizedTest
+  @MethodSource("provideParseShreddingDDLTestCases")
+  public void testParseShreddingDDL(String ddl, Map<String, HoodieSchemaType> expectedTypes) throws Exception {
+    // Use reflection to call the private static method
+    Method method = HoodieAvroWriteSupport.class.getDeclaredMethod(
+        "parseShreddingDDL", String.class);
+    method.setAccessible(true);
+
+    @SuppressWarnings("unchecked")
+    Map<String, HoodieSchema> result = (Map<String, HoodieSchema>) method.invoke(null, ddl);
+
+    assertEquals(expectedTypes.size(), result.size(), "Number of fields should match");
+
+    for (Map.Entry<String, HoodieSchemaType> entry : expectedTypes.entrySet()) {
+      String fieldName = entry.getKey();
+      HoodieSchemaType expectedType = entry.getValue();
+
+      assertTrue(result.containsKey(fieldName), "Should contain field: " + fieldName);
+      assertEquals(expectedType, result.get(fieldName).getType(),
+          "Type for field " + fieldName + " should match");
+    }
+  }
+
+  private static Stream<Arguments> provideParseShreddingDDLTestCases() {
+    Map<String, HoodieSchemaType> case1 = new LinkedHashMap<>();
+    case1.put("a", HoodieSchemaType.INT);
+    case1.put("b", HoodieSchemaType.STRING);
+
+    Map<String, HoodieSchemaType> case2 = new LinkedHashMap<>();
+    case2.put("x", HoodieSchemaType.LONG);
+    case2.put("y", HoodieSchemaType.DOUBLE);
+    case2.put("z", HoodieSchemaType.BOOLEAN);
+
+    Map<String, HoodieSchemaType> case3 = new LinkedHashMap<>();
+    case3.put("field1", HoodieSchemaType.FLOAT);
+    case3.put("field2", HoodieSchemaType.BYTES);
+
+    Map<String, HoodieSchemaType> case4 = new LinkedHashMap<>();
+    case4.put("id", HoodieSchemaType.INT);
+
+    Map<String, HoodieSchemaType> case5 = new LinkedHashMap<>();
+    case5.put("value", HoodieSchemaType.DECIMAL);
+
+    return Stream.of(
+        Arguments.of("a int, b string", case1),
+        Arguments.of("x long, y double, z boolean", case2),
+        Arguments.of("field1 float, field2 binary", case3),
+        Arguments.of("id integer", case4),
+        Arguments.of("value decimal(10,2)", case5)
+    );
+  }
+
+  /**
+   * Test parseShreddingDDL with whitespace variations.
+   */
+  @Test
+  public void testParseShreddingDDLWithWhitespace() throws Exception {
+    Method method = HoodieAvroWriteSupport.class.getDeclaredMethod(
+        "parseShreddingDDL", String.class);
+    method.setAccessible(true);
+
+    // Extra spaces
+    @SuppressWarnings("unchecked")
+    Map<String, HoodieSchema> result1 = (Map<String, HoodieSchema>) method.invoke(null,
+        "  a    int  ,   b   string  ");
+    assertEquals(2, result1.size());
+    assertEquals(HoodieSchemaType.INT, result1.get("a").getType());
+    assertEquals(HoodieSchemaType.STRING, result1.get("b").getType());
+
+    // Tabs
+    @SuppressWarnings("unchecked")
+    Map<String, HoodieSchema> result2 = (Map<String, HoodieSchema>) method.invoke(null,
+        "a\tint,\tb\tstring");
+    assertEquals(2, result2.size());
+
+    // Mixed
+    @SuppressWarnings("unchecked")
+    Map<String, HoodieSchema> result3 = (Map<String, HoodieSchema>) method.invoke(null,
+        " a int , b   string,  c\tdouble ");
+    assertEquals(3, result3.size());
+  }
+
+  /**
+   * Test parseShreddingDDL with empty/invalid inputs.
+   */
+  @Test
+  public void testParseShreddingDDLInvalidInputs() throws Exception {
+    Method method = HoodieAvroWriteSupport.class.getDeclaredMethod(
+        "parseShreddingDDL", String.class);
+    method.setAccessible(true);
+
+    // Empty string
+    @SuppressWarnings("unchecked")
+    Map<String, HoodieSchema> result1 = (Map<String, HoodieSchema>) method.invoke(null, "");
+    assertEquals(0, result1.size());
+
+    // Only whitespace
+    @SuppressWarnings("unchecked")
+    Map<String, HoodieSchema> result2 = (Map<String, HoodieSchema>) method.invoke(null, "   ");
+    assertEquals(0, result2.size());
+
+    // Only comma
+    @SuppressWarnings("unchecked")
+    Map<String, HoodieSchema> result3 = (Map<String, HoodieSchema>) method.invoke(null, ",,,");
+    assertEquals(0, result3.size());
+
+    // Invalid format - missing type
+    assertThrows(Exception.class, () -> {
+      method.invoke(null, "a");
+    });
+
+    // Invalid format - only type
+    assertThrows(Exception.class, () -> {
+      method.invoke(null, "int");
+    });
+  }
+
+  /**
+   * Test parseShreddingDDL with decimal types containing commas.
+   * This verifies that commas inside decimal(p,s) are not treated as field separators.
+   */
+  @Test
+  public void testParseShreddingDDLWithDecimal() throws Exception {
+    Method method = HoodieAvroWriteSupport.class.getDeclaredMethod(
+        "parseShreddingDDL", String.class);
+    method.setAccessible(true);
+
+    // Test with decimal type that has comma in it
+    @SuppressWarnings("unchecked")
+    Map<String, HoodieSchema> result = (Map<String, HoodieSchema>) method.invoke(null,
+        "a int, b decimal(10,2), c string");
+
+    assertEquals(3, result.size(), "Should have 3 fields");
+    assertTrue(result.containsKey("a"));
+    assertTrue(result.containsKey("b"));
+    assertTrue(result.containsKey("c"));
+
+    assertEquals(HoodieSchemaType.INT, result.get("a").getType());
+    assertEquals(HoodieSchemaType.DECIMAL, result.get("b").getType());
+    assertEquals(HoodieSchemaType.STRING, result.get("c").getType());
+
+    // Test with multiple decimals
+    @SuppressWarnings("unchecked")
+    Map<String, HoodieSchema> result2 = (Map<String, HoodieSchema>) method.invoke(null,
+        "price decimal(15,2), quantity int, discount decimal(5,3)");
+
+    assertEquals(3, result2.size());
+    assertEquals(HoodieSchemaType.DECIMAL, result2.get("price").getType());
+    assertEquals(HoodieSchemaType.INT, result2.get("quantity").getType());
+    assertEquals(HoodieSchemaType.DECIMAL, result2.get("discount").getType());
+  }
+
+  /**
+   * Test parseSimpleType with all supported types.
+   */
+  @ParameterizedTest
+  @ValueSource(strings = {
+      "int", "INT", "integer", "INTEGER",
+      "long", "LONG", "bigint", "BIGINT",
+      "string", "STRING",
+      "double", "DOUBLE",
+      "float", "FLOAT",
+      "boolean", "BOOLEAN",
+      "binary", "BINARY"
+  })
+  public void testParseSimpleTypeBasicTypes(String typeStr) throws Exception {
+    Method method = HoodieAvroWriteSupport.class.getDeclaredMethod(
+        "parseSimpleType", String.class);
+    method.setAccessible(true);
+
+    HoodieSchema result = (HoodieSchema) method.invoke(null, typeStr);
+    assertNotNull(result);
+
+    String lower = typeStr.toLowerCase();
+    if (lower.equals("int") || lower.equals("integer")) {
+      assertEquals(HoodieSchemaType.INT, result.getType());
+    } else if (lower.equals("long") || lower.equals("bigint")) {
+      assertEquals(HoodieSchemaType.LONG, result.getType());
+    } else if (lower.equals("string")) {
+      assertEquals(HoodieSchemaType.STRING, result.getType());
+    } else if (lower.equals("double")) {
+      assertEquals(HoodieSchemaType.DOUBLE, result.getType());
+    } else if (lower.equals("float")) {
+      assertEquals(HoodieSchemaType.FLOAT, result.getType());
+    } else if (lower.equals("boolean")) {
+      assertEquals(HoodieSchemaType.BOOLEAN, result.getType());
+    } else if (lower.equals("binary")) {
+      assertEquals(HoodieSchemaType.BYTES, result.getType());
+    }
+  }
+
+  /**
+   * Test parseSimpleType with decimal types.
+   */
+  @ParameterizedTest
+  @MethodSource("provideDecimalTestCases")
+  public void testParseSimpleTypeDecimal(String typeStr, int expectedPrecision, int expectedScale)
+      throws Exception {
+    Method method = HoodieAvroWriteSupport.class.getDeclaredMethod(
+        "parseSimpleType", String.class);
+    method.setAccessible(true);
+
+    HoodieSchema result = (HoodieSchema) method.invoke(null, typeStr);
+    assertEquals(HoodieSchemaType.DECIMAL, result.getType());
+
+    // Verify precision and scale via Avro schema
+    Schema avroSchema = result.getAvroSchema();
+    LogicalType logicalType = avroSchema.getLogicalType();
+    assertInstanceOf(Decimal.class, logicalType);
+    LogicalTypes.Decimal decimal = (LogicalTypes.Decimal) logicalType;
+    assertEquals(expectedPrecision, decimal.getPrecision());
+    assertEquals(expectedScale, decimal.getScale());
+  }
+
+  private static Stream<Arguments> provideDecimalTestCases() {
+    return Stream.of(
+        Arguments.of("decimal(10,2)", 10, 2),
+        Arguments.of("decimal(38,18)", 38, 18),
+        Arguments.of("decimal(5,0)", 5, 0),
+        Arguments.of("DECIMAL(15,3)", 15, 3),
+        Arguments.of("decimal( 20 , 5 )", 20, 5)  // with spaces
+    );
+  }
+
+  /**
+   * Test parseSimpleType with unsupported types.
+   */
+  @ParameterizedTest
+  @ValueSource(strings = {"unsupported", "array", "map", "struct", "invalid"})
+  public void testParseSimpleTypeUnsupported(String typeStr) throws Exception {
+    Method method = HoodieAvroWriteSupport.class.getDeclaredMethod(
+        "parseSimpleType", String.class);
+    method.setAccessible(true);
+
+    assertThrows(Exception.class, () -> {
+      method.invoke(null, typeStr);
+    });
+  }
+
+  /**
+   * Test generateEffectiveSchema with shredding disabled.
+   */
+  @Test
+  public void testGenerateEffectiveSchemaWithShreddingDisabled() {
+    // Create a schema with a shredded variant field
+    Map<String, HoodieSchema> typedValueFields = new LinkedHashMap<>();
+    typedValueFields.put("a", HoodieSchema.create(HoodieSchemaType.INT));
+    typedValueFields.put("b", HoodieSchema.create(HoodieSchemaType.STRING));
+
+    HoodieSchema.Variant shreddedVariant = HoodieSchema.createVariantShreddedObject(
+        "myVariant", null, null, typedValueFields);
+
+    List<HoodieSchemaField> fields = new ArrayList<>();
+    fields.add(HoodieSchemaField.of("id", HoodieSchema.create(HoodieSchemaType.INT)));
+    fields.add(HoodieSchemaField.of("v", shreddedVariant));
+
+    HoodieSchema inputSchema = HoodieSchema.createRecord("TestRecord", null, null, fields);
+
+    // Configure shredding disabled
+    Properties props = new Properties();
+    props.setProperty(PARQUET_VARIANT_WRITE_SHREDDING_ENABLED.key(), "false");
+
+    HoodieSchema effectiveSchema = HoodieAvroWriteSupport.generateEffectiveSchema(inputSchema, props);
+
+    // Verify the variant field is unshredded
+    HoodieSchemaField variantField = effectiveSchema.getFields().get(1);
+    HoodieSchema variantSchema = variantField.schema();
+    assertEquals(HoodieSchemaType.VARIANT, variantSchema.getType());
+
+    HoodieSchema.Variant variant = (HoodieSchema.Variant) variantSchema;
+    assertFalse(variant.isShredded(), "Variant should be unshredded when shredding is disabled");
+  }
+
+  /**
+   * Test generateEffectiveSchema with shredding enabled and forced schema.
+   */
+  @Test
+  public void testGenerateEffectiveSchemaWithForcedShreddingSchema() {
+    // Create a schema with an unshredded variant
+    HoodieSchema.Variant unshreddedVariant = HoodieSchema.createVariant("myVariant", null, null);
+
+    List<HoodieSchemaField> fields = new ArrayList<>();
+    fields.add(HoodieSchemaField.of("id", HoodieSchema.create(HoodieSchemaType.INT)));
+    fields.add(HoodieSchemaField.of("v", unshreddedVariant));
+
+    HoodieSchema inputSchema = HoodieSchema.createRecord("TestRecord", null, null, fields);
+
+    // Configure shredding enabled with forced schema
+    Properties props = new Properties();
+    props.setProperty(PARQUET_VARIANT_WRITE_SHREDDING_ENABLED.key(), "true");
+    props.setProperty(PARQUET_VARIANT_FORCE_SHREDDING_SCHEMA_FOR_TEST.key(), "x int, y string");
+
+    HoodieSchema effectiveSchema = HoodieAvroWriteSupport.generateEffectiveSchema(inputSchema, props);
+
+    // Verify the variant field is now shredded
+    HoodieSchemaField variantField = effectiveSchema.getFields().get(1);
+    HoodieSchema variantSchema = variantField.schema();
+    assertEquals(HoodieSchemaType.VARIANT, variantSchema.getType());
+
+    HoodieSchema.Variant variant = (HoodieSchema.Variant) variantSchema;
+    assertTrue(variant.isShredded(), "Variant should be shredded with forced schema");
+    assertTrue(variant.getTypedValueField().isPresent(), "Should have typed_value field");
+  }
+
+  /**
+   * Test generateEffectiveSchema with nullable variant fields.
+   */
+  @Test
+  public void testGenerateEffectiveSchemaWithNullableVariant() {
+    HoodieSchema.Variant variant = HoodieSchema.createVariant("myVariant", null, null);
+    HoodieSchema nullableVariant = HoodieSchema.createNullable(variant);
+
+    List<HoodieSchemaField> fields = new ArrayList<>();
+    fields.add(HoodieSchemaField.of("id", HoodieSchema.create(HoodieSchemaType.INT)));
+    fields.add(HoodieSchemaField.of("v", nullableVariant));
+
+    HoodieSchema inputSchema = HoodieSchema.createRecord("TestRecord", null, null, fields);
+
+    Properties props = new Properties();
+    props.setProperty(PARQUET_VARIANT_WRITE_SHREDDING_ENABLED.key(), "true");
+    props.setProperty(PARQUET_VARIANT_FORCE_SHREDDING_SCHEMA_FOR_TEST.key(), "a int");
+
+    HoodieSchema effectiveSchema = HoodieAvroWriteSupport.generateEffectiveSchema(inputSchema, props);
+
+    HoodieSchemaField variantField = effectiveSchema.getFields().get(1);
+    HoodieSchema variantSchema = variantField.schema();
+
+    assertTrue(variantSchema.isNullable(), "Variant should remain nullable");
+
+    HoodieSchema unwrapped = variantSchema.getNonNullType();
+    assertEquals(HoodieSchemaType.VARIANT, unwrapped.getType());
+    assertTrue(((HoodieSchema.Variant) unwrapped).isShredded());
+  }
+
+  /**
+   * Test generateEffectiveSchema with multiple variant fields.
+   */
+  @Test
+  public void testGenerateEffectiveSchemaWithMultipleVariantFields() {
+    HoodieSchema.Variant v1 = HoodieSchema.createVariant("variant1", null, null);
+    HoodieSchema.Variant v2 = HoodieSchema.createVariant("variant2", null, null);
+
+    List<HoodieSchemaField> fields = new ArrayList<>();
+    fields.add(HoodieSchemaField.of("id", HoodieSchema.create(HoodieSchemaType.INT)));
+    fields.add(HoodieSchemaField.of("v1", v1));
+    fields.add(HoodieSchemaField.of("name", HoodieSchema.create(HoodieSchemaType.STRING)));
+    fields.add(HoodieSchemaField.of("v2", v2));
+
+    HoodieSchema inputSchema = HoodieSchema.createRecord("TestRecord", null, null, fields);
+
+    Properties props = new Properties();
+    props.setProperty(PARQUET_VARIANT_WRITE_SHREDDING_ENABLED.key(), "true");
+    props.setProperty(PARQUET_VARIANT_FORCE_SHREDDING_SCHEMA_FOR_TEST.key(), "field1 int, field2 string");
+
+    HoodieSchema effectiveSchema = HoodieAvroWriteSupport.generateEffectiveSchema(inputSchema, props);
+
+    // Both variant fields should be shredded
+    HoodieSchemaField v1Field = effectiveSchema.getFields().get(1);
+    HoodieSchemaField v2Field = effectiveSchema.getFields().get(3);
+
+    assertTrue(((HoodieSchema.Variant) v1Field.schema()).isShredded());
+    assertTrue(((HoodieSchema.Variant) v2Field.schema()).isShredded());
+
+    // Non-variant fields should be unchanged
+    assertEquals(HoodieSchemaType.INT, effectiveSchema.getFields().get(0).schema().getType());
+    assertEquals(HoodieSchemaType.STRING, effectiveSchema.getFields().get(2).schema().getType());
+  }
+
+  /**
+   * Test generateEffectiveSchema with HoodieConfig overload.
+   */
+  @Test
+  public void testGenerateEffectiveSchemaWithHoodieConfig() {
+    HoodieSchema.Variant variant = HoodieSchema.createVariant("myVariant", null, null);
+
+    List<HoodieSchemaField> fields = Collections.singletonList(
+        HoodieSchemaField.of("v", variant)
+    );
+
+    HoodieSchema inputSchema = HoodieSchema.createRecord("TestRecord", null, null, fields);
+
+    HoodieConfig config = new HoodieConfig();
+    config.setValue(PARQUET_VARIANT_WRITE_SHREDDING_ENABLED.key(), "true");
+    config.setValue(PARQUET_VARIANT_FORCE_SHREDDING_SCHEMA_FOR_TEST.key(), "a int");
+
+    HoodieSchema effectiveSchema = HoodieAvroWriteSupport.generateEffectiveSchema(inputSchema, config);
+
+    HoodieSchemaField variantField = effectiveSchema.getFields().get(0);
+    assertTrue(((HoodieSchema.Variant) variantField.schema()).isShredded());
+  }
+
+  /**
+   * Test that non-record schemas are returned unchanged.
+   */
+  @Test
+  public void testGenerateEffectiveSchemaWithNonRecordSchema() {
+    HoodieSchema intSchema = HoodieSchema.create(HoodieSchemaType.INT);
+
+    Properties props = new Properties();
+    props.setProperty(PARQUET_VARIANT_WRITE_SHREDDING_ENABLED.key(), "true");
+
+    HoodieSchema effectiveSchema = HoodieAvroWriteSupport.generateEffectiveSchema(intSchema, props);
+
+    assertEquals(intSchema, effectiveSchema, "Non-record schema should be returned unchanged");
+  }
+
+  /**
+   * Test schema with no variant fields is returned unchanged.
+   */
+  @Test
+  public void testGenerateEffectiveSchemaWithNoVariantFields() {
+    List<HoodieSchemaField> fields = new ArrayList<>();
+    fields.add(HoodieSchemaField.of("id", HoodieSchema.create(HoodieSchemaType.INT)));
+    fields.add(HoodieSchemaField.of("name", HoodieSchema.create(HoodieSchemaType.STRING)));
+
+    HoodieSchema inputSchema = HoodieSchema.createRecord("TestRecord", null, null, fields);
+
+    Properties props = new Properties();
+    props.setProperty(PARQUET_VARIANT_WRITE_SHREDDING_ENABLED.key(), "true");
+    props.setProperty(PARQUET_VARIANT_FORCE_SHREDDING_SCHEMA_FOR_TEST.key(), "a int");
+
+    HoodieSchema effectiveSchema = HoodieAvroWriteSupport.generateEffectiveSchema(inputSchema, props);
+
+    assertEquals(inputSchema, effectiveSchema, "Schema with no variant fields should be unchanged");
+  }
+
+  /**
+   * Test decimal parsing with various formats.
+   */
+  @ParameterizedTest
+  @ValueSource(strings = {
+      "decimal(1,0)",
+      "decimal(38,38)",
+      "decimal(10,5)",
+      "DECIMAL(20,10)",
+      "decimal( 15 , 7 )"
+  })
+  public void testDecimalParsingVariations(String decimalType) throws Exception {
+    Method method = HoodieAvroWriteSupport.class.getDeclaredMethod(
+        "parseSimpleType", String.class);
+    method.setAccessible(true);
+
+    HoodieSchema result = (HoodieSchema) method.invoke(null, decimalType);
+    assertEquals(HoodieSchemaType.DECIMAL, result.getType());
+  }
+}

--- a/hudi-hadoop-common/src/test/java/org/apache/hudi/io/storage/hadoop/TestHoodieAvroFileWriterFactoryVariantShredding.java
+++ b/hudi-hadoop-common/src/test/java/org/apache/hudi/io/storage/hadoop/TestHoodieAvroFileWriterFactoryVariantShredding.java
@@ -1,0 +1,275 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.hudi.io.storage.hadoop;
+
+import java.util.Collections;
+import org.apache.hudi.common.config.HoodieConfig;
+import org.apache.hudi.common.schema.HoodieSchema;
+import org.apache.hudi.common.schema.HoodieSchemaField;
+import org.apache.hudi.common.schema.HoodieSchemaType;
+
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.apache.hudi.common.config.HoodieStorageConfig.PARQUET_VARIANT_FORCE_SHREDDING_SCHEMA_FOR_TEST;
+import static org.apache.hudi.common.config.HoodieStorageConfig.PARQUET_VARIANT_WRITE_SHREDDING_ENABLED;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Tests for variant shredding provider auto-detection in HoodieAvroFileWriterFactory.
+ */
+public class TestHoodieAvroFileWriterFactoryVariantShredding {
+
+  /**
+   * Test that the detectShreddingProvider method can detect a provider when it exists on the classpath.
+   * This test uses reflection to call the private static method.
+   */
+  @Test
+  public void testDetectShreddingProvider() throws Exception {
+    Method detectMethod = HoodieAvroFileWriterFactory.class.getDeclaredMethod("detectShreddingProvider");
+    detectMethod.setAccessible(true);
+
+    String detected = (String) detectMethod.invoke(null);
+
+    // The result depends on whether the Spark4VariantShreddingProvider is on the classpath
+    // In a test environment without Spark 4, this will be null
+    // In a Spark 4 environment, it should detect org.apache.hudi.variant.Spark4VariantShreddingProvider
+    if (detected != null) {
+      assertTrue(detected.contains("VariantShreddingProvider"),
+          "Detected class should be a VariantShreddingProvider");
+    }
+    // If null, that's also valid - no provider found on classpath
+  }
+
+  /**
+   * Test that detectShreddingProvider returns null when no provider is available.
+   * This is verified by the fact that it doesn't throw an exception.
+   */
+  @Test
+  public void testDetectShreddingProviderNoProviderAvailable() throws Exception {
+    Method detectMethod = HoodieAvroFileWriterFactory.class.getDeclaredMethod("detectShreddingProvider");
+    detectMethod.setAccessible(true);
+
+    // This should not throw an exception even if no provider is found
+    String detected = (String) detectMethod.invoke(null);
+
+    // detected can be null or a valid provider class name
+    // Both are valid outcomes depending on the test environment
+  }
+
+  /**
+   * Test effective schema generation with various configurations.
+   */
+  @Test
+  public void testEffectiveSchemaGenerationIntegration() {
+    // Create a schema with a variant field
+    HoodieSchema.Variant variant = HoodieSchema.createVariant("testVariant", null, null);
+
+    List<HoodieSchemaField> fields = new ArrayList<>();
+    fields.add(HoodieSchemaField.of("id", HoodieSchema.create(HoodieSchemaType.INT)));
+    fields.add(HoodieSchemaField.of("v", variant));
+
+    HoodieSchema inputSchema = HoodieSchema.createRecord("TestRecord", null, null, fields);
+
+    // Test 1: Shredding disabled
+    HoodieConfig config1 = new HoodieConfig();
+    config1.setValue(PARQUET_VARIANT_WRITE_SHREDDING_ENABLED.key(), "false");
+
+    HoodieSchema effective1 = org.apache.hudi.avro.HoodieAvroWriteSupport.generateEffectiveSchema(
+        inputSchema, config1);
+    assertNotNull(effective1);
+
+    // Test 2: Shredding enabled with forced schema
+    HoodieConfig config2 = new HoodieConfig();
+    config2.setValue(PARQUET_VARIANT_WRITE_SHREDDING_ENABLED.key(), "true");
+    config2.setValue(PARQUET_VARIANT_FORCE_SHREDDING_SCHEMA_FOR_TEST.key(), "a int, b string");
+
+    HoodieSchema effective2 = org.apache.hudi.avro.HoodieAvroWriteSupport.generateEffectiveSchema(
+        inputSchema, config2);
+    assertNotNull(effective2);
+
+    HoodieSchemaField variantField = effective2.getFields().get(1);
+    HoodieSchema.Variant resultVariant = (HoodieSchema.Variant) variantField.schema();
+    assertTrue(resultVariant.isShredded(), "Variant should be shredded with forced schema");
+  }
+
+  /**
+   * Test schema generation with multiple variant fields.
+   */
+  @Test
+  public void testEffectiveSchemaWithMultipleVariants() {
+    HoodieSchema.Variant v1 = HoodieSchema.createVariant("variant1", null, null);
+    HoodieSchema.Variant v2 = HoodieSchema.createVariant("variant2", null, null);
+
+    List<HoodieSchemaField> fields = new ArrayList<>();
+    fields.add(HoodieSchemaField.of("id", HoodieSchema.create(HoodieSchemaType.INT)));
+    fields.add(HoodieSchemaField.of("v1", v1));
+    fields.add(HoodieSchemaField.of("v2", v2));
+
+    HoodieSchema inputSchema = HoodieSchema.createRecord("TestRecord", null, null, fields);
+
+    HoodieConfig config = new HoodieConfig();
+    config.setValue(PARQUET_VARIANT_WRITE_SHREDDING_ENABLED.key(), "true");
+    config.setValue(PARQUET_VARIANT_FORCE_SHREDDING_SCHEMA_FOR_TEST.key(), "x int, y string");
+
+    HoodieSchema effectiveSchema = org.apache.hudi.avro.HoodieAvroWriteSupport.generateEffectiveSchema(
+        inputSchema, config);
+
+    assertNotNull(effectiveSchema);
+    // Both variant fields should be transformed
+    HoodieSchemaField v1Field = effectiveSchema.getFields().get(1);
+    HoodieSchemaField v2Field = effectiveSchema.getFields().get(2);
+
+    assertTrue(((HoodieSchema.Variant) v1Field.schema()).isShredded());
+    assertTrue(((HoodieSchema.Variant) v2Field.schema()).isShredded());
+  }
+
+  /**
+   * Test schema generation with nullable variant fields.
+   */
+  @Test
+  public void testEffectiveSchemaWithNullableVariants() {
+    HoodieSchema.Variant variant = HoodieSchema.createVariant("testVariant", null, null);
+    HoodieSchema nullableVariant = HoodieSchema.createNullable(variant);
+
+    List<HoodieSchemaField> fields = new ArrayList<>();
+    fields.add(HoodieSchemaField.of("v", nullableVariant));
+
+    HoodieSchema inputSchema = HoodieSchema.createRecord("TestRecord", null, null, fields);
+
+    HoodieConfig config = new HoodieConfig();
+    config.setValue(PARQUET_VARIANT_WRITE_SHREDDING_ENABLED.key(), "true");
+    config.setValue(PARQUET_VARIANT_FORCE_SHREDDING_SCHEMA_FOR_TEST.key(), "a int");
+
+    HoodieSchema effectiveSchema = org.apache.hudi.avro.HoodieAvroWriteSupport.generateEffectiveSchema(
+        inputSchema, config);
+
+    HoodieSchemaField variantField = effectiveSchema.getFields().get(0);
+    assertTrue(variantField.schema().isNullable(), "Variant should remain nullable");
+
+    HoodieSchema unwrapped = variantField.schema().getNonNullType();
+    assertTrue(((HoodieSchema.Variant) unwrapped).isShredded());
+  }
+
+  /**
+   * Test that effective schema generation handles already-shredded variants correctly.
+   */
+  @Test
+  public void testEffectiveSchemaWithAlreadyShreddedVariant() {
+    // Create a variant that's already shredded
+    Map<String, HoodieSchema> typedFields = new LinkedHashMap<>();
+    typedFields.put("a", HoodieSchema.create(HoodieSchemaType.INT));
+    typedFields.put("b", HoodieSchema.create(HoodieSchemaType.STRING));
+
+    HoodieSchema.Variant shreddedVariant = HoodieSchema.createVariantShreddedObject(
+        "testVariant", null, null, typedFields);
+
+    List<HoodieSchemaField> fields = Collections.singletonList(
+        HoodieSchemaField.of("v", shreddedVariant));
+
+    HoodieSchema inputSchema = HoodieSchema.createRecord("TestRecord", null, null, fields);
+
+    // Shredding enabled but no forced schema
+    HoodieConfig config = new HoodieConfig();
+    config.setValue(PARQUET_VARIANT_WRITE_SHREDDING_ENABLED.key(), "true");
+
+    HoodieSchema effectiveSchema = org.apache.hudi.avro.HoodieAvroWriteSupport.generateEffectiveSchema(
+        inputSchema, config);
+
+    // The already-shredded variant should remain shredded
+    HoodieSchemaField variantField = effectiveSchema.getFields().get(0);
+    HoodieSchema.Variant resultVariant = (HoodieSchema.Variant) variantField.schema();
+    assertTrue(resultVariant.isShredded());
+  }
+
+  /**
+   * Test unshredding when shredding is disabled.
+   */
+  @Test
+  public void testEffectiveSchemaUnshreddingWhenDisabled() {
+    // Create a shredded variant
+    Map<String, HoodieSchema> typedFields = new LinkedHashMap<>();
+    typedFields.put("a", HoodieSchema.create(HoodieSchemaType.INT));
+
+    HoodieSchema.Variant shreddedVariant = HoodieSchema.createVariantShreddedObject(
+        "testVariant", null, null, typedFields);
+
+    List<HoodieSchemaField> fields = Collections.singletonList(
+        HoodieSchemaField.of("v", shreddedVariant)
+    );
+
+    HoodieSchema inputSchema = HoodieSchema.createRecord("TestRecord", null, null, fields);
+
+    // Shredding disabled - should unshred
+    HoodieConfig config = new HoodieConfig();
+    config.setValue(PARQUET_VARIANT_WRITE_SHREDDING_ENABLED.key(), "false");
+
+    HoodieSchema effectiveSchema = org.apache.hudi.avro.HoodieAvroWriteSupport.generateEffectiveSchema(
+        inputSchema, config);
+
+    HoodieSchemaField variantField = effectiveSchema.getFields().get(0);
+    HoodieSchema.Variant resultVariant = (HoodieSchema.Variant) variantField.schema();
+    // Should be unshredded now
+    assertTrue(!resultVariant.isShredded() || !resultVariant.getTypedValueField().isPresent(),
+        "Variant should be unshredded when shredding is disabled");
+  }
+
+  /**
+   * Test that non-variant fields are preserved during schema transformation.
+   */
+  @Test
+  public void testEffectiveSchemaPreservesNonVariantFields() {
+    HoodieSchema.Variant variant = HoodieSchema.createVariant("testVariant", null, null);
+
+    List<HoodieSchemaField> fields = new ArrayList<>();
+    fields.add(HoodieSchemaField.of("id", HoodieSchema.create(HoodieSchemaType.INT)));
+    fields.add(HoodieSchemaField.of("name", HoodieSchema.create(HoodieSchemaType.STRING)));
+    fields.add(HoodieSchemaField.of("v", variant));
+    fields.add(HoodieSchemaField.of("timestamp", HoodieSchema.create(HoodieSchemaType.LONG)));
+
+    HoodieSchema inputSchema = HoodieSchema.createRecord("TestRecord", null, null, fields);
+
+    HoodieConfig config = new HoodieConfig();
+    config.setValue(PARQUET_VARIANT_WRITE_SHREDDING_ENABLED.key(), "true");
+    config.setValue(PARQUET_VARIANT_FORCE_SHREDDING_SCHEMA_FOR_TEST.key(), "a int");
+
+    HoodieSchema effectiveSchema = org.apache.hudi.avro.HoodieAvroWriteSupport.generateEffectiveSchema(
+        inputSchema, config);
+
+    // Verify all non-variant fields are preserved
+    List<HoodieSchemaField> resultFields = effectiveSchema.getFields();
+    assertNotNull(resultFields.get(0).schema()); // id
+    assertNotNull(resultFields.get(1).schema()); // name
+    assertNotNull(resultFields.get(2).schema()); // v (variant, should be shredded)
+    assertNotNull(resultFields.get(3).schema()); // timestamp
+
+    // Non-variant field types should be unchanged
+    assertSame(HoodieSchemaType.INT, resultFields.get(0).schema().getType());
+    assertSame(HoodieSchemaType.STRING, resultFields.get(1).schema().getType());
+    assertSame(HoodieSchemaType.LONG, resultFields.get(3).schema().getType());
+  }
+}

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieHadoopFsRelationFactory.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/hudi/HoodieHadoopFsRelationFactory.scala
@@ -62,6 +62,18 @@ abstract class HoodieBaseHadoopFsRelationFactory(val sqlContext: SQLContext,
                                                  val schemaSpec: Option[StructType],
                                                  val isBootstrap: Boolean
                                                 ) extends SparkAdapterSupport with HoodieHadoopFsRelationFactory with Logging {
+  // Propagate Hudi's variant allow-reading-shredded config to Spark's SQLConf.
+  // ParquetToSparkSchemaConverter reads this from SQLConf.get(), so it must be set
+  // before query execution starts here during table resolution
+  if (HoodieSparkUtils.gteqSpark4_0) {
+    val sqlConf = sqlContext.sparkSession.sessionState.conf
+    val hoodieParquetAllowReadingShreddedConfKey = "hoodie.parquet.variant.allow.reading.shredded"
+    val allowReadingShredded = options.getOrElse(
+      hoodieParquetAllowReadingShreddedConfKey,
+      sqlConf.getConfString(hoodieParquetAllowReadingShreddedConfKey, "true"))
+    sqlConf.setConfString("spark.sql.variant.allowReadingShredded", allowReadingShredded)
+  }
+
   protected lazy val sparkSession: SparkSession = sqlContext.sparkSession
   protected lazy val optParams: Map[String, String] = options
 

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/dml/schema/TestVariantDataType.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/spark/sql/hudi/dml/schema/TestVariantDataType.scala
@@ -24,6 +24,10 @@ import org.apache.hudi.common.testutils.HoodieTestUtils
 import org.apache.hudi.common.util.StringUtils
 import org.apache.hudi.internal.schema.HoodieSchemaException
 
+import org.apache.hadoop.fs.{FileSystem, Path => HadoopPath}
+import org.apache.parquet.hadoop.ParquetFileReader
+import org.apache.parquet.hadoop.util.HadoopInputFile
+import org.apache.parquet.schema.{GroupType, MessageType, Type}
 import org.apache.spark.sql.hudi.common.HoodieSparkSqlTestBase
 
 
@@ -188,5 +192,407 @@ class TestVariantDataType extends HoodieSparkSqlTestBase {
     assert(spark.sql(s"select * from $tableName").count() == 1, "Should be able to read all columns including variant")
 
     spark.sql(s"drop table $tableName")
+  }
+
+  test("Test Shredded Variant with Multiple Variant Columns") {
+    assume(HoodieSparkUtils.gteqSpark4_0, "Variant type requires Spark 4.0 or higher")
+
+    withRecordType()(withTempDir { tmp =>
+      val tableName = generateTableName
+      spark.sql(
+        s"""
+           |create table $tableName (
+           |  id int,
+           |  v1 variant,
+           |  v2 variant,
+           |  ts long
+           |) using hudi
+           | location '${tmp.getCanonicalPath}'
+           | tblproperties (
+           |  primaryKey = 'id',
+           |  type = 'cow',
+           |  preCombineField = 'ts'
+           | )
+        """.stripMargin)
+
+      spark.sql("set hoodie.parquet.variant.write.shredding.enabled = true")
+      spark.sql("set hoodie.parquet.variant.allow.reading.shredded = true")
+      spark.sql("set hoodie.parquet.variant.force.shredding.schema.for.test = a int, b string")
+
+      spark.sql(
+        s"""
+           |insert into $tableName values
+           |  (1, parse_json('{"a": 10, "b": "first"}'), parse_json('{"a": 20, "b": "second"}'), 1000),
+           |  (2, parse_json('{"a": 30, "b": "third"}'), parse_json('{"a": 40, "b": "fourth"}'), 2000)
+        """.stripMargin)
+
+      checkAnswer(s"select id, cast(v1 as string), cast(v2 as string) from $tableName order by id")(
+        Seq(1, "{\"a\":10,\"b\":\"first\"}", "{\"a\":20,\"b\":\"second\"}"),
+        Seq(2, "{\"a\":30,\"b\":\"third\"}", "{\"a\":40,\"b\":\"fourth\"}")
+      )
+    })
+  }
+
+  test("Test Variant Shredding with Update Operation") {
+    assume(HoodieSparkUtils.gteqSpark4_0, "Variant type requires Spark 4.0 or higher")
+
+    withRecordType()(withTempDir { tmp =>
+      val tableName = generateTableName
+      spark.sql(
+        s"""
+           |create table $tableName (
+           |  id int,
+           |  v variant,
+           |  ts long
+           |) using hudi
+           | location '${tmp.getCanonicalPath}'
+           | tblproperties (
+           |  primaryKey = 'id',
+           |  type = 'cow',
+           |  preCombineField = 'ts'
+           | )
+        """.stripMargin)
+
+      spark.sql("set hoodie.parquet.variant.write.shredding.enabled = true")
+      spark.sql("set hoodie.parquet.variant.allow.reading.shredded = true")
+      spark.sql("set hoodie.parquet.variant.force.shredding.schema.for.test = a int, b string")
+
+      // Initial insert
+      spark.sql(
+        s"""
+           |insert into $tableName values
+           |  (1, parse_json('{"a": 1, "b": "initial"}'), 1000)
+        """.stripMargin)
+
+      // Update the variant value
+      spark.sql(
+        s"""
+           |update $tableName set v = parse_json('{"a": 999, "b": "updated"}'), ts = 2000 where id = 1
+        """.stripMargin)
+
+      checkAnswer(s"select id, cast(v as string), ts from $tableName")(
+        Seq(1, "{\"a\":999,\"b\":\"updated\"}", 2000)
+      )
+
+      // Verify parquet schema has shredded structure with typed_value
+      val parquetFiles = listDataParquetFiles(tmp.getCanonicalPath)
+      assert(parquetFiles.nonEmpty, "Should have at least one data parquet file")
+
+      parquetFiles.foreach { filePath =>
+        val schema = readParquetSchema(filePath)
+        val variantGroup = getFieldAsGroup(schema, "v")
+        assert(groupContainsField(variantGroup, "typed_value"),
+          s"Shredded variant should have typed_value field. Schema:\n$variantGroup")
+        val valueField = variantGroup.getType(variantGroup.getFieldIndex("value"))
+        assert(valueField.getRepetition == Type.Repetition.OPTIONAL,
+          "Shredded variant value field should be OPTIONAL")
+        val metadataField = variantGroup.getType(variantGroup.getFieldIndex("metadata"))
+        assert(metadataField.getRepetition == Type.Repetition.REQUIRED,
+          "Shredded variant metadata field should be REQUIRED")
+      }
+    })
+  }
+
+  test("Test Variant Shredding with Merge Operation") {
+    assume(HoodieSparkUtils.gteqSpark4_0, "Variant type requires Spark 4.0 or higher")
+
+    withRecordType()(withTempDir { tmp =>
+      val tableName = generateTableName
+      spark.sql(
+        s"""
+           |create table $tableName (
+           |  id int,
+           |  v variant,
+           |  ts long
+           |) using hudi
+           | location '${tmp.getCanonicalPath}'
+           | tblproperties (
+           |  primaryKey = 'id',
+           |  type = 'cow',
+           |  preCombineField = 'ts'
+           | )
+        """.stripMargin)
+
+      spark.sql("set hoodie.parquet.variant.write.shredding.enabled = true")
+      spark.sql("set hoodie.parquet.variant.allow.reading.shredded = true")
+      spark.sql("set hoodie.parquet.variant.force.shredding.schema.for.test = a int, b string")
+
+      // Initial data
+      spark.sql(
+        s"""
+           |insert into $tableName values
+           |  (1, parse_json('{"a": 1, "b": "first"}'), 1000)
+        """.stripMargin)
+
+      // Merge in updates and inserts
+      spark.sql(
+        s"""
+           |merge into $tableName as target
+           |using (
+           |  select 1 as id, parse_json('{"a": 100, "b": "merged"}') as v, 2000L as ts
+           |  union all
+           |  select 2 as id, parse_json('{"a": 200, "b": "new"}') as v, 3000L as ts
+           |) as source
+           |on target.id = source.id
+           |when matched then update set target.v = source.v, target.ts = source.ts
+           |when not matched then insert *
+        """.stripMargin)
+
+      checkAnswer(s"select id, cast(v as string) from $tableName order by id")(
+        Seq(1, "{\"a\":100,\"b\":\"merged\"}"),
+        Seq(2, "{\"a\":200,\"b\":\"new\"}")
+      )
+    })
+  }
+
+  test("Test Variant Shredding with Null Values") {
+    assume(HoodieSparkUtils.gteqSpark4_0, "Variant type requires Spark 4.0 or higher")
+
+    withRecordType()(withTempDir { tmp =>
+      val tableName = generateTableName
+      spark.sql(
+        s"""
+           |create table $tableName (
+           |  id int,
+           |  v variant,
+           |  ts long
+           |) using hudi
+           | location '${tmp.getCanonicalPath}'
+           | tblproperties (
+           |  primaryKey = 'id',
+           |  type = 'cow',
+           |  preCombineField = 'ts'
+           | )
+        """.stripMargin)
+
+      spark.sql("set hoodie.parquet.variant.write.shredding.enabled = true")
+      spark.sql("set hoodie.parquet.variant.allow.reading.shredded = true")
+      spark.sql("set hoodie.parquet.variant.force.shredding.schema.for.test = a int, b string")
+
+      spark.sql(
+        s"""
+           |insert into $tableName values
+           |  (1, parse_json('{"a": null, "b": "test"}'), 1000),
+           |  (2, null, 2000)
+        """.stripMargin)
+
+      val result = spark.sql(s"select id, v from $tableName order by id").collect()
+      assert(result.length == 2)
+      assert(!result(0).isNullAt(1), "First row should have non-null variant")
+      assert(result(1).isNullAt(1), "Second row should have null variant")
+    })
+  }
+
+  test("Test Variant with Different Numeric Types") {
+    assume(HoodieSparkUtils.gteqSpark4_0, "Variant type requires Spark 4.0 or higher")
+
+    withRecordType()(withTempDir { tmp =>
+      val tableName = generateTableName
+      spark.sql(
+        s"""
+           |create table $tableName (
+           |  id int,
+           |  v variant,
+           |  ts long
+           |) using hudi
+           | location '${tmp.getCanonicalPath}'
+           | tblproperties (
+           |  primaryKey = 'id',
+           |  type = 'cow',
+           |  preCombineField = 'ts'
+           | )
+        """.stripMargin)
+
+      spark.sql("set hoodie.parquet.variant.write.shredding.enabled = true")
+      spark.sql("set hoodie.parquet.variant.allow.reading.shredded = true")
+      spark.sql("set hoodie.parquet.variant.force.shredding.schema.for.test = price decimal(10,2), quantity long, rating double")
+
+      spark.sql(
+        s"""
+           |insert into $tableName values
+           |  (1, parse_json('{"price": 99.99, "quantity": 5, "rating": 4.5}'), 1000)
+        """.stripMargin)
+
+      checkAnswer(s"select id from $tableName")(
+        Seq(1)
+      )
+    })
+  }
+
+  test("Test Variant Shredding Toggle") {
+    assume(HoodieSparkUtils.gteqSpark4_0, "Variant type requires Spark 4.0 or higher")
+
+    withRecordType()(withTempDir { tmp =>
+      val tableName = generateTableName
+      spark.sql(
+        s"""
+           |create table $tableName (
+           |  id int,
+           |  v variant,
+           |  ts long
+           |) using hudi
+           | location '${tmp.getCanonicalPath}'
+           | tblproperties (
+           |  primaryKey = 'id',
+           |  type = 'cow',
+           |  preCombineField = 'ts'
+           | )
+        """.stripMargin)
+
+      // First write: shredding disabled
+      spark.sql("set hoodie.parquet.variant.write.shredding.enabled = false")
+
+      spark.sql(
+        s"""
+           |insert into $tableName values
+           |  (1, parse_json('{"a": 1, "b": "hello"}'), 1000)
+        """.stripMargin)
+
+      // Second write: shredding enabled
+      spark.sql("set hoodie.parquet.variant.write.shredding.enabled = true")
+      spark.sql("set hoodie.parquet.variant.force.shredding.schema.for.test = a int, b string")
+
+      spark.sql(
+        s"""
+           |insert into $tableName values
+           |  (2, parse_json('{"a": 2, "b": "world"}'), 2000)
+        """.stripMargin)
+
+      // Both records should be readable
+      checkAnswer(s"select id, cast(v as string) from $tableName order by id")(
+        Seq(1, "{\"a\":1,\"b\":\"hello\"}"),
+        Seq(2, "{\"a\":2,\"b\":\"world\"}")
+      )
+    })
+  }
+
+  test("Test Variant Shredding with Complex Field Names") {
+    assume(HoodieSparkUtils.gteqSpark4_0, "Variant type requires Spark 4.0 or higher")
+
+    withRecordType()(withTempDir { tmp =>
+      val tableName = generateTableName
+      spark.sql(
+        s"""
+           |create table $tableName (
+           |  id int,
+           |  v variant,
+           |  ts long
+           |) using hudi
+           | location '${tmp.getCanonicalPath}'
+           | tblproperties (
+           |  primaryKey = 'id',
+           |  type = 'cow',
+           |  preCombineField = 'ts'
+           | )
+        """.stripMargin)
+
+      spark.sql("set hoodie.parquet.variant.write.shredding.enabled = true")
+      spark.sql("set hoodie.parquet.variant.allow.reading.shredded = true")
+      spark.sql("set hoodie.parquet.variant.force.shredding.schema.for.test = field1 int, field2 string, field3 boolean")
+
+      spark.sql(
+        s"""
+           |insert into $tableName values
+           |  (1, parse_json('{"field1": 100, "field2": "value", "field3": true, "extra": "ignored"}'), 1000)
+        """.stripMargin)
+
+      val result = spark.sql(s"select cast(v as string) from $tableName").collect()
+      assert(result.length == 1)
+      // Verify the JSON contains all expected fields
+      val json = result(0).getString(0)
+      assert(json.contains("field1"))
+      assert(json.contains("field2"))
+      assert(json.contains("field3"))
+    })
+  }
+
+  test("Test Variant with Empty Object") {
+    assume(HoodieSparkUtils.gteqSpark4_0, "Variant type requires Spark 4.0 or higher")
+
+    withRecordType()(withTempDir { tmp =>
+      val tableName = generateTableName
+      spark.sql(
+        s"""
+           |create table $tableName (
+           |  id int,
+           |  v variant,
+           |  ts long
+           |) using hudi
+           | location '${tmp.getCanonicalPath}'
+           | tblproperties (
+           |  primaryKey = 'id',
+           |  type = 'cow',
+           |  preCombineField = 'ts'
+           | )
+        """.stripMargin)
+
+      spark.sql("set hoodie.parquet.variant.write.shredding.enabled = true")
+      spark.sql("set hoodie.parquet.variant.allow.reading.shredded = true")
+      spark.sql("set hoodie.parquet.variant.force.shredding.schema.for.test = a int")
+
+      spark.sql(
+        s"""
+           |insert into $tableName values
+           |  (1, parse_json('{}'), 1000)
+        """.stripMargin)
+
+      checkAnswer(s"select id, cast(v as string) from $tableName")(
+        Seq(1, "{}")
+      )
+    })
+  }
+
+  /**
+   * Lists data parquet files in the table directory, excluding Hudi metadata files.
+   */
+  private def listDataParquetFiles(tablePath: String): Seq[String] = {
+    val conf = spark.sparkContext.hadoopConfiguration
+    val fs = FileSystem.get(new HadoopPath(tablePath).toUri, conf)
+    val iter = fs.listFiles(new HadoopPath(tablePath), true)
+    val files = scala.collection.mutable.ArrayBuffer[String]()
+    while (iter.hasNext) {
+      val file = iter.next()
+      val path = file.getPath.toString
+      if (path.endsWith(".parquet") && !path.contains(".hoodie")) {
+        files += path
+      }
+    }
+    files.toSeq
+  }
+
+  /**
+   * Reads the Parquet schema (MessageType) from a parquet file.
+   */
+  private def readParquetSchema(filePath: String): MessageType = {
+    val conf = spark.sparkContext.hadoopConfiguration
+    val inputFile = HadoopInputFile.fromPath(new HadoopPath(filePath), conf)
+    val reader = ParquetFileReader.open(inputFile)
+    try {
+      reader.getFooter.getFileMetaData.getSchema
+    } finally {
+      reader.close()
+    }
+  }
+
+  /**
+   * Gets a named field from a GroupType (MessageType) and returns it as a GroupType.
+   * Uses getFieldIndex(String) + getType(int) to avoid Scala overload resolution issues.
+   */
+  private def getFieldAsGroup(parent: GroupType, fieldName: String): GroupType = {
+    val idx: Int = parent.getFieldIndex(fieldName)
+    parent.getType(idx).asGroupType()
+  }
+
+  /**
+   * Checks whether a GroupType contains a field with the given name.
+   * Uses try/catch on getFieldIndex to avoid Scala-Java collection converter dependencies.
+   */
+  private def groupContainsField(group: GroupType, fieldName: String): Boolean = {
+    try {
+      group.getFieldIndex(fieldName)
+      true
+    } catch {
+      case _: Exception => false
+    }
   }
 }

--- a/hudi-spark-datasource/hudi-spark3-common/src/main/scala/org/apache/spark/sql/adapter/BaseSpark3Adapter.scala
+++ b/hudi-spark-datasource/hudi-spark3-common/src/main/scala/org/apache/spark/sql/adapter/BaseSpark3Adapter.scala
@@ -226,4 +226,12 @@ abstract class BaseSpark3Adapter extends SparkAdapter with Logging {
   ): BiConsumer[SpecializedGetters, Integer] = {
     throw new UnsupportedOperationException("Spark 3.x does not support Variant shredding")
   }
+
+  override def convertVariantToStruct(variantValue: Any, structType: StructType): InternalRow = {
+    throw new UnsupportedOperationException("Spark 3.x does not support VariantType")
+  }
+
+  override def convertStructToVariant(structRow: InternalRow, structType: StructType): Any = {
+    throw new UnsupportedOperationException("Spark 3.x does not support VariantType")
+  }
 }

--- a/hudi-spark-datasource/hudi-spark4-common/src/main/java/org/apache/hudi/variant/Spark4VariantShreddingProvider.java
+++ b/hudi-spark-datasource/hudi-spark4-common/src/main/java/org/apache/hudi/variant/Spark4VariantShreddingProvider.java
@@ -1,0 +1,405 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.hudi.variant;
+
+import org.apache.hudi.avro.VariantShreddingProvider;
+import org.apache.hudi.common.schema.HoodieSchema;
+
+import org.apache.avro.LogicalType;
+import org.apache.avro.LogicalTypes;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericData;
+import org.apache.avro.generic.GenericRecord;
+import org.apache.spark.types.variant.Variant;
+import org.apache.spark.types.variant.VariantSchema;
+import org.apache.spark.types.variant.VariantShreddingWriter;
+import org.apache.spark.types.variant.VariantShreddingWriter.ShreddedResult;
+import org.apache.spark.types.variant.VariantShreddingWriter.ShreddedResultBuilder;
+
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.IdentityHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+/**
+ * Implementation of {@link VariantShreddingProvider} using Spark 4's variant parsing library.
+ *
+ * <p>This class bridges the Avro record path and Spark's {@link VariantShreddingWriter}
+ * to allow {@code HoodieRecordType.AVRO} to write shredded variant types. It converts
+ * the shredded output into Avro {@link GenericRecord}s that can be written via
+ * {@link org.apache.hudi.avro.HoodieAvroWriteSupport}.</p>
+ *
+ * <p>The shredding logic is delegated to {@link VariantShreddingWriter#castShredded},
+ * which handles scalar, object, and array shredding including residual value construction
+ * for non-matching fields. This class implements the {@link ShreddedResult} and
+ * {@link ShreddedResultBuilder} interfaces to collect the shredded components into
+ * Avro GenericRecords.</p>
+ */
+public class Spark4VariantShreddingProvider implements VariantShreddingProvider {
+
+  private static final String VALUE_FIELD = "value";
+  private static final String METADATA_FIELD = "metadata";
+  private static final String TYPED_VALUE_FIELD = "typed_value";
+
+  @Override
+  public GenericRecord shredVariantRecord(
+      GenericRecord unshreddedVariant,
+      Schema shreddedSchema,
+      HoodieSchema.Variant variantSchema) {
+
+    ByteBuffer valueBuf = (ByteBuffer) unshreddedVariant.get(VALUE_FIELD);
+    ByteBuffer metadataBuf = (ByteBuffer) unshreddedVariant.get(METADATA_FIELD);
+
+    if (valueBuf == null || metadataBuf == null) {
+      return null;
+    }
+
+    byte[] valueBytes = toByteArray(valueBuf);
+    byte[] metadataBytes = toByteArray(metadataBuf);
+
+    Variant variant = new Variant(valueBytes, metadataBytes);
+
+    // Build VariantSchema from the Avro shredded schema, registering
+    // Avro schemas at each level for GenericRecord construction.
+    AvroShreddedResultBuilder builder = new AvroShreddedResultBuilder();
+    VariantSchema sparkSchema = buildVariantSchema(shreddedSchema, true, builder);
+
+    // Delegate to Spark's VariantShreddingWriter for the actual shredding logic.
+    AvroShreddedResult result = (AvroShreddedResult)
+        VariantShreddingWriter.castShredded(variant, sparkSchema, builder);
+
+    return result.toGenericRecord();
+  }
+
+  /**
+   * Builds a {@link VariantSchema} from an Avro {@link Schema} representing a
+   * shredded variant structure ({@code value}, {@code metadata}, {@code typed_value}).
+   *
+   * <p>This method also registers the Avro schema mapping in the builder so that
+   * {@link AvroShreddedResultBuilder#createEmpty} can create results with the
+   * correct Avro schema at each nesting level.</p>
+   */
+  private VariantSchema buildVariantSchema(Schema avroSchema, boolean isTopLevel,
+                                           AvroShreddedResultBuilder builder) {
+    Schema.Field valueField = avroSchema.getField(VALUE_FIELD);
+    Schema.Field metadataField = avroSchema.getField(METADATA_FIELD);
+    Schema.Field typedValueField = avroSchema.getField(TYPED_VALUE_FIELD);
+
+    int idx = 0;
+    int variantIdx = valueField != null ? idx++ : -1;
+    int topLevelMetadataIdx;
+    if (metadataField != null && isTopLevel) {
+      topLevelMetadataIdx = idx++;
+    } else {
+      topLevelMetadataIdx = -1;
+      if (metadataField != null) {
+        idx++;
+      }
+    }
+    int typedIdx = typedValueField != null ? idx++ : -1;
+    int numFields = idx;
+
+    VariantSchema.ScalarType scalarSchema = null;
+    VariantSchema.ObjectField[] objectSchema = null;
+    VariantSchema arraySchema = null;
+
+    if (typedValueField != null) {
+      Schema tvSchema = unwrapNullable(typedValueField.schema());
+
+      switch (tvSchema.getType()) {
+        case RECORD:
+          // Object shredding: each field has a nested {value, typed_value} sub-struct
+          List<VariantSchema.ObjectField> fields = new ArrayList<>();
+          for (Schema.Field field : tvSchema.getFields()) {
+            Schema fieldSchema = unwrapNullable(field.schema());
+            VariantSchema subSchema = buildVariantSchema(fieldSchema, false, builder);
+            fields.add(new VariantSchema.ObjectField(field.name(), subSchema));
+          }
+          objectSchema = fields.toArray(new VariantSchema.ObjectField[0]);
+          break;
+
+        case ARRAY:
+          // Array shredding: elements follow the shredding schema
+          Schema elementSchema = unwrapNullable(tvSchema.getElementType());
+          arraySchema = buildVariantSchema(elementSchema, false, builder);
+          break;
+
+        default:
+          // Scalar shredding
+          scalarSchema = avroTypeToScalarType(tvSchema);
+          break;
+      }
+    }
+
+    VariantSchema result = new VariantSchema(
+        typedIdx, variantIdx, topLevelMetadataIdx, numFields,
+        scalarSchema, objectSchema, arraySchema);
+
+    builder.registerSchema(result, avroSchema);
+
+    return result;
+  }
+
+  /**
+   * Maps an Avro {@link Schema} type (potentially with logical type annotations)
+   * to a {@link VariantSchema.ScalarType}.
+   */
+  private VariantSchema.ScalarType avroTypeToScalarType(Schema schema) {
+    LogicalType logicalType = schema.getLogicalType();
+
+    // Check logical types first
+    if (logicalType != null) {
+      if (logicalType instanceof LogicalTypes.Decimal) {
+        LogicalTypes.Decimal decimal = (LogicalTypes.Decimal) logicalType;
+        return new VariantSchema.DecimalType(decimal.getPrecision(), decimal.getScale());
+      }
+      String name = logicalType.getName();
+      if ("date".equals(name)) {
+        return new VariantSchema.DateType();
+      }
+      if ("timestamp-micros".equals(name)) {
+        return new VariantSchema.TimestampType();
+      }
+      if ("local-timestamp-micros".equals(name)) {
+        return new VariantSchema.TimestampNTZType();
+      }
+      if ("timestamp-millis".equals(name)) {
+        return new VariantSchema.TimestampType();
+      }
+      if ("local-timestamp-millis".equals(name)) {
+        return new VariantSchema.TimestampNTZType();
+      }
+      if ("uuid".equals(name)) {
+        return new VariantSchema.UuidType();
+      }
+    }
+
+    switch (schema.getType()) {
+      case BOOLEAN:
+        return new VariantSchema.BooleanType();
+      case INT:
+        return new VariantSchema.IntegralType(VariantSchema.IntegralSize.INT);
+      case LONG:
+        return new VariantSchema.IntegralType(VariantSchema.IntegralSize.LONG);
+      case FLOAT:
+        return new VariantSchema.FloatType();
+      case DOUBLE:
+        return new VariantSchema.DoubleType();
+      case STRING:
+        return new VariantSchema.StringType();
+      case BYTES:
+        return new VariantSchema.BinaryType();
+      case FIXED:
+        return new VariantSchema.BinaryType();
+      default:
+        return null;
+    }
+  }
+
+  private static Schema unwrapNullable(Schema schema) {
+    if (schema.getType() == Schema.Type.UNION) {
+      for (Schema type : schema.getTypes()) {
+        if (type.getType() != Schema.Type.NULL) {
+          return type;
+        }
+      }
+    }
+    return schema;
+  }
+
+  private static byte[] toByteArray(ByteBuffer buffer) {
+    if (buffer.hasArray() && buffer.position() == 0
+        && buffer.arrayOffset() == 0
+        && buffer.remaining() == buffer.array().length) {
+      return buffer.array();
+    }
+    byte[] bytes = new byte[buffer.remaining()];
+    buffer.duplicate().get(bytes);
+    return bytes;
+  }
+
+  /**
+   * {@link ShreddedResult} implementation that collects shredded variant components
+   * and converts them into an Avro {@link GenericRecord}.
+   */
+  static class AvroShreddedResult implements ShreddedResult {
+    private final VariantSchema variantSchema;
+    private final Schema avroSchema;
+
+    private byte[] metadata;
+    private byte[] variantValue;
+    private Object scalarValue;
+    private AvroShreddedResult[] objectFields;
+    private AvroShreddedResult[] arrayElements;
+
+    AvroShreddedResult(VariantSchema variantSchema, Schema avroSchema) {
+      this.variantSchema = variantSchema;
+      this.avroSchema = avroSchema;
+    }
+
+    @Override
+    public void addArray(ShreddedResult[] array) {
+      this.arrayElements = new AvroShreddedResult[array.length];
+      for (int i = 0; i < array.length; i++) {
+        this.arrayElements[i] = (AvroShreddedResult) array[i];
+      }
+    }
+
+    @Override
+    public void addObject(ShreddedResult[] values) {
+      this.objectFields = new AvroShreddedResult[values.length];
+      for (int i = 0; i < values.length; i++) {
+        this.objectFields[i] = (AvroShreddedResult) values[i];
+      }
+    }
+
+    @Override
+    public void addVariantValue(byte[] result) {
+      this.variantValue = result;
+    }
+
+    @Override
+    public void addScalar(Object result) {
+      this.scalarValue = result;
+    }
+
+    @Override
+    public void addMetadata(byte[] result) {
+      this.metadata = result;
+    }
+
+    /**
+     * Converts the collected shredded components into an Avro {@link GenericRecord}.
+     */
+    GenericRecord toGenericRecord() {
+      GenericRecord record = new GenericData.Record(avroSchema);
+
+      // Metadata (only present at top level)
+      if (metadata != null) {
+        record.put(METADATA_FIELD, ByteBuffer.wrap(metadata));
+      }
+
+      // Value (variant binary for non-shredded or residual data)
+      Schema.Field valueField = avroSchema.getField(VALUE_FIELD);
+      if (valueField != null) {
+        if (variantValue != null) {
+          record.put(VALUE_FIELD, ByteBuffer.wrap(variantValue));
+        } else {
+          record.put(VALUE_FIELD, null);
+        }
+      }
+
+      // Typed value
+      Schema.Field tvField = avroSchema.getField(TYPED_VALUE_FIELD);
+      if (tvField == null) {
+        return record;
+      }
+
+      if (scalarValue != null) {
+        Schema tvSchema = unwrapNullable(tvField.schema());
+        record.put(TYPED_VALUE_FIELD, convertScalarToAvro(scalarValue, tvSchema));
+      } else if (objectFields != null) {
+        Schema tvSchema = unwrapNullable(tvField.schema());
+        GenericRecord tvRecord = new GenericData.Record(tvSchema);
+        for (int i = 0; i < objectFields.length; i++) {
+          String fieldName = variantSchema.objectSchema[i].fieldName;
+          // Always create the sub-record even for missing fields (non-null struct with null fields)
+          tvRecord.put(fieldName, objectFields[i].toGenericRecord());
+        }
+        record.put(TYPED_VALUE_FIELD, tvRecord);
+      } else if (arrayElements != null) {
+        List<GenericRecord> list = new ArrayList<>(arrayElements.length);
+        for (AvroShreddedResult element : arrayElements) {
+          list.add(element.toGenericRecord());
+        }
+        record.put(TYPED_VALUE_FIELD, list);
+      } else {
+        record.put(TYPED_VALUE_FIELD, null);
+      }
+
+      return record;
+    }
+
+    /**
+     * Converts a scalar value from Spark's variant representation to an Avro-compatible type.
+     * Handles type widening (Byte/Short to Int/Long) and binary wrapping.
+     */
+    private static Object convertScalarToAvro(Object value, Schema avroSchema) {
+      if (value instanceof byte[]) {
+        return ByteBuffer.wrap((byte[]) value);
+      }
+      if (value instanceof UUID) {
+        return value.toString();
+      }
+      // Widen integer types to match Avro schema expectations
+      if (avroSchema.getType() == Schema.Type.INT) {
+        if (value instanceof Byte) {
+          return ((Byte) value).intValue();
+        }
+        if (value instanceof Short) {
+          return ((Short) value).intValue();
+        }
+      }
+      if (avroSchema.getType() == Schema.Type.LONG) {
+        if (value instanceof Byte) {
+          return ((Byte) value).longValue();
+        }
+        if (value instanceof Short) {
+          return ((Short) value).longValue();
+        }
+        if (value instanceof Integer) {
+          return ((Integer) value).longValue();
+        }
+      }
+      // BigDecimal, Boolean, String, Integer, Long, Float, Double
+      // are directly compatible with Avro's type system
+      return value;
+    }
+  }
+
+  /**
+   * {@link ShreddedResultBuilder} that creates {@link AvroShreddedResult} instances
+   * with the corresponding Avro schema at each nesting level.
+   */
+  static class AvroShreddedResultBuilder implements ShreddedResultBuilder {
+    private final Map<VariantSchema, Schema> schemaMap = new IdentityHashMap<>();
+
+    void registerSchema(VariantSchema variantSchema, Schema avroSchema) {
+      schemaMap.put(variantSchema, avroSchema);
+    }
+
+    @Override
+    public ShreddedResult createEmpty(VariantSchema schema) {
+      Schema avroSchema = schemaMap.get(schema);
+      if (avroSchema == null) {
+        throw new IllegalStateException(
+            "No Avro schema registered for VariantSchema: " + schema);
+      }
+      return new AvroShreddedResult(schema, avroSchema);
+    }
+
+    @Override
+    public boolean allowNumericScaleChanges() {
+      return true;
+    }
+  }
+}

--- a/hudi-spark-datasource/hudi-spark4-common/src/main/scala/org/apache/spark/sql/adapter/BaseSpark4Adapter.scala
+++ b/hudi-spark-datasource/hudi-spark4-common/src/main/scala/org/apache/spark/sql/adapter/BaseSpark4Adapter.scala
@@ -207,18 +207,19 @@ abstract class BaseSpark4Adapter extends SparkAdapter with Logging {
   override def isDataTypeEqualForPhysicalSchema(requiredType: DataType, fileType: DataType): Option[Boolean] = {
     /**
      * Checks if a StructType is the physical representation of VariantType in Parquet.
-     * VariantType is stored in Parquet as a struct with two binary fields: "metadata" and "value".
+     * VariantType is stored in Parquet as a struct with binary "metadata" and "value" fields.
+     * Supports both unshredded (2 fields) and shredded (3 fields with "typed_value") layouts.
      */
     def isVariantPhysicalSchema(structType: StructType): Boolean = {
-      if (structType.fields.length != 2) {
-        false
-      } else {
-        val fieldMap = structType.fields.map(f => (f.name, f.dataType)).toMap
-        fieldMap.contains(HoodieSchema.Variant.VARIANT_VALUE_FIELD) &&
-          fieldMap.contains(HoodieSchema.Variant.VARIANT_METADATA_FIELD) &&
-          fieldMap(HoodieSchema.Variant.VARIANT_VALUE_FIELD) == BinaryType &&
-          fieldMap(HoodieSchema.Variant.VARIANT_METADATA_FIELD) == BinaryType
-      }
+      val fieldMap = structType.fields.map(f => (f.name, f.dataType)).toMap
+      val hasRequiredFields = fieldMap.contains(HoodieSchema.Variant.VARIANT_VALUE_FIELD) &&
+        fieldMap.contains(HoodieSchema.Variant.VARIANT_METADATA_FIELD) &&
+        fieldMap(HoodieSchema.Variant.VARIANT_VALUE_FIELD) == BinaryType &&
+        fieldMap(HoodieSchema.Variant.VARIANT_METADATA_FIELD) == BinaryType
+      val isUnshredded = structType.fields.length == 2
+      val isShredded = structType.fields.length == 3 &&
+        fieldMap.contains(HoodieSchema.Variant.VARIANT_TYPED_VALUE_FIELD)
+      hasRequiredFields && (isUnshredded || isShredded)
     }
 
     // Handle VariantType comparisons
@@ -300,5 +301,30 @@ abstract class BaseSpark4Adapter extends SparkAdapter with Logging {
       val shreddedValues = SparkShreddingUtils.castShredded(variant, variantShreddingSchema)
       writeStruct.accept(shreddedValues)
     }
+  }
+
+  override def convertVariantToStruct(variantValue: Any, structType: StructType): InternalRow = {
+    import org.apache.spark.sql.catalyst.expressions.SpecificInternalRow
+    import org.apache.spark.unsafe.types.VariantVal
+
+    val variant = variantValue.asInstanceOf[VariantVal]
+    val valueIdx = structType.fieldIndex("value")
+    val metadataIdx = structType.fieldIndex("metadata")
+
+    val row = new SpecificInternalRow(structType)
+    row.update(valueIdx, variant.getValue)
+    row.update(metadataIdx, variant.getMetadata)
+    row
+  }
+
+  override def convertStructToVariant(structRow: InternalRow, structType: StructType): Any = {
+    import org.apache.spark.unsafe.types.VariantVal
+
+    val valueIdx = structType.fieldIndex("value")
+    val metadataIdx = structType.fieldIndex("metadata")
+
+    val valueBytes = structRow.getBinary(valueIdx)
+    val metadataBytes = structRow.getBinary(metadataIdx)
+    new VariantVal(valueBytes, metadataBytes)
   }
 }

--- a/hudi-spark-datasource/hudi-spark4-common/src/test/java/org/apache/hudi/variant/TestSpark4VariantShreddingProvider.java
+++ b/hudi-spark-datasource/hudi-spark4-common/src/test/java/org/apache/hudi/variant/TestSpark4VariantShreddingProvider.java
@@ -1,0 +1,279 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.hudi.variant;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import org.apache.avro.Schema;
+import org.apache.avro.SchemaBuilder;
+import org.apache.avro.generic.GenericData;
+import org.apache.avro.generic.GenericRecord;
+import org.apache.hudi.common.schema.HoodieSchema;
+import org.apache.hudi.common.schema.HoodieSchemaField;
+import org.apache.hudi.common.schema.HoodieSchemaType;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for Spark4VariantShreddingProvider.
+ *
+ * <p>Note: These tests verify the provider's structure and API contracts.
+ * Full end-to-end tests with actual Spark Variant parsing are in the integration test suite.</p>
+ */
+public class TestSpark4VariantShreddingProvider {
+
+  private Spark4VariantShreddingProvider provider;
+
+  @BeforeEach
+  public void setup() {
+    provider = new Spark4VariantShreddingProvider();
+  }
+
+  /**
+   * Test that the provider can be instantiated successfully.
+   */
+  @Test
+  public void testProviderInstantiation() {
+    assertNotNull(provider, "Provider should be instantiated");
+  }
+
+  /**
+   * Test null variant handling - provider should return null for null inputs.
+   */
+  @Test
+  public void testShredNullVariant() {
+    Schema unshreddedSchema = createUnshreddedVariantSchema();
+    GenericRecord unshreddedVariant = new GenericData.Record(unshreddedSchema);
+    unshreddedVariant.put("value", null);
+    unshreddedVariant.put("metadata", null);
+
+    Schema shreddedSchema = createShreddedVariantSchema(Schema.create(Schema.Type.INT));
+    HoodieSchema.Variant variantSchema = HoodieSchema.createVariantShredded(
+        "test", null, null, HoodieSchema.create(HoodieSchemaType.INT));
+
+    GenericRecord result = provider.shredVariantRecord(unshreddedVariant, shreddedSchema, variantSchema);
+
+    assertNull(result, "Provider should return null for null variant inputs");
+  }
+
+  /**
+   * Test that the provider handles object shredding schema structure.
+   */
+  @Test
+  public void testObjectShreddingSchemaStructure() {
+    // Create shredded object schema with fields a:int, b:string
+    Map<String, HoodieSchema> typedFields = new LinkedHashMap<>();
+    typedFields.put("a", HoodieSchema.create(HoodieSchemaType.INT));
+    typedFields.put("b", HoodieSchema.create(HoodieSchemaType.STRING));
+
+    HoodieSchema.Variant variantSchema = HoodieSchema.createVariantShreddedObject(
+        "test", null, null, typedFields);
+
+    assertNotNull(variantSchema, "Variant schema should be created");
+    assertTrue(variantSchema.getTypedValueField().isPresent(), "Should have typed_value field");
+  }
+
+  /**
+   * Test that provider correctly constructs Avro schemas for basic types.
+   */
+  @Test
+  public void testAvroSchemaConstruction() {
+    // Test INT type
+    HoodieSchema intSchema = HoodieSchema.create(HoodieSchemaType.INT);
+    HoodieSchema.Variant intVariant = HoodieSchema.createVariantShredded("test", null, null, intSchema);
+    assertNotNull(intVariant);
+    assertNotNull(intVariant.getAvroSchema());
+
+    // Test STRING type
+    HoodieSchema stringSchema = HoodieSchema.create(HoodieSchemaType.STRING);
+    HoodieSchema.Variant stringVariant = HoodieSchema.createVariantShredded("test", null, null, stringSchema);
+    assertNotNull(stringVariant);
+
+    // Test LONG type
+    HoodieSchema longSchema = HoodieSchema.create(HoodieSchemaType.LONG);
+    HoodieSchema.Variant longVariant = HoodieSchema.createVariantShredded("test", null, null, longSchema);
+    assertNotNull(longVariant);
+
+    // Test DOUBLE type
+    HoodieSchema doubleSchema = HoodieSchema.create(HoodieSchemaType.DOUBLE);
+    HoodieSchema.Variant doubleVariant = HoodieSchema.createVariantShredded("test", null, null, doubleSchema);
+    assertNotNull(doubleVariant);
+
+    // Test BOOLEAN type
+    HoodieSchema boolSchema = HoodieSchema.create(HoodieSchemaType.BOOLEAN);
+    HoodieSchema.Variant boolVariant = HoodieSchema.createVariantShredded("test", null, null, boolSchema);
+    assertNotNull(boolVariant);
+  }
+
+  /**
+   * Test decimal schema construction.
+   */
+  @Test
+  public void testDecimalSchemaConstruction() {
+    HoodieSchema decimalSchema = HoodieSchema.createDecimal(10, 2);
+    HoodieSchema.Variant decimalVariant = HoodieSchema.createVariantShredded("test", null, null, decimalSchema);
+
+    assertNotNull(decimalVariant);
+    assertNotNull(decimalVariant.getAvroSchema());
+    assertTrue(decimalVariant.getTypedValueField().isPresent());
+  }
+
+  /**
+   * Test object schema with multiple fields.
+   */
+  @Test
+  public void testMultiFieldObjectSchema() {
+    Map<String, HoodieSchema> fields = new LinkedHashMap<>();
+    fields.put("field1", HoodieSchema.create(HoodieSchemaType.INT));
+    fields.put("field2", HoodieSchema.create(HoodieSchemaType.STRING));
+    fields.put("field3", HoodieSchema.create(HoodieSchemaType.DOUBLE));
+    fields.put("field4", HoodieSchema.create(HoodieSchemaType.BOOLEAN));
+
+    HoodieSchema.Variant variant = HoodieSchema.createVariantShreddedObject("test", null, null, fields);
+
+    assertNotNull(variant);
+    assertNotNull(variant.getAvroSchema());
+    assertTrue(variant.isShredded());
+    assertTrue(variant.getTypedValueField().isPresent());
+
+    // Verify the typed_value field is a RECORD with the correct fields
+    HoodieSchema typedValueSchema = variant.getTypedValueField().get();
+    assertEquals(HoodieSchemaType.RECORD, typedValueSchema.getType());
+
+    List<HoodieSchemaField> typedFields = typedValueSchema.getFields();
+    assertEquals(4, typedFields.size(), "Should have 4 fields");
+  }
+
+  /**
+   * Test that array shredding schema can be created with correct structure.
+   */
+  @Test
+  public void testArrayShreddingSchemaStructure() {
+    // Create element schema wrapped in the shredded field struct
+    HoodieSchema elementType = HoodieSchema.create(HoodieSchemaType.INT);
+    HoodieSchema arrayElementSchema = HoodieSchema.createShreddedFieldStruct("element", elementType);
+
+    // Create array schema
+    HoodieSchema arraySchema = HoodieSchema.createArray(arrayElementSchema);
+
+    // Create variant with array typed_value
+    HoodieSchema.Variant arrayVariant = HoodieSchema.createVariantShredded("test", null, null, arraySchema);
+
+    assertNotNull(arrayVariant);
+    assertTrue(arrayVariant.isShredded());
+    assertTrue(arrayVariant.getTypedValueField().isPresent());
+
+    HoodieSchema typedValue = arrayVariant.getTypedValueField().get();
+    assertEquals(HoodieSchemaType.ARRAY, typedValue.getType());
+  }
+
+  /**
+   * Test schema structure with nested objects.
+   */
+  @Test
+  public void testNestedObjectSchemaStructure() {
+    // Create inner object
+    List<HoodieSchemaField> innerFields = new java.util.ArrayList<>();
+    innerFields.add(HoodieSchemaField.of("x",
+        HoodieSchema.create(HoodieSchemaType.INT)));
+    innerFields.add(HoodieSchemaField.of("y",
+        HoodieSchema.create(HoodieSchemaType.INT)));
+
+    HoodieSchema innerObject = HoodieSchema.createRecord("inner", null, null, innerFields);
+
+    // Create outer object with the inner object as a field
+    Map<String, HoodieSchema> outerFields = new LinkedHashMap<>();
+    outerFields.put("name", HoodieSchema.create(HoodieSchemaType.STRING));
+    outerFields.put("point", innerObject);
+
+    HoodieSchema.Variant variant = HoodieSchema.createVariantShreddedObject("test", null, null, outerFields);
+
+    assertNotNull(variant);
+    assertTrue(variant.isShredded());
+  }
+
+  /**
+   * Test that provider respects nullable wrapper for variant fields.
+   */
+  @Test
+  public void testNullableVariantSchema() {
+    HoodieSchema intSchema = HoodieSchema.create(HoodieSchemaType.INT);
+    HoodieSchema.Variant variant = HoodieSchema.createVariantShredded("test", null, null, intSchema);
+    HoodieSchema nullableVariant = HoodieSchema.createNullable(variant);
+
+    assertNotNull(nullableVariant);
+    assertTrue(nullableVariant.isNullable());
+
+    HoodieSchema unwrapped = nullableVariant.getNonNullType();
+    assertEquals(HoodieSchemaType.VARIANT, unwrapped.getType());
+  }
+
+  /**
+   * Test complex DDL-style schema with various types.
+   */
+  @Test
+  public void testComplexDDLSchema() {
+    Map<String, HoodieSchema> fields = new LinkedHashMap<>();
+    fields.put("id", HoodieSchema.create(HoodieSchemaType.LONG));
+    fields.put("name", HoodieSchema.create(HoodieSchemaType.STRING));
+    fields.put("price", HoodieSchema.createDecimal(15, 2));
+    fields.put("quantity", HoodieSchema.create(HoodieSchemaType.INT));
+    fields.put("active", HoodieSchema.create(HoodieSchemaType.BOOLEAN));
+    fields.put("rating", HoodieSchema.create(HoodieSchemaType.DOUBLE));
+
+    HoodieSchema.Variant variant = HoodieSchema.createVariantShreddedObject("test", null, null, fields);
+
+    assertNotNull(variant);
+    assertTrue(variant.isShredded());
+
+    HoodieSchema typedValue = variant.getTypedValueField().get();
+    List<HoodieSchemaField> typedFields = typedValue.getFields();
+    assertEquals(6, typedFields.size(), "Should have all 6 fields");
+  }
+
+  /**
+   * Helper method to create an unshredded variant schema.
+   */
+  private Schema createUnshreddedVariantSchema() {
+    return SchemaBuilder.record("variant")
+        .fields()
+        .requiredBytes("value")
+        .requiredBytes("metadata")
+        .endRecord();
+  }
+
+  /**
+   * Helper method to create a shredded variant schema with the given typed_value type.
+   */
+  private Schema createShreddedVariantSchema(Schema typedValueType) {
+    return SchemaBuilder.record("variant")
+        .fields()
+        .optionalBytes("value")
+        .requiredBytes("metadata")
+        .name("typed_value").type().unionOf().nullType().and().type(typedValueType).endUnion().noDefault()
+        .endRecord();
+  }
+}

--- a/hudi-spark-datasource/hudi-spark4.0.x/src/main/scala/org/apache/spark/sql/avro/AvroDeserializer.scala
+++ b/hudi-spark-datasource/hudi-spark4.0.x/src/main/scala/org/apache/spark/sql/avro/AvroDeserializer.scala
@@ -273,17 +273,22 @@ private[sql] class AvroDeserializer(rootAvroType: Schema,
           val record = value.asInstanceOf[IndexedRecord]
 
           val valueBuffer = record.get(valueIdx).asInstanceOf[ByteBuffer]
-          val valueBytes = new Array[Byte](valueBuffer.remaining)
-          valueBuffer.get(valueBytes)
-          valueBuffer.rewind()
+          // value field can be null during merging
+          if (valueBuffer == null) {
+            updater.setNullAt(ordinal)
+          } else {
+            val valueBytes = new Array[Byte](valueBuffer.remaining)
+            valueBuffer.get(valueBytes)
+            valueBuffer.rewind()
 
-          val metadataBuffer = record.get(metadataIdx).asInstanceOf[ByteBuffer]
-          val metadataBytes = new Array[Byte](metadataBuffer.remaining)
-          metadataBuffer.get(metadataBytes)
-          metadataBuffer.rewind()
+            val metadataBuffer = record.get(metadataIdx).asInstanceOf[ByteBuffer]
+            val metadataBytes = new Array[Byte](metadataBuffer.remaining)
+            metadataBuffer.get(metadataBytes)
+            metadataBuffer.rewind()
 
-          val variant = new VariantVal(valueBytes, metadataBytes)
-          updater.set(ordinal, variant)
+            val variant = new VariantVal(valueBytes, metadataBytes)
+            updater.set(ordinal, variant)
+          }
 
       case (RECORD, st: StructType) =>
         // Avro datasource doesn't accept filters with nested attributes. See SPARK-32328.

--- a/hudi-spark-datasource/hudi-spark4.0.x/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/Spark40ParquetReader.scala
+++ b/hudi-spark-datasource/hudi-spark4.0.x/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/Spark40ParquetReader.scala
@@ -276,6 +276,9 @@ object Spark40ParquetReader extends SparkParquetReaderBuilder {
     )
     hadoopConf.setBoolean(SQLConf.PARQUET_INFER_TIMESTAMP_NTZ_ENABLED.key, sqlConf.parquetInferTimestampNTZEnabled)
 
+    hadoopConf.setBoolean(SQLConf.VARIANT_ALLOW_READING_SHREDDED.key,
+      options.getOrElse("hoodie.parquet.variant.allow.reading.shredded", "true").toBoolean)
+
     val enableLogicalTimestampRepair = hadoopConf.getBoolean(ENABLE_LOGICAL_TIMESTAMP_REPAIR, true)
     val returningBatch = sqlConf.parquetVectorizedReaderEnabled &&
       options.getOrElse(FileFormat.OPTION_RETURNING_BATCH,


### PR DESCRIPTION
Mirror of https://github.com/apache/hudi/pull/18065 for automated bot review.

**Original author:** @voonhous
**Base branch:** master


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

* **New Features**
  * Added clustering expiration with heartbeat-based eligibility tracking for automatic rollback of stale clustering operations.
  * Introduced vector search table-valued functions (`hudi_vector_search`, `hudi_vector_search_batch`) for semantic similarity queries in Spark 4.x.
  * Added Parquet variant column shredding support for improved query performance on complex data types (Spark 4.x).
  * Implemented record limit push-down for Flink source reads to optimize LIMIT clause execution.
  * Added column pruning optimization for incremental reads to reduce data transfer.
  * Enabled optional catalog-based partition discovery to improve metadata handling.

* **Bug Fixes**
  * Improved schema validation to prevent invalid nested vector configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->