### PR TITLE
[OSS PR #18497] [WIP] feat(lance): round-trip Hudi VECTOR columns as native Lance fixed-size lists

### DIFF
--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/io/storage/HoodieSparkLanceReader.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/io/storage/HoodieSparkLanceReader.java
@@ -202,7 +202,8 @@ public class HoodieSparkLanceReader implements HoodieSparkFileReader {
   @Override
   public HoodieSchema getSchema() {
     try {
-      StructType structType = LanceArrowUtils.fromArrowSchema(arrowSchema);
+      StructType structType = VectorConversionUtils.restoreVectorMetadataFromArrowSchema(
+          arrowSchema, LanceArrowUtils.fromArrowSchema(arrowSchema));
       return HoodieSchemaConversionUtils.convertStructTypeToHoodieSchema(structType, "record", "", false);
     } catch (Exception e) {
       throw new HoodieException("Failed to read schema from Lance file: " + path, e);

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/io/storage/HoodieSparkLanceWriter.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/io/storage/HoodieSparkLanceWriter.java
@@ -23,7 +23,9 @@ import org.apache.hudi.common.config.HoodieStorageConfig;
 import org.apache.hudi.common.engine.TaskContextSupplier;
 import org.apache.hudi.common.model.HoodieKey;
 import org.apache.hudi.common.model.HoodieRecord;
+import org.apache.hudi.common.schema.HoodieSchema;
 import org.apache.hudi.common.util.Option;
+import org.apache.hudi.exception.HoodieNotSupportedException;
 import org.apache.hudi.io.lance.HoodieBaseLanceWriter;
 import org.apache.hudi.io.storage.row.HoodieBloomFilterRowWriteSupport;
 import org.apache.hudi.io.storage.row.HoodieInternalRowFileWriter;
@@ -36,11 +38,19 @@ import lombok.Builder;
 import org.apache.arrow.vector.VectorSchemaRoot;
 import org.apache.arrow.vector.types.pojo.Schema;
 import org.apache.spark.sql.catalyst.InternalRow;
+import org.apache.spark.sql.types.ArrayType;
+import org.apache.spark.sql.types.DataType;
+import org.apache.spark.sql.types.DoubleType$;
+import org.apache.spark.sql.types.FloatType$;
+import org.apache.spark.sql.types.Metadata;
+import org.apache.spark.sql.types.MetadataBuilder;
+import org.apache.spark.sql.types.StructField;
 import org.apache.spark.sql.types.StructType;
 import org.apache.spark.sql.util.LanceArrowUtils;
 import org.apache.spark.unsafe.types.UTF8String;
 
 import java.io.IOException;
+import java.util.Map;
 import java.util.function.Function;
 
 import static org.apache.hudi.common.model.HoodieRecord.HoodieMetadataField.COMMIT_SEQNO_METADATA_FIELD;
@@ -120,8 +130,11 @@ public class HoodieSparkLanceWriter extends HoodieBaseLanceWriter<InternalRow, U
                                  Option<BloomFilter> bloomFilterOpt,
                                  long maxFileSize) {
     super(file, DEFAULT_BATCH_SIZE, bloomFilterOpt.map(HoodieBloomFilterRowWriteSupport::new));
-    this.sparkSchema = sparkSchema;
-    this.arrowSchema = LanceArrowUtils.toArrowSchema(sparkSchema, DEFAULT_TIMEZONE, true, false);
+    // Enrich fields carrying the Hudi VECTOR logical type with the Spark metadata key
+    // that lance-spark's toArrowSchema / LanceArrowWriter use to emit a native Arrow
+    // FixedSizeList (i.e. Lance's vector column encoding) instead of a plain List.
+    this.sparkSchema = enrichSparkSchemaForLanceVectors(sparkSchema);
+    this.arrowSchema = LanceArrowUtils.toArrowSchema(this.sparkSchema, DEFAULT_TIMEZONE, true, false);
     this.fileName = UTF8String.fromString(file.getName());
     this.instantTime = UTF8String.fromString(instantTime);
     this.populateMetaFields = populateMetaFields;
@@ -130,6 +143,54 @@ public class HoodieSparkLanceWriter extends HoodieBaseLanceWriter<InternalRow, U
       Integer partitionId = taskContextSupplier.getPartitionIdSupplier().get();
       return HoodieRecord.generateSequenceId(instantTime, partitionId, recordIndex);
     };
+  }
+
+  /**
+   * For every field carrying a Hudi VECTOR logical type annotation
+   * (Spark metadata key {@link HoodieSchema#TYPE_METADATA_FIELD} starting with {@code "VECTOR"}),
+   * attach the lance-spark metadata key {@link LanceArrowUtils#ARROW_FIXED_SIZE_LIST_SIZE_KEY()}
+   * with the vector's dimension so that {@link LanceArrowUtils#toArrowSchema} emits a native
+   * Arrow {@code FixedSizeList<elem, dim>} (Lance's vector column encoding) and
+   * {@link LanceArrowWriter} selects its fixed-size-list field writer when serializing values.
+   *
+   * <p>Currently only FLOAT and DOUBLE element vectors are supported on Lance, matching
+   * lance-spark's {@code VectorUtils.shouldBeFixedSizeList}. Other element types would
+   * silently fall through to a plain list write, so we fail fast instead.
+   */
+  private static StructType enrichSparkSchemaForLanceVectors(StructType sparkSchema) {
+    Map<Integer, HoodieSchema.Vector> vectorColumns =
+        VectorConversionUtils.detectVectorColumnsFromMetadata(sparkSchema);
+    if (vectorColumns.isEmpty()) {
+      return sparkSchema;
+    }
+    StructField[] fields = sparkSchema.fields();
+    StructField[] newFields = new StructField[fields.length];
+    for (int i = 0; i < fields.length; i++) {
+      StructField field = fields[i];
+      HoodieSchema.Vector vec = vectorColumns.get(i);
+      if (vec == null) {
+        newFields[i] = field;
+        continue;
+      }
+      DataType dt = field.dataType();
+      if (!(dt instanceof ArrayType)) {
+        throw new HoodieNotSupportedException(
+            "Hudi VECTOR column '" + field.name() + "' must be Spark ArrayType to be written to Lance; got " + dt);
+      }
+      DataType elemType = ((ArrayType) dt).elementType();
+      boolean elemSupported = elemType instanceof FloatType$ || elemType instanceof DoubleType$;
+      if (!elemSupported) {
+        throw new HoodieNotSupportedException(
+            "Lance base-file format currently supports FLOAT/DOUBLE VECTOR columns only; "
+                + "got element type " + elemType.simpleString() + " for field '" + field.name() + "'");
+      }
+      Metadata enriched = new MetadataBuilder()
+          .withMetadata(field.metadata())
+          .putLong(LanceArrowUtils.ARROW_FIXED_SIZE_LIST_SIZE_KEY(), vec.getDimension())
+          .build();
+      newFields[i] = new StructField(field.name(), field.dataType(), field.nullable(), enriched);
+    }
+    return new StructType(newFields);
   }
 
   @Override

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/io/storage/HoodieSparkLanceWriter.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/io/storage/HoodieSparkLanceWriter.java
@@ -38,10 +38,6 @@ import lombok.Builder;
 import org.apache.arrow.vector.VectorSchemaRoot;
 import org.apache.arrow.vector.types.pojo.Schema;
 import org.apache.spark.sql.catalyst.InternalRow;
-import org.apache.spark.sql.types.ArrayType;
-import org.apache.spark.sql.types.DataType;
-import org.apache.spark.sql.types.DoubleType$;
-import org.apache.spark.sql.types.FloatType$;
 import org.apache.spark.sql.types.Metadata;
 import org.apache.spark.sql.types.MetadataBuilder;
 import org.apache.spark.sql.types.StructField;
@@ -50,6 +46,7 @@ import org.apache.spark.sql.util.LanceArrowUtils;
 import org.apache.spark.unsafe.types.UTF8String;
 
 import java.io.IOException;
+import java.util.Collections;
 import java.util.Map;
 import java.util.function.Function;
 
@@ -130,9 +127,6 @@ public class HoodieSparkLanceWriter extends HoodieBaseLanceWriter<InternalRow, U
                                  Option<BloomFilter> bloomFilterOpt,
                                  long maxFileSize) {
     super(file, DEFAULT_BATCH_SIZE, bloomFilterOpt.map(HoodieBloomFilterRowWriteSupport::new));
-    // Enrich fields carrying the Hudi VECTOR logical type with the Spark metadata key
-    // that lance-spark's toArrowSchema / LanceArrowWriter use to emit a native Arrow
-    // FixedSizeList (i.e. Lance's vector column encoding) instead of a plain List.
     this.sparkSchema = enrichSparkSchemaForLanceVectors(sparkSchema);
     this.arrowSchema = LanceArrowUtils.toArrowSchema(this.sparkSchema, DEFAULT_TIMEZONE, true, false);
     this.fileName = UTF8String.fromString(file.getName());
@@ -172,16 +166,12 @@ public class HoodieSparkLanceWriter extends HoodieBaseLanceWriter<InternalRow, U
         newFields[i] = field;
         continue;
       }
-      if (!(field.dataType() instanceof ArrayType)) {
-        throw new HoodieNotSupportedException(
-            "Hudi VECTOR column '" + field.name() + "' must be Spark ArrayType to be written to Lance; got " + field.dataType());
-      }
-      DataType elemType = ((ArrayType) field.dataType()).elementType();
-      boolean elemSupported = elemType instanceof FloatType$ || elemType instanceof DoubleType$;
-      if (!elemSupported) {
+      HoodieSchema.Vector.VectorElementType elemType = vec.getVectorElementType();
+      if (elemType != HoodieSchema.Vector.VectorElementType.FLOAT
+          && elemType != HoodieSchema.Vector.VectorElementType.DOUBLE) {
         throw new HoodieNotSupportedException(
             "Lance base-file format currently supports FLOAT/DOUBLE VECTOR columns only; "
-                + "got element type " + elemType.simpleString() + " for field '" + field.name() + "'");
+                + "got element type " + elemType + " for field '" + field.name() + "'");
       }
       Metadata enriched = new MetadataBuilder()
           .withMetadata(field.metadata())
@@ -272,12 +262,11 @@ public class HoodieSparkLanceWriter extends HoodieBaseLanceWriter<InternalRow, U
    */
   @Override
   protected java.util.Map<String, String> additionalSchemaMetadata() {
-    String value = VectorConversionUtils.buildVectorColumnsMetadataValue(sparkSchema);
+    String value = VectorConversionUtils.buildVectorColumnsFooterValue(sparkSchema);
     if (value.isEmpty()) {
-      return java.util.Collections.emptyMap();
+      return Collections.emptyMap();
     }
-    return java.util.Collections.singletonMap(
-        org.apache.hudi.common.schema.HoodieSchema.PARQUET_VECTOR_COLUMNS_METADATA_KEY, value);
+    return Collections.singletonMap(HoodieSchema.VECTOR_COLUMNS_METADATA_KEY, value);
   }
 
   /**

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/io/storage/HoodieSparkLanceWriter.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/io/storage/HoodieSparkLanceWriter.java
@@ -260,6 +260,28 @@ public class HoodieSparkLanceWriter extends HoodieBaseLanceWriter<InternalRow, U
   }
 
   /**
+   * Emit Hudi's {@code hoodie.vector.columns} footer entry alongside any
+   * bloom-filter metadata. Mirrors the Parquet writer (see
+   * {@code HoodieRowParquetWriteSupport#init}) so Lance files carry the same
+   * self-describing VECTOR descriptor list that Parquet files do.
+   *
+   * <p>The read side today derives VECTOR identity from the Arrow
+   * {@code FixedSizeList<Float/Double, N>} type — this footer entry is a
+   * forward-compat guard: it lets future readers recover the exact descriptor
+   * (including fields the Arrow type cannot express, e.g. quantization tags)
+   * without a writer bump.
+   */
+  @Override
+  protected java.util.Map<String, String> additionalSchemaMetadata() {
+    String value = VectorConversionUtils.buildVectorColumnsMetadataValue(sparkSchema);
+    if (value.isEmpty()) {
+      return java.util.Collections.emptyMap();
+    }
+    return java.util.Collections.singletonMap(
+        org.apache.hudi.common.schema.HoodieSchema.PARQUET_VECTOR_COLUMNS_METADATA_KEY, value);
+  }
+
+  /**
    * Update Hudi metadata fields in the InternalRow.
    *
    * @param row InternalRow to update

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/io/storage/HoodieSparkLanceWriter.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/io/storage/HoodieSparkLanceWriter.java
@@ -172,12 +172,11 @@ public class HoodieSparkLanceWriter extends HoodieBaseLanceWriter<InternalRow, U
         newFields[i] = field;
         continue;
       }
-      DataType dt = field.dataType();
-      if (!(dt instanceof ArrayType)) {
+      if (!(field.dataType() instanceof ArrayType)) {
         throw new HoodieNotSupportedException(
-            "Hudi VECTOR column '" + field.name() + "' must be Spark ArrayType to be written to Lance; got " + dt);
+            "Hudi VECTOR column '" + field.name() + "' must be Spark ArrayType to be written to Lance; got " + field.dataType());
       }
-      DataType elemType = ((ArrayType) dt).elementType();
+      DataType elemType = ((ArrayType) field.dataType()).elementType();
       boolean elemSupported = elemType instanceof FloatType$ || elemType instanceof DoubleType$;
       if (!elemSupported) {
         throw new HoodieNotSupportedException(

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/io/storage/VectorConversionUtils.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/io/storage/VectorConversionUtils.java
@@ -22,10 +22,14 @@ import org.apache.hudi.common.schema.HoodieSchema;
 import org.apache.hudi.common.schema.HoodieSchemaField;
 import org.apache.hudi.common.schema.HoodieSchemaType;
 
+import org.apache.arrow.vector.types.FloatingPointPrecision;
+import org.apache.arrow.vector.types.pojo.ArrowType;
+import org.apache.arrow.vector.types.pojo.Field;
 import org.apache.spark.sql.catalyst.expressions.UnsafeArrayData;
 import org.apache.spark.sql.catalyst.util.ArrayData;
 import org.apache.spark.sql.catalyst.util.GenericArrayData;
 import org.apache.spark.sql.types.BinaryType$;
+import org.apache.spark.sql.types.MetadataBuilder;
 import org.apache.spark.sql.types.StructField;
 import org.apache.spark.sql.types.StructType;
 
@@ -234,5 +238,87 @@ public final class VectorConversionUtils {
         result.update(i, row.get(i, readSchema.apply(i).dataType()));
       }
     }
+  }
+
+  /**
+   * Restores Hudi's VECTOR logical-type metadata on a Spark schema derived from a Lance
+   * (Arrow) schema. The upstream conversion {@code LanceArrowUtils.fromArrowSchema} maps
+   * Arrow {@code FixedSizeList<Float32|Float64, dim>} to Spark {@code ArrayType(FloatType|DoubleType)}
+   * but drops all field-level metadata, so a column that was written as a Hudi VECTOR
+   * comes back indistinguishable from a plain array. This method walks the original Arrow
+   * schema (which still carries the fixed-size-list intent and dimension) and re-attaches
+   * {@link HoodieSchema#TYPE_METADATA_FIELD} = {@code "VECTOR(dim[, DOUBLE])"} to matching
+   * fields so downstream VECTOR-aware code sees the same schema it would on the Parquet path.
+   *
+   * <p>Only FLOAT and DOUBLE element types are recognized, matching what the Lance write
+   * path can produce today. Any other Arrow type (including non-FixedSizeList or
+   * FixedSizeList of non-floating-point children) is passed through unchanged.
+   *
+   * @param arrowSchema     the original Arrow schema read from the Lance file
+   * @param convertedSpark  the StructType produced by {@code LanceArrowUtils.fromArrowSchema}
+   *                        (must have the same field count and order as {@code arrowSchema})
+   * @return a new StructType with VECTOR metadata restored on eligible fields
+   */
+  public static StructType restoreVectorMetadataFromArrowSchema(
+      org.apache.arrow.vector.types.pojo.Schema arrowSchema, StructType convertedSpark) {
+    if (arrowSchema == null || convertedSpark == null) {
+      return convertedSpark;
+    }
+    List<Field> arrowFields = arrowSchema.getFields();
+    StructField[] sparkFields = convertedSpark.fields();
+    if (arrowFields.size() != sparkFields.length) {
+      // Schemas desynchronized — bail out rather than risk corrupting metadata.
+      return convertedSpark;
+    }
+    StructField[] newFields = new StructField[sparkFields.length];
+    boolean anyChanged = false;
+    for (int i = 0; i < sparkFields.length; i++) {
+      StructField sf = sparkFields[i];
+      String descriptor = deriveVectorDescriptor(arrowFields.get(i));
+      if (descriptor == null) {
+        newFields[i] = sf;
+      } else {
+        newFields[i] = new StructField(
+            sf.name(),
+            sf.dataType(),
+            sf.nullable(),
+            new MetadataBuilder()
+                .withMetadata(sf.metadata())
+                .putString(HoodieSchema.TYPE_METADATA_FIELD, descriptor)
+                .build());
+        anyChanged = true;
+      }
+    }
+    return anyChanged ? new StructType(newFields) : convertedSpark;
+  }
+
+  /**
+   * Derives Hudi's VECTOR type descriptor for an Arrow field if it represents a
+   * fixed-size list of single- or double-precision floats, otherwise returns null.
+   */
+  private static String deriveVectorDescriptor(Field arrowField) {
+    ArrowType type = arrowField.getType();
+    if (!(type instanceof ArrowType.FixedSizeList)) {
+      return null;
+    }
+    int dim = ((ArrowType.FixedSizeList) type).getListSize();
+    List<Field> children = arrowField.getChildren();
+    if (children.size() != 1) {
+      return null;
+    }
+    ArrowType childType = children.get(0).getType();
+    if (!(childType instanceof ArrowType.FloatingPoint)) {
+      return null;
+    }
+    FloatingPointPrecision precision = ((ArrowType.FloatingPoint) childType).getPrecision();
+    HoodieSchema.Vector.VectorElementType elementType;
+    if (precision == FloatingPointPrecision.SINGLE) {
+      elementType = HoodieSchema.Vector.VectorElementType.FLOAT;
+    } else if (precision == FloatingPointPrecision.DOUBLE) {
+      elementType = HoodieSchema.Vector.VectorElementType.DOUBLE;
+    } else {
+      return null;
+    }
+    return ((HoodieSchema.Vector) HoodieSchema.createVector(dim, elementType)).toTypeDescriptor();
   }
 }

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/io/storage/VectorConversionUtils.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/io/storage/VectorConversionUtils.java
@@ -80,6 +80,39 @@ public final class VectorConversionUtils {
   }
 
   /**
+   * Builds the value string for {@link HoodieSchema#PARQUET_VECTOR_COLUMNS_METADATA_KEY}
+   * from a Spark {@link StructType}, matching the comma-separated
+   * {@code colName:VECTOR(dim[,elemType])} format produced on the Parquet path by
+   * {@link HoodieSchema#buildVectorColumnsMetadataValue}.
+   *
+   * <p>Intended to be written as file-footer metadata (e.g. via
+   * {@code LanceFileWriter.addSchemaMetadata}) so any reader can identify VECTOR
+   * columns from the file alone, mirroring the Parquet footer convention.
+   *
+   * @param schema Spark StructType (may be null)
+   * @return comma-separated descriptor list, or empty string if no VECTOR columns
+   */
+  public static String buildVectorColumnsMetadataValue(StructType schema) {
+    if (schema == null) {
+      return "";
+    }
+    StringBuilder sb = new StringBuilder();
+    StructField[] fields = schema.fields();
+    Map<Integer, HoodieSchema.Vector> detected = detectVectorColumnsFromMetadata(schema);
+    for (int i = 0; i < fields.length; i++) {
+      HoodieSchema.Vector v = detected.get(i);
+      if (v == null) {
+        continue;
+      }
+      if (sb.length() > 0) {
+        sb.append(',');
+      }
+      sb.append(fields[i].name()).append(':').append(v.toTypeDescriptor());
+    }
+    return sb.toString();
+  }
+
+  /**
    * Detects VECTOR columns from Spark StructType metadata annotations.
    * Fields with metadata key {@link HoodieSchema#TYPE_METADATA_FIELD} starting with "VECTOR"
    * are parsed and included.

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/io/storage/VectorConversionUtils.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/io/storage/VectorConversionUtils.java
@@ -18,6 +18,7 @@
 
 package org.apache.hudi.io.storage;
 
+import org.apache.arrow.vector.types.pojo.Schema;
 import org.apache.hudi.common.schema.HoodieSchema;
 import org.apache.hudi.common.schema.HoodieSchemaField;
 import org.apache.hudi.common.schema.HoodieSchemaType;
@@ -80,40 +81,25 @@ public final class VectorConversionUtils {
   }
 
   /**
-   * Builds the value string for {@link HoodieSchema#PARQUET_VECTOR_COLUMNS_METADATA_KEY}
-   * from a Spark {@link StructType}, matching the comma-separated
-   * {@code colName:VECTOR(dim[,elemType])} format produced on the Parquet path by
-   * {@link HoodieSchema#buildVectorColumnsMetadataValue(org.apache.hudi.common.schema.HoodieSchema)}.
-   *
-   * <p>This Spark-specific variant operates on {@link StructType} field metadata
-   * rather than {@link org.apache.hudi.common.schema.HoodieSchema}, since the Lance
-   * writer works with Spark schemas directly and does not convert to HoodieSchema.
-   *
-   * <p>Intended to be written as file-footer metadata (e.g. via
-   * {@code LanceFileWriter.addSchemaMetadata}) so any reader can identify VECTOR
-   * columns from the file alone, mirroring the Parquet footer convention.
+   * Builds the {@link HoodieSchema#VECTOR_COLUMNS_METADATA_KEY} footer value
+   * from a Spark {@link StructType} by detecting VECTOR metadata annotations and
+   * delegating to {@link HoodieSchema#serializeVectorColumnsMetadata}.
    *
    * @param schema Spark StructType (may be null)
    * @return comma-separated descriptor list, or empty string if no VECTOR columns
+   * @see HoodieSchema#serializeVectorColumnsMetadata(java.util.Map)
    */
-  public static String buildVectorColumnsMetadataValue(StructType schema) {
+  public static String buildVectorColumnsFooterValue(StructType schema) {
     if (schema == null) {
       return "";
     }
-    StringBuilder sb = new StringBuilder();
     StructField[] fields = schema.fields();
     Map<Integer, HoodieSchema.Vector> detected = detectVectorColumnsFromMetadata(schema);
-    for (int i = 0; i < fields.length; i++) {
-      HoodieSchema.Vector v = detected.get(i);
-      if (v == null) {
-        continue;
-      }
-      if (sb.length() > 0) {
-        sb.append(',');
-      }
-      sb.append(fields[i].name()).append(':').append(v.toTypeDescriptor());
+    java.util.LinkedHashMap<String, HoodieSchema.Vector> named = new java.util.LinkedHashMap<>();
+    for (Map.Entry<Integer, HoodieSchema.Vector> entry : detected.entrySet()) {
+      named.put(fields[entry.getKey()].name(), entry.getValue());
     }
-    return sb.toString();
+    return HoodieSchema.serializeVectorColumnsMetadata(named);
   }
 
   /**
@@ -278,28 +264,20 @@ public final class VectorConversionUtils {
   }
 
   /**
-   * Restores Hudi's VECTOR logical-type metadata on a Spark schema derived from a Lance
-   * (Arrow) schema. The upstream conversion {@code LanceArrowUtils.fromArrowSchema} maps
-   * Arrow {@code FixedSizeList<Float32|Float64, dim>} to Spark {@code ArrayType(FloatType|DoubleType)}
-   * but drops all field-level metadata, so a column that was written as a Hudi VECTOR
-   * comes back indistinguishable from a plain array. This method walks the original Arrow
-   * schema (which still carries the fixed-size-list intent and dimension) and re-attaches
-   * {@link HoodieSchema#TYPE_METADATA_FIELD} = {@code "VECTOR(dim[, DOUBLE])"} to matching
-   * fields so downstream VECTOR-aware code sees the same schema it would on the Parquet path.
+   * Re-attaches {@link HoodieSchema#TYPE_METADATA_FIELD} to Spark fields that were
+   * Arrow {@code FixedSizeList<Float32|Float64, dim>} in the Lance file.
+   * {@code LanceArrowUtils.fromArrowSchema} drops all field metadata, so without this
+   * step VECTOR columns are indistinguishable from plain arrays.
    *
-   * <p>Only top-level fields are inspected; nested struct children are not recursed into.
+   * <p>Only top-level FLOAT/DOUBLE fields are inspected; nested structs are not recursed.
    *
-   * <p>Only FLOAT and DOUBLE element types are recognized, matching what the Lance write
-   * path can produce today. Any other Arrow type (including non-FixedSizeList or
-   * FixedSizeList of non-floating-point children) is passed through unchanged.
-   *
-   * @param arrowSchema     the original Arrow schema read from the Lance file
-   * @param convertedSpark  the StructType produced by {@code LanceArrowUtils.fromArrowSchema}
-   *                        (must have the same field count and order as {@code arrowSchema})
-   * @return a new StructType with VECTOR metadata restored on eligible fields
+   * @param arrowSchema     original Arrow schema from the Lance file
+   * @param convertedSpark  Spark schema from {@code LanceArrowUtils.fromArrowSchema}
+   *                        (same field count and order as {@code arrowSchema})
+   * @return StructType with VECTOR metadata restored on eligible fields
    */
   public static StructType restoreVectorMetadataFromArrowSchema(
-      org.apache.arrow.vector.types.pojo.Schema arrowSchema, StructType convertedSpark) {
+          Schema arrowSchema, StructType convertedSpark) {
     if (arrowSchema == null || convertedSpark == null) {
       return convertedSpark;
     }
@@ -358,6 +336,6 @@ public final class VectorConversionUtils {
     } else {
       return null;
     }
-    return ((HoodieSchema.Vector) HoodieSchema.createVector(dim, elementType)).toTypeDescriptor();
+    return HoodieSchema.createVector(dim, elementType).toTypeDescriptor();
   }
 }

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/io/storage/VectorConversionUtils.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/io/storage/VectorConversionUtils.java
@@ -83,7 +83,11 @@ public final class VectorConversionUtils {
    * Builds the value string for {@link HoodieSchema#PARQUET_VECTOR_COLUMNS_METADATA_KEY}
    * from a Spark {@link StructType}, matching the comma-separated
    * {@code colName:VECTOR(dim[,elemType])} format produced on the Parquet path by
-   * {@link HoodieSchema#buildVectorColumnsMetadataValue}.
+   * {@link HoodieSchema#buildVectorColumnsMetadataValue(org.apache.hudi.common.schema.HoodieSchema)}.
+   *
+   * <p>This Spark-specific variant operates on {@link StructType} field metadata
+   * rather than {@link org.apache.hudi.common.schema.HoodieSchema}, since the Lance
+   * writer works with Spark schemas directly and does not convert to HoodieSchema.
    *
    * <p>Intended to be written as file-footer metadata (e.g. via
    * {@code LanceFileWriter.addSchemaMetadata}) so any reader can identify VECTOR
@@ -282,6 +286,8 @@ public final class VectorConversionUtils {
    * schema (which still carries the fixed-size-list intent and dimension) and re-attaches
    * {@link HoodieSchema#TYPE_METADATA_FIELD} = {@code "VECTOR(dim[, DOUBLE])"} to matching
    * fields so downstream VECTOR-aware code sees the same schema it would on the Parquet path.
+   *
+   * <p>Only top-level fields are inspected; nested struct children are not recursed into.
    *
    * <p>Only FLOAT and DOUBLE element types are recognized, matching what the Lance write
    * path can produce today. Any other Arrow type (including non-FixedSizeList or

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/io/storage/VectorConversionUtils.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/io/storage/VectorConversionUtils.java
@@ -283,10 +283,6 @@ public final class VectorConversionUtils {
     }
     List<Field> arrowFields = arrowSchema.getFields();
     StructField[] sparkFields = convertedSpark.fields();
-    if (arrowFields.size() != sparkFields.length) {
-      // Schemas desynchronized — bail out rather than risk corrupting metadata.
-      return convertedSpark;
-    }
     StructField[] newFields = new StructField[sparkFields.length];
     boolean anyChanged = false;
     for (int i = 0; i < sparkFields.length; i++) {

--- a/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/io/storage/row/HoodieRowParquetWriteSupport.java
+++ b/hudi-client/hudi-spark-client/src/main/java/org/apache/hudi/io/storage/row/HoodieRowParquetWriteSupport.java
@@ -167,7 +167,7 @@ public class HoodieRowParquetWriteSupport extends WriteSupport<InternalRow> {
     }
     String vectorMeta = HoodieSchema.buildVectorColumnsMetadataValue(schema);
     if (!vectorMeta.isEmpty()) {
-      metadata.put(HoodieSchema.PARQUET_VECTOR_COLUMNS_METADATA_KEY, vectorMeta);
+      metadata.put(HoodieSchema.VECTOR_COLUMNS_METADATA_KEY, vectorMeta);
     }
     Configuration configurationCopy = new Configuration(configuration);
     configurationCopy.set(AvroWriteSupport.WRITE_OLD_LIST_STRUCTURE, Boolean.toString(writeLegacyListFormat));

--- a/hudi-client/hudi-spark-client/src/main/scala/org/apache/hudi/SparkFileFormatInternalRowReaderContext.scala
+++ b/hudi-client/hudi-spark-client/src/main/scala/org/apache/hudi/SparkFileFormatInternalRowReaderContext.scala
@@ -83,8 +83,9 @@ class SparkFileFormatInternalRowReaderContext(baseFileReader: SparkColumnarFileR
 
     // Parquet stores VECTOR as FIXED_LEN_BYTE_ARRAY, so the reader needs BinaryType
     // and we decode back to ArrayType below. Lance returns ArrayType natively, so skip.
+    // Log files are always parquet regardless of the table's base-file format.
     val isLanceBaseFile = !FSUtils.isLogFile(filePath) &&
-      filePath.getName.endsWith(HoodieFileFormat.LANCE.getFileExtension)
+      tableConfig.getBaseFileFormat == HoodieFileFormat.LANCE
     val vectorColumnInfo: Map[Int, HoodieSchema.Vector] = if (isLanceBaseFile) {
       Map.empty
     } else {

--- a/hudi-client/hudi-spark-client/src/main/scala/org/apache/hudi/SparkFileFormatInternalRowReaderContext.scala
+++ b/hudi-client/hudi-spark-client/src/main/scala/org/apache/hudi/SparkFileFormatInternalRowReaderContext.scala
@@ -23,7 +23,7 @@ import org.apache.hadoop.conf.Configuration
 import org.apache.hudi.SparkFileFormatInternalRowReaderContext.{filterIsSafeForBootstrap, filterIsSafeForPrimaryKey, getAppliedRequiredSchema}
 import org.apache.hudi.common.engine.HoodieReaderContext
 import org.apache.hudi.common.fs.FSUtils
-import org.apache.hudi.common.model.HoodieRecord
+import org.apache.hudi.common.model.{HoodieFileFormat, HoodieRecord}
 import org.apache.hudi.common.schema.{HoodieSchema, HoodieSchemaUtils}
 import org.apache.hudi.common.table.HoodieTableConfig
 import org.apache.hudi.common.table.read.buffer.PositionBasedFileGroupRecordBuffer.ROW_INDEX_TEMPORARY_COLUMN_NAME
@@ -82,8 +82,18 @@ class SparkFileFormatInternalRowReaderContext(baseFileReader: SparkColumnarFileR
     val structType = HoodieInternalRowUtils.getCachedSchema(requiredSchema)
 
     // Detect VECTOR columns and replace with BinaryType for the Parquet reader
-    // (Parquet stores VECTOR as FIXED_LEN_BYTE_ARRAY which Spark maps to BinaryType)
-    val vectorColumnInfo = SparkFileFormatInternalRowReaderContext.detectVectorColumns(requiredSchema)
+    // (Parquet stores VECTOR as FIXED_LEN_BYTE_ARRAY which Spark maps to BinaryType).
+    // Lance stores vectors natively as Arrow FixedSizeList and returns them as ArrayType,
+    // so the BinaryType rewrite would cause an invalid Cast(ArrayType -> BinaryType) in
+    // the reader's projection — skip it for .lance base files. Hudi log files are always
+    // parquet-encoded, so we only need to special-case Lance base files here.
+    val isLanceBaseFile = !FSUtils.isLogFile(filePath) &&
+      filePath.getName.endsWith(HoodieFileFormat.LANCE.getFileExtension)
+    val vectorColumnInfo: Map[Int, HoodieSchema.Vector] = if (isLanceBaseFile) {
+      Map.empty
+    } else {
+      SparkFileFormatInternalRowReaderContext.detectVectorColumns(requiredSchema)
+    }
     val parquetReadStructType = if (vectorColumnInfo.nonEmpty) {
       SparkFileFormatInternalRowReaderContext.replaceVectorColumnsWithBinary(structType, vectorColumnInfo)
     } else {

--- a/hudi-client/hudi-spark-client/src/main/scala/org/apache/hudi/SparkFileFormatInternalRowReaderContext.scala
+++ b/hudi-client/hudi-spark-client/src/main/scala/org/apache/hudi/SparkFileFormatInternalRowReaderContext.scala
@@ -81,12 +81,8 @@ class SparkFileFormatInternalRowReaderContext(baseFileReader: SparkColumnarFileR
     }
     val structType = HoodieInternalRowUtils.getCachedSchema(requiredSchema)
 
-    // Detect VECTOR columns and replace with BinaryType for the Parquet reader
-    // (Parquet stores VECTOR as FIXED_LEN_BYTE_ARRAY which Spark maps to BinaryType).
-    // Lance stores vectors natively as Arrow FixedSizeList and returns them as ArrayType,
-    // so the BinaryType rewrite would cause an invalid Cast(ArrayType -> BinaryType) in
-    // the reader's projection — skip it for .lance base files. Hudi log files are always
-    // parquet-encoded, so we only need to special-case Lance base files here.
+    // Parquet stores VECTOR as FIXED_LEN_BYTE_ARRAY, so the reader needs BinaryType
+    // and we decode back to ArrayType below. Lance returns ArrayType natively, so skip.
     val isLanceBaseFile = !FSUtils.isLogFile(filePath) &&
       filePath.getName.endsWith(HoodieFileFormat.LANCE.getFileExtension)
     val vectorColumnInfo: Map[Int, HoodieSchema.Vector] = if (isLanceBaseFile) {

--- a/hudi-common/src/main/java/org/apache/hudi/common/schema/HoodieSchema.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/schema/HoodieSchema.java
@@ -209,39 +209,59 @@ public class HoodieSchema implements Serializable {
   public static final String PARQUET_ARRAY_AVRO = "." + ARRAY_LIST_ELEMENT;
 
   /**
-   * Parquet file-footer metadata key under which VECTOR column names and type descriptors
+   * Base-file footer metadata key under which VECTOR column names and type descriptors
    * are recorded. The value is a comma-separated list of {@code colName:VECTOR(dim[,elemType])}
    * entries, e.g. {@code "embedding:VECTOR(128),tags:VECTOR(64,INT8)"}.
    *
-   * <p>Stored as file-level key-value metadata (Parquet footer) so that any reader can
-   * identify vector columns without needing the Hudi schema store.
+   * <p>Stored as file-level key-value metadata (Parquet footer, Lance schema metadata)
+   * so that any reader can identify vector columns without needing the Hudi schema store.
    */
-  public static final String PARQUET_VECTOR_COLUMNS_METADATA_KEY = "hoodie.vector.columns";
+  public static final String VECTOR_COLUMNS_METADATA_KEY = "hoodie.vector.columns";
 
   /**
-   * Builds the value string for {@link #PARQUET_VECTOR_COLUMNS_METADATA_KEY}.
+   * Serializes a name-to-Vector map into the comma-separated
+   * {@code colName:VECTOR(dim[,elemType])} format used for {@link #VECTOR_COLUMNS_METADATA_KEY}.
+   *
+   * <p>This is the single canonical serializer — all format-specific code (Parquet, Lance)
+   * should build the map from their respective schema representation and delegate here.
+   *
+   * @param vectorColumns ordered map of field name to Vector descriptor (iteration order is preserved)
+   * @return comma-separated descriptor list, or empty string if the map is null or empty
+   */
+  public static String serializeVectorColumnsMetadata(java.util.Map<String, Vector> vectorColumns) {
+    if (vectorColumns == null || vectorColumns.isEmpty()) {
+      return "";
+    }
+    StringBuilder sb = new StringBuilder();
+    for (java.util.Map.Entry<String, Vector> entry : vectorColumns.entrySet()) {
+      if (sb.length() > 0) {
+        sb.append(',');
+      }
+      sb.append(entry.getKey()).append(':').append(entry.getValue().toTypeDescriptor());
+    }
+    return sb.toString();
+  }
+
+  /**
+   * Builds the value string for {@link #VECTOR_COLUMNS_METADATA_KEY} from a {@link HoodieSchema}.
    *
    * @param schema a HoodieSchema of type RECORD (or null)
    * @return comma-separated {@code colName:VECTOR(dim[,elemType])} entries, or empty string
    *         if the schema is null or has no VECTOR columns
+   * @see #serializeVectorColumnsMetadata(java.util.Map)
    */
   public static String buildVectorColumnsMetadataValue(HoodieSchema schema) {
     if (schema == null || schema.isSchemaNull()) {
       return "";
     }
-    List<HoodieSchemaField> fields = schema.getFields();
-    StringBuilder sb = new StringBuilder();
-    for (HoodieSchemaField field : fields) {
+    java.util.LinkedHashMap<String, Vector> vectorColumns = new java.util.LinkedHashMap<>();
+    for (HoodieSchemaField field : schema.getFields()) {
       HoodieSchema fieldSchema = field.schema().getNonNullType();
       if (fieldSchema.getType() == HoodieSchemaType.VECTOR) {
-        Vector vectorSchema = (Vector) fieldSchema;
-        if (sb.length() > 0) {
-          sb.append(',');
-        }
-        sb.append(field.name()).append(':').append(vectorSchema.toTypeDescriptor());
+        vectorColumns.put(field.name(), (Vector) fieldSchema);
       }
     }
-    return sb.toString();
+    return serializeVectorColumnsMetadata(vectorColumns);
   }
 
   private Schema avroSchema;

--- a/hudi-hadoop-common/src/main/java/org/apache/hudi/avro/HoodieAvroWriteSupport.java
+++ b/hudi-hadoop-common/src/main/java/org/apache/hudi/avro/HoodieAvroWriteSupport.java
@@ -50,7 +50,7 @@ public class HoodieAvroWriteSupport<T> extends AvroWriteSupport<T> {
     this.properties = properties;
     String vectorMeta = HoodieSchema.buildVectorColumnsMetadataValue(hoodieSchema);
     if (!vectorMeta.isEmpty()) {
-      footerMetadata.put(HoodieSchema.PARQUET_VECTOR_COLUMNS_METADATA_KEY, vectorMeta);
+      footerMetadata.put(HoodieSchema.VECTOR_COLUMNS_METADATA_KEY, vectorMeta);
     }
   }
 

--- a/hudi-hadoop-common/src/main/java/org/apache/hudi/io/lance/HoodieBaseLanceWriter.java
+++ b/hudi-hadoop-common/src/main/java/org/apache/hudi/io/lance/HoodieBaseLanceWriter.java
@@ -37,6 +37,7 @@ import javax.annotation.concurrent.NotThreadSafe;
 
 import java.io.Closeable;
 import java.io.IOException;
+import java.util.Collections;
 import java.util.Map;
 
 /**
@@ -116,7 +117,7 @@ public abstract class HoodieBaseLanceWriter<R, K extends Comparable<K>> implemen
    * @return map of footer metadata key-value pairs, or empty map for none
    */
   protected Map<String, String> additionalSchemaMetadata() {
-    return java.util.Collections.emptyMap();
+    return Collections.emptyMap();
   }
 
   /**

--- a/hudi-hadoop-common/src/main/java/org/apache/hudi/io/lance/HoodieBaseLanceWriter.java
+++ b/hudi-hadoop-common/src/main/java/org/apache/hudi/io/lance/HoodieBaseLanceWriter.java
@@ -177,17 +177,18 @@ public abstract class HoodieBaseLanceWriter<R, K extends Comparable<K>> implemen
         writer.write(root);
       }
 
-      // Finalize and write bloom filter metadata
-      if (writer != null && bloomFilterWriteSupportOpt.isPresent()) {
-        Map<String, String> metadata = bloomFilterWriteSupportOpt.get().finalizeMetadata();
-        if (!metadata.isEmpty()) {
-          writer.addSchemaMetadata(metadata);
-        }
-      }
-
-      // Allow subclasses to contribute additional footer key-value metadata
-      // (e.g. Spark writer emits `hoodie.vector.columns` for forward-compat read).
       if (writer != null) {
+        // Finalize and write bloom filter metadata
+        if (bloomFilterWriteSupportOpt.isPresent()) {
+          Map<String, String> metadata = bloomFilterWriteSupportOpt.get().finalizeMetadata();
+          if (!metadata.isEmpty()) {
+            writer.addSchemaMetadata(metadata);
+          }
+        }
+
+        // Allow subclasses to contribute additional footer key-value metadata
+        // (e.g. Spark writer emits `hoodie.vector.columns` for forward-compat read).
+        // Called unconditionally; returns an empty map when no VECTOR columns are present.
         Map<String, String> extra = additionalSchemaMetadata();
         if (extra != null && !extra.isEmpty()) {
           writer.addSchemaMetadata(extra);

--- a/hudi-hadoop-common/src/main/java/org/apache/hudi/io/lance/HoodieBaseLanceWriter.java
+++ b/hudi-hadoop-common/src/main/java/org/apache/hudi/io/lance/HoodieBaseLanceWriter.java
@@ -106,6 +106,20 @@ public abstract class HoodieBaseLanceWriter<R, K extends Comparable<K>> implemen
   protected abstract Schema getArrowSchema();
 
   /**
+   * Subclass hook for emitting additional Lance file-footer key-value metadata
+   * alongside any bloom-filter entries. Called once during {@link #close()}.
+   *
+   * <p>Default implementation returns an empty map. Overriders should return a
+   * fresh map; the caller does not retain a reference. Colliding keys are
+   * overwritten per {@code LanceFileWriter.addSchemaMetadata} semantics.
+   *
+   * @return map of footer metadata key-value pairs, or empty map for none
+   */
+  protected Map<String, String> additionalSchemaMetadata() {
+    return java.util.Collections.emptyMap();
+  }
+
+  /**
    * Write a single record. Records are buffered and flushed in batches.
    *
    * @param record Record to write
@@ -168,6 +182,15 @@ public abstract class HoodieBaseLanceWriter<R, K extends Comparable<K>> implemen
         Map<String, String> metadata = bloomFilterWriteSupportOpt.get().finalizeMetadata();
         if (!metadata.isEmpty()) {
           writer.addSchemaMetadata(metadata);
+        }
+      }
+
+      // Allow subclasses to contribute additional footer key-value metadata
+      // (e.g. Spark writer emits `hoodie.vector.columns` for forward-compat read).
+      if (writer != null) {
+        Map<String, String> extra = additionalSchemaMetadata();
+        if (extra != null && !extra.isEmpty()) {
+          writer.addSchemaMetadata(extra);
         }
       }
     } catch (Exception e) {

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/execution/datasources/lance/SparkLanceReaderBase.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/execution/datasources/lance/SparkLanceReaderBase.scala
@@ -23,7 +23,7 @@ import org.apache.hudi.SparkAdapterSupport.sparkAdapter
 import org.apache.hudi.common.util
 import org.apache.hudi.internal.schema.InternalSchema
 import org.apache.hudi.io.memory.HoodieArrowAllocator
-import org.apache.hudi.io.storage.{HoodieSparkLanceReader, LanceRecordIterator}
+import org.apache.hudi.io.storage.{HoodieSparkLanceReader, LanceRecordIterator, VectorConversionUtils}
 import org.apache.hudi.storage.StorageConfiguration
 
 import org.apache.hadoop.conf.Configuration
@@ -90,9 +90,13 @@ class SparkLanceReaderBase(enableVectorizedReader: Boolean) extends SparkColumna
         // Open Lance file reader
         val lanceReader = LanceFileReader.open(filePath, allocator)
 
-        // Get schema from Lance file
+        // Get schema from Lance file. lance-spark drops all Arrow field metadata during
+        // StructType conversion, so re-attach Hudi's VECTOR logical-type descriptor onto
+        // fields that are encoded as Arrow FixedSizeList<Float32|Float64, dim>. This mirrors
+        // the Parquet read path, where VECTOR metadata is restored from footer entries.
         val arrowSchema = lanceReader.schema()
-        val fileSchema = LanceArrowUtils.fromArrowSchema(arrowSchema)
+        val fileSchema = VectorConversionUtils.restoreVectorMetadataFromArrowSchema(
+          arrowSchema, LanceArrowUtils.fromArrowSchema(arrowSchema))
 
         // Build type change info for schema evolution
         val (implicitTypeChangeInfo, sparkRequestSchema) =

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/HoodieFileGroupReaderBasedFileFormat.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/HoodieFileGroupReaderBasedFileFormat.scala
@@ -442,11 +442,16 @@ class HoodieFileGroupReaderBasedFileFormat(tablePath: String,
    * @return (modified schema with BinaryType for vectors, vector column ordinal map)
    */
   private def withVectorRewrite(schema: StructType): (StructType, Map[Int, HoodieSchema.Vector]) = {
+    // Only Parquet needs the BinaryType rewrite; other formats (Lance) return ArrayType natively.
     if (hoodieFileFormat != HoodieFileFormat.PARQUET) {
       (schema, Map.empty[Int, HoodieSchema.Vector])
     } else {
       val vecs = detectVectorColumns(schema)
-      if (vecs.nonEmpty) (replaceVectorFieldsWithBinary(schema, vecs), vecs) else (schema, vecs)
+      if (vecs.isEmpty) {
+        (schema, vecs)
+      } else {
+        (replaceVectorFieldsWithBinary(schema, vecs), vecs)
+      }
     }
   }
 

--- a/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/HoodieFileGroupReaderBasedFileFormat.scala
+++ b/hudi-spark-datasource/hudi-spark-common/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/HoodieFileGroupReaderBasedFileFormat.scala
@@ -431,11 +431,23 @@ class HoodieFileGroupReaderBasedFileFormat(tablePath: String,
 
   /**
    * Detects vector columns and replaces them with BinaryType in one step.
+   *
+   * <p>The BinaryType rewrite is Parquet-specific: Hudi stores VECTOR columns as
+   * FIXED_LEN_BYTE_ARRAY in Parquet, so the reader must see BinaryType and the raw
+   * bytes are post-converted back to ArrayType. Other formats (e.g. Lance) encode
+   * vectors natively as Arrow FixedSizeList and return ArrayType directly, so the
+   * rewrite would introduce a spurious ArrayType→BinaryType cast during schema
+   * evolution and break the read. Skip the rewrite for those formats.
+   *
    * @return (modified schema with BinaryType for vectors, vector column ordinal map)
    */
   private def withVectorRewrite(schema: StructType): (StructType, Map[Int, HoodieSchema.Vector]) = {
-    val vecs = detectVectorColumns(schema)
-    if (vecs.nonEmpty) (replaceVectorFieldsWithBinary(schema, vecs), vecs) else (schema, vecs)
+    if (hoodieFileFormat != HoodieFileFormat.PARQUET) {
+      (schema, Map.empty[Int, HoodieSchema.Vector])
+    } else {
+      val vecs = detectVectorColumns(schema)
+      if (vecs.nonEmpty) (replaceVectorFieldsWithBinary(schema, vecs), vecs) else (schema, vecs)
+    }
   }
 
   /**

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestLanceDataSource.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestLanceDataSource.scala
@@ -913,6 +913,171 @@ class TestLanceDataSource extends HoodieSparkClientTestBase {
       s"embedding:VECTOR($embeddingDim),features:VECTOR($featuresDim, DOUBLE)")
   }
 
+  @ParameterizedTest
+  @EnumSource(value = classOf[HoodieTableType])
+  def testNullableVectorRoundTrip(tableType: HoodieTableType): Unit = {
+    val tableName = s"test_lance_vec_nullable_${tableType.name().toLowerCase}"
+    val tablePath = s"$basePath/$tableName"
+
+    val dim = 3
+    val schema = StructType(Seq(
+      StructField("id", IntegerType, nullable = false),
+      StructField("embedding",
+        ArrayType(FloatType, containsNull = false),
+        nullable = true,
+        vectorMetadata(s"VECTOR($dim)"))
+    ))
+    val data = Seq(
+      Row(1, Array(1.0f, 2.0f, 3.0f)),
+      Row(2, null),
+      Row(3, Array(7.0f, 8.0f, 9.0f))
+    )
+    val df = spark.createDataFrame(spark.sparkContext.parallelize(data), schema).coalesce(1)
+
+    writeDataframe(tableType, tableName, tablePath, df, saveMode = SaveMode.Overwrite)
+
+    val readDf = spark.read.format("hudi").load(tablePath).select("id", "embedding")
+    assertHudiTypeMetadata(readDf.schema("embedding"), s"VECTOR($dim)")
+
+    val rows = readDf.collect().sortBy(_.getInt(0))
+    assertEquals(3, rows.length)
+    assertEquals(Seq(1.0f, 2.0f, 3.0f), rows(0).getAs[Seq[Float]](1).toSeq)
+    assertTrue(rows(1).isNullAt(1), "Row with id=2 should have null embedding")
+    assertEquals(Seq(7.0f, 8.0f, 9.0f), rows(2).getAs[Seq[Float]](1).toSeq)
+  }
+
+  @ParameterizedTest
+  @EnumSource(value = classOf[HoodieTableType])
+  def testVectorMorUpdatePath(tableType: HoodieTableType): Unit = {
+    val tableName = s"test_lance_vec_update_${tableType.name().toLowerCase}"
+    val tablePath = s"$basePath/$tableName"
+
+    val dim = 3
+    val schema = StructType(Seq(
+      StructField("id", IntegerType, nullable = false),
+      StructField("name", StringType, nullable = false),
+      StructField("age", IntegerType, nullable = false),
+      StructField("embedding",
+        ArrayType(FloatType, containsNull = false),
+        nullable = false,
+        vectorMetadata(s"VECTOR($dim)"))
+    ))
+
+    // Initial insert
+    val data1 = Seq(
+      Row(1, "Alice", 30, Array(1.0f, 2.0f, 3.0f)),
+      Row(2, "Bob", 25, Array(4.0f, 5.0f, 6.0f)),
+      Row(3, "Charlie", 35, Array(7.0f, 8.0f, 9.0f))
+    )
+    val df1 = spark.createDataFrame(spark.sparkContext.parallelize(data1), schema).coalesce(1)
+    writeDataframe(tableType, tableName, tablePath, df1, saveMode = SaveMode.Overwrite, operation = Some("insert"))
+
+    // Upsert — update Bob's embedding
+    val data2 = Seq(
+      Row(2, "Bob", 40, Array(10.0f, 20.0f, 30.0f))
+    )
+    val df2 = spark.createDataFrame(spark.sparkContext.parallelize(data2), schema).coalesce(1)
+    writeDataframe(tableType, tableName, tablePath, df2, operation = Some("upsert"))
+
+    // Read merged result
+    val readDf = spark.read.format("hudi").load(tablePath).select("id", "name", "age", "embedding")
+    assertHudiTypeMetadata(readDf.schema("embedding"), s"VECTOR($dim)")
+
+    val rows = readDf.collect().sortBy(_.getInt(0))
+    assertEquals(3, rows.length)
+    assertEquals(Seq(1.0f, 2.0f, 3.0f), rows(0).getAs[Seq[Float]](3).toSeq)
+    assertEquals(Seq(10.0f, 20.0f, 30.0f), rows(1).getAs[Seq[Float]](3).toSeq)
+    assertEquals(40, rows(1).getInt(2), "Bob's age should be updated to 40")
+    assertEquals(Seq(7.0f, 8.0f, 9.0f), rows(2).getAs[Seq[Float]](3).toSeq)
+  }
+
+  @ParameterizedTest
+  @EnumSource(value = classOf[HoodieTableType])
+  def testVectorProjection(tableType: HoodieTableType): Unit = {
+    val tableName = s"test_lance_vec_proj_${tableType.name().toLowerCase}"
+    val tablePath = s"$basePath/$tableName"
+
+    val dim = 4
+    val schema = StructType(Seq(
+      StructField("id", IntegerType, nullable = false),
+      StructField("name", StringType, nullable = false),
+      StructField("embedding",
+        ArrayType(FloatType, containsNull = false),
+        nullable = false,
+        vectorMetadata(s"VECTOR($dim)"))
+    ))
+    val data = Seq(
+      Row(1, "Alice", Array(1.0f, 2.0f, 3.0f, 4.0f)),
+      Row(2, "Bob", Array(5.0f, 6.0f, 7.0f, 8.0f))
+    )
+    val df = spark.createDataFrame(spark.sparkContext.parallelize(data), schema).coalesce(1)
+    writeDataframe(tableType, tableName, tablePath, df, saveMode = SaveMode.Overwrite)
+
+    // Project only the vector column
+    val vecOnly = spark.read.format("hudi").load(tablePath).select("embedding")
+    assertEquals(1, vecOnly.schema.fields.length)
+    assertHudiTypeMetadata(vecOnly.schema("embedding"), s"VECTOR($dim)")
+    val vecRows = vecOnly.collect().map(_.getAs[Seq[Float]](0).toSeq).toSet
+    assertEquals(Set(Seq(1.0f, 2.0f, 3.0f, 4.0f), Seq(5.0f, 6.0f, 7.0f, 8.0f)), vecRows)
+
+    // Project vector alongside Hudi metadata columns
+    val withMeta = spark.read.format("hudi").load(tablePath)
+      .select("_hoodie_record_key", "embedding")
+    assertEquals(2, withMeta.schema.fields.length)
+    assertHudiTypeMetadata(withMeta.schema("embedding"), s"VECTOR($dim)")
+    val metaRows = withMeta.collect().map(r =>
+      r.getString(0) -> r.getAs[Seq[Float]](1).toSeq).toMap
+    assertEquals(Seq(1.0f, 2.0f, 3.0f, 4.0f), metaRows("1"))
+    assertEquals(Seq(5.0f, 6.0f, 7.0f, 8.0f), metaRows("2"))
+  }
+
+  @ParameterizedTest
+  @EnumSource(value = classOf[HoodieTableType])
+  def testVectorPartitionedTable(tableType: HoodieTableType): Unit = {
+    val tableName = s"test_lance_vec_part_${tableType.name().toLowerCase}"
+    val tablePath = s"$basePath/$tableName"
+
+    val dim = 3
+    val schema = StructType(Seq(
+      StructField("id", IntegerType, nullable = false),
+      StructField("department", StringType, nullable = false),
+      StructField("age", IntegerType, nullable = false),
+      StructField("embedding",
+        ArrayType(FloatType, containsNull = false),
+        nullable = false,
+        vectorMetadata(s"VECTOR($dim)"))
+    ))
+    val data = Seq(
+      Row(1, "engineering", 30, Array(1.0f, 2.0f, 3.0f)),
+      Row(2, "sales", 25, Array(4.0f, 5.0f, 6.0f)),
+      Row(3, "engineering", 35, Array(7.0f, 8.0f, 9.0f))
+    )
+    val df = spark.createDataFrame(spark.sparkContext.parallelize(data), schema).coalesce(1)
+    writeDataframe(tableType, tableName, tablePath, df, saveMode = SaveMode.Overwrite,
+      extraOptions = Map(PARTITIONPATH_FIELD.key() -> "department"))
+
+    // Read back all partitions
+    val readDf = spark.read.format("hudi").load(tablePath).select("id", "department", "embedding")
+    assertHudiTypeMetadata(readDf.schema("embedding"), s"VECTOR($dim)")
+
+    val rows = readDf.collect().sortBy(_.getInt(0))
+    assertEquals(3, rows.length)
+    assertEquals(Seq(1.0f, 2.0f, 3.0f), rows(0).getAs[Seq[Float]](2).toSeq)
+    assertEquals("engineering", rows(0).getString(1))
+    assertEquals(Seq(4.0f, 5.0f, 6.0f), rows(1).getAs[Seq[Float]](2).toSeq)
+    assertEquals("sales", rows(1).getString(1))
+    assertEquals(Seq(7.0f, 8.0f, 9.0f), rows(2).getAs[Seq[Float]](2).toSeq)
+    assertEquals("engineering", rows(2).getString(1))
+
+    // Read a single partition
+    val engDf = spark.read.format("hudi").load(tablePath)
+      .filter("department = 'engineering'").select("id", "embedding")
+    val engRows = engDf.collect().sortBy(_.getInt(0))
+    assertEquals(2, engRows.length)
+    assertEquals(Seq(1.0f, 2.0f, 3.0f), engRows(0).getAs[Seq[Float]](1).toSeq)
+    assertEquals(Seq(7.0f, 8.0f, 9.0f), engRows(1).getAs[Seq[Float]](1).toSeq)
+  }
+
   private def assertHudiTypeMetadata(field: StructField, expectedDescriptor: String): Unit = {
     assertTrue(field.metadata.contains(HoodieSchema.TYPE_METADATA_FIELD),
       s"Expected field ${field.name} to carry ${HoodieSchema.TYPE_METADATA_FIELD} metadata after read")

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestLanceDataSource.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestLanceDataSource.scala
@@ -819,7 +819,7 @@ class TestLanceDataSource extends HoodieSparkClientTestBase {
     assertHudiTypeMetadata(readDf.schema("embedding"), s"VECTOR($dim)")
 
     val actualByKey = readDf.collect().map(r =>
-      r.getInt(0) -> r.getAs[Seq[Float]](1).toSeq).toMap
+      r.getInt(0) -> r.getSeq[Float](1).toSeq).toMap
     val expectedByKey = data.map(r =>
       r.getInt(0) -> r.getAs[Array[Float]](1).toSeq).toMap
     assertEquals(expectedByKey, actualByKey)
@@ -858,7 +858,7 @@ class TestLanceDataSource extends HoodieSparkClientTestBase {
     assertHudiTypeMetadata(readDf.schema("embedding"), s"VECTOR($dim, DOUBLE)")
 
     val actualByKey = readDf.collect().map(r =>
-      r.getInt(0) -> r.getAs[Seq[Double]](1).toSeq).toMap
+      r.getInt(0) -> r.getSeq[Double](1).toSeq).toMap
     val expectedByKey = data.map(r =>
       r.getInt(0) -> r.getAs[Array[Double]](1).toSeq).toMap
     assertEquals(expectedByKey, actualByKey)
@@ -896,7 +896,7 @@ class TestLanceDataSource extends HoodieSparkClientTestBase {
 
     val readDf = spark.read.format("hudi").load(tablePath).select("id", "embedding", "features")
     val rows = readDf.collect().map { r =>
-      (r.getInt(0), r.getAs[Seq[Float]](1).toSeq, r.getAs[Seq[Double]](2).toSeq)
+      (r.getInt(0), r.getSeq[Float](1).toSeq, r.getSeq[Double](2).toSeq)
     }.toSet
     val expected = data.map { r =>
       (r.getInt(0),
@@ -941,9 +941,9 @@ class TestLanceDataSource extends HoodieSparkClientTestBase {
 
     val rows = readDf.collect().sortBy(_.getInt(0))
     assertEquals(3, rows.length)
-    assertEquals(Seq(1.0f, 2.0f, 3.0f), rows(0).getAs[Seq[Float]](1).toSeq)
+    assertEquals(Seq(1.0f, 2.0f, 3.0f), rows(0).getSeq[Float](1).toSeq)
     assertTrue(rows(1).isNullAt(1), "Row with id=2 should have null embedding")
-    assertEquals(Seq(7.0f, 8.0f, 9.0f), rows(2).getAs[Seq[Float]](1).toSeq)
+    assertEquals(Seq(7.0f, 8.0f, 9.0f), rows(2).getSeq[Float](1).toSeq)
   }
 
   @ParameterizedTest
@@ -985,10 +985,10 @@ class TestLanceDataSource extends HoodieSparkClientTestBase {
 
     val rows = readDf.collect().sortBy(_.getInt(0))
     assertEquals(3, rows.length)
-    assertEquals(Seq(1.0f, 2.0f, 3.0f), rows(0).getAs[Seq[Float]](3).toSeq)
-    assertEquals(Seq(10.0f, 20.0f, 30.0f), rows(1).getAs[Seq[Float]](3).toSeq)
+    assertEquals(Seq(1.0f, 2.0f, 3.0f), rows(0).getSeq[Float](3).toSeq)
+    assertEquals(Seq(10.0f, 20.0f, 30.0f), rows(1).getSeq[Float](3).toSeq)
     assertEquals(40, rows(1).getInt(2), "Bob's age should be updated to 40")
-    assertEquals(Seq(7.0f, 8.0f, 9.0f), rows(2).getAs[Seq[Float]](3).toSeq)
+    assertEquals(Seq(7.0f, 8.0f, 9.0f), rows(2).getSeq[Float](3).toSeq)
   }
 
   @ParameterizedTest
@@ -1017,7 +1017,7 @@ class TestLanceDataSource extends HoodieSparkClientTestBase {
     val vecOnly = spark.read.format("hudi").load(tablePath).select("embedding")
     assertEquals(1, vecOnly.schema.fields.length)
     assertHudiTypeMetadata(vecOnly.schema("embedding"), s"VECTOR($dim)")
-    val vecRows = vecOnly.collect().map(_.getAs[Seq[Float]](0).toSeq).toSet
+    val vecRows = vecOnly.collect().map(_.getSeq[Float](0).toSeq).toSet
     assertEquals(Set(Seq(1.0f, 2.0f, 3.0f, 4.0f), Seq(5.0f, 6.0f, 7.0f, 8.0f)), vecRows)
 
     // Project vector alongside Hudi metadata columns
@@ -1026,7 +1026,7 @@ class TestLanceDataSource extends HoodieSparkClientTestBase {
     assertEquals(2, withMeta.schema.fields.length)
     assertHudiTypeMetadata(withMeta.schema("embedding"), s"VECTOR($dim)")
     val metaRows = withMeta.collect().map(r =>
-      r.getString(0) -> r.getAs[Seq[Float]](1).toSeq).toMap
+      r.getString(0) -> r.getSeq[Float](1).toSeq).toMap
     assertEquals(Seq(1.0f, 2.0f, 3.0f, 4.0f), metaRows("1"))
     assertEquals(Seq(5.0f, 6.0f, 7.0f, 8.0f), metaRows("2"))
   }
@@ -1062,11 +1062,11 @@ class TestLanceDataSource extends HoodieSparkClientTestBase {
 
     val rows = readDf.collect().sortBy(_.getInt(0))
     assertEquals(3, rows.length)
-    assertEquals(Seq(1.0f, 2.0f, 3.0f), rows(0).getAs[Seq[Float]](2).toSeq)
+    assertEquals(Seq(1.0f, 2.0f, 3.0f), rows(0).getSeq[Float](2).toSeq)
     assertEquals("engineering", rows(0).getString(1))
-    assertEquals(Seq(4.0f, 5.0f, 6.0f), rows(1).getAs[Seq[Float]](2).toSeq)
+    assertEquals(Seq(4.0f, 5.0f, 6.0f), rows(1).getSeq[Float](2).toSeq)
     assertEquals("sales", rows(1).getString(1))
-    assertEquals(Seq(7.0f, 8.0f, 9.0f), rows(2).getAs[Seq[Float]](2).toSeq)
+    assertEquals(Seq(7.0f, 8.0f, 9.0f), rows(2).getSeq[Float](2).toSeq)
     assertEquals("engineering", rows(2).getString(1))
 
     // Read a single partition
@@ -1074,8 +1074,8 @@ class TestLanceDataSource extends HoodieSparkClientTestBase {
       .filter("department = 'engineering'").select("id", "embedding")
     val engRows = engDf.collect().sortBy(_.getInt(0))
     assertEquals(2, engRows.length)
-    assertEquals(Seq(1.0f, 2.0f, 3.0f), engRows(0).getAs[Seq[Float]](1).toSeq)
-    assertEquals(Seq(7.0f, 8.0f, 9.0f), engRows(1).getAs[Seq[Float]](1).toSeq)
+    assertEquals(Seq(1.0f, 2.0f, 3.0f), engRows(0).getSeq[Float](1).toSeq)
+    assertEquals(Seq(7.0f, 8.0f, 9.0f), engRows(1).getSeq[Float](1).toSeq)
   }
 
   private def assertHudiTypeMetadata(field: StructField, expectedDescriptor: String): Unit = {

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestLanceDataSource.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestLanceDataSource.scala
@@ -22,6 +22,7 @@ import org.apache.hudi.DefaultSparkRecordMerger
 import org.apache.hudi.common.config.{HoodieCommonConfig, HoodieMetadataConfig}
 import org.apache.hudi.common.engine.HoodieLocalEngineContext
 import org.apache.hudi.common.model.HoodieTableType
+import org.apache.hudi.common.schema.HoodieSchema
 import org.apache.hudi.common.table.{HoodieTableConfig, HoodieTableMetaClient}
 import org.apache.hudi.common.table.view.{FileSystemViewManager, FileSystemViewStorageConfig}
 import org.apache.hudi.common.testutils.HoodieTestUtils
@@ -30,12 +31,16 @@ import org.apache.hudi.io.storage.HoodieSparkLanceReader
 import org.apache.hudi.storage.StoragePath
 import org.apache.hudi.testutils.HoodieSparkClientTestBase
 
-import org.apache.spark.sql.{DataFrame, SaveMode, SparkSession}
+import org.apache.arrow.memory.RootAllocator
+import org.apache.arrow.vector.types.pojo.ArrowType
+import org.apache.spark.sql.{DataFrame, Row, SaveMode, SparkSession}
+import org.apache.spark.sql.types._
 import org.junit.jupiter.api.{AfterEach, BeforeEach}
 import org.junit.jupiter.api.Assertions.{assertEquals, assertFalse, assertNotNull, assertTrue}
 import org.junit.jupiter.api.condition.DisabledIfSystemProperty
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.EnumSource
+import org.lance.file.LanceFileReader
 
 import java.util.stream.Collectors
 
@@ -782,6 +787,175 @@ class TestLanceDataSource extends HoodieSparkClientTestBase {
       }
     }
     fsView.close()
+  }
+
+  @ParameterizedTest
+  @EnumSource(value = classOf[HoodieTableType])
+  def testFloatVectorRoundTrip(tableType: HoodieTableType): Unit = {
+    val tableName = s"test_lance_vec_f32_${tableType.name().toLowerCase}"
+    val tablePath = s"$basePath/$tableName"
+
+    val dim = 4
+    val schema = StructType(Seq(
+      StructField("id", IntegerType, nullable = false),
+      StructField("embedding",
+        ArrayType(FloatType, containsNull = false),
+        nullable = false,
+        vectorMetadata(s"VECTOR($dim)"))
+    ))
+    val data = Seq(
+      Row(1, Array(1.0f, 2.0f, 4.0f, 8.0f)),
+      Row(2, Array(0.5f, 0.25f, 0.125f, 0.0625f)),
+      Row(3, Array(-1.0f, -2.0f, -4.0f, -8.0f))
+    )
+    val df = spark.createDataFrame(spark.sparkContext.parallelize(data), schema).coalesce(1)
+
+    writeDataframe(tableType, tableName, tablePath, df, saveMode = SaveMode.Overwrite)
+
+    val readDf = spark.read.format("hudi").load(tablePath).select("id", "embedding")
+    assertEquals(
+      ArrayType(FloatType, containsNull = false),
+      readDf.schema("embedding").dataType)
+
+    val actualByKey = readDf.collect().map(r =>
+      r.getInt(0) -> r.getAs[Seq[Float]](1).toSeq).toMap
+    val expectedByKey = data.map(r =>
+      r.getInt(0) -> r.getAs[Array[Float]](1).toSeq).toMap
+    assertEquals(expectedByKey, actualByKey)
+
+    assertLanceFieldIsFixedSizeList(tablePath, "embedding", dim)
+  }
+
+  @ParameterizedTest
+  @EnumSource(value = classOf[HoodieTableType])
+  def testDoubleVectorRoundTrip(tableType: HoodieTableType): Unit = {
+    val tableName = s"test_lance_vec_f64_${tableType.name().toLowerCase}"
+    val tablePath = s"$basePath/$tableName"
+
+    val dim = 4
+    val schema = StructType(Seq(
+      StructField("id", IntegerType, nullable = false),
+      StructField("embedding",
+        ArrayType(DoubleType, containsNull = false),
+        nullable = false,
+        vectorMetadata(s"VECTOR($dim, DOUBLE)"))
+    ))
+    val data = Seq(
+      Row(1, Array(1.0d, 2.0d, 4.0d, 8.0d)),
+      Row(2, Array(0.5d, 0.25d, 0.125d, 0.0625d)),
+      Row(3, Array(-1.0d, -2.0d, -4.0d, -8.0d))
+    )
+    val df = spark.createDataFrame(spark.sparkContext.parallelize(data), schema).coalesce(1)
+
+    writeDataframe(tableType, tableName, tablePath, df, saveMode = SaveMode.Overwrite)
+
+    val readDf = spark.read.format("hudi").load(tablePath).select("id", "embedding")
+    assertEquals(
+      ArrayType(DoubleType, containsNull = false),
+      readDf.schema("embedding").dataType)
+
+    val actualByKey = readDf.collect().map(r =>
+      r.getInt(0) -> r.getAs[Seq[Double]](1).toSeq).toMap
+    val expectedByKey = data.map(r =>
+      r.getInt(0) -> r.getAs[Array[Double]](1).toSeq).toMap
+    assertEquals(expectedByKey, actualByKey)
+
+    assertLanceFieldIsFixedSizeList(tablePath, "embedding", dim)
+  }
+
+  @ParameterizedTest
+  @EnumSource(value = classOf[HoodieTableType])
+  def testMultipleVectorColumns(tableType: HoodieTableType): Unit = {
+    val tableName = s"test_lance_vec_multi_${tableType.name().toLowerCase}"
+    val tablePath = s"$basePath/$tableName"
+
+    val embeddingDim = 3
+    val featuresDim = 2
+    val schema = StructType(Seq(
+      StructField("id", IntegerType, nullable = false),
+      StructField("embedding",
+        ArrayType(FloatType, containsNull = false),
+        nullable = false,
+        vectorMetadata(s"VECTOR($embeddingDim)")),
+      StructField("features",
+        ArrayType(DoubleType, containsNull = false),
+        nullable = false,
+        vectorMetadata(s"VECTOR($featuresDim, DOUBLE)"))
+    ))
+    val data = Seq(
+      Row(1, Array(1.0f, 2.0f, 3.0f), Array(10.0d, 20.0d)),
+      Row(2, Array(4.0f, 5.0f, 6.0f), Array(30.0d, 40.0d))
+    )
+    val df = spark.createDataFrame(spark.sparkContext.parallelize(data), schema).coalesce(1)
+
+    writeDataframe(tableType, tableName, tablePath, df, saveMode = SaveMode.Overwrite)
+
+    val readDf = spark.read.format("hudi").load(tablePath).select("id", "embedding", "features")
+    val rows = readDf.collect().map { r =>
+      (r.getInt(0), r.getAs[Seq[Float]](1).toSeq, r.getAs[Seq[Double]](2).toSeq)
+    }.toSet
+    val expected = data.map { r =>
+      (r.getInt(0),
+        r.getAs[Array[Float]](1).toSeq,
+        r.getAs[Array[Double]](2).toSeq)
+    }.toSet
+    assertEquals(expected, rows)
+
+    assertLanceFieldIsFixedSizeList(tablePath, "embedding", embeddingDim)
+    assertLanceFieldIsFixedSizeList(tablePath, "features", featuresDim)
+  }
+
+  private def vectorMetadata(descriptor: String): Metadata =
+    new MetadataBuilder().putString(HoodieSchema.TYPE_METADATA_FIELD, descriptor).build()
+
+  /**
+   * Opens the raw Lance base file(s) for the given Hudi table and asserts that the
+   * named field is encoded as an Arrow FixedSizeList with the expected listSize.
+   * This proves that the write path used Lance's native vector column encoding
+   * rather than a plain variable-length list.
+   */
+  private def assertLanceFieldIsFixedSizeList(tablePath: String, fieldName: String, expectedDim: Int): Unit = {
+    val metaClient = HoodieTableMetaClient.builder()
+      .setConf(HoodieTestUtils.getDefaultStorageConf)
+      .setBasePath(tablePath)
+      .build()
+    val engineContext = new HoodieLocalEngineContext(metaClient.getStorageConf)
+    val metadataConfig = HoodieMetadataConfig.newBuilder.build
+    val viewManager = FileSystemViewManager.createViewManager(
+      engineContext, metadataConfig, FileSystemViewStorageConfig.newBuilder.build,
+      HoodieCommonConfig.newBuilder.build,
+      (mc: HoodieTableMetaClient) => metaClient.getTableFormat
+        .getMetadataFactory.create(engineContext, mc.getStorage, metadataConfig, tablePath))
+    val fsView = viewManager.getFileSystemView(metaClient)
+    try {
+      val baseFiles = fsView.getLatestBaseFiles("")
+        .collect(Collectors.toList[org.apache.hudi.common.model.HoodieBaseFile])
+      assertTrue(baseFiles.size() > 0, "Expected at least one Lance base file")
+      val allocator = new RootAllocator()
+      try {
+        baseFiles.asScala.foreach { bf =>
+          val reader = LanceFileReader.open(bf.getPath, allocator)
+          try {
+            val field = reader.schema().findField(fieldName)
+            assertNotNull(field, s"Field $fieldName not found in Lance schema for ${bf.getPath}")
+            field.getType match {
+              case fsl: ArrowType.FixedSizeList =>
+                assertEquals(expectedDim, fsl.getListSize,
+                  s"Lance field $fieldName in ${bf.getPath} should be FixedSizeList of size $expectedDim")
+              case other =>
+                throw new AssertionError(
+                  s"Lance field $fieldName in ${bf.getPath} should be FixedSizeList but was $other")
+            }
+          } finally {
+            reader.close()
+          }
+        }
+      } finally {
+        allocator.close()
+      }
+    } finally {
+      fsView.close()
+    }
   }
 
   private def createDataFrame(records: Seq[(Int, String, Int, Double)]) = {

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestLanceDataSource.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestLanceDataSource.scala
@@ -21,7 +21,7 @@ import org.apache.hudi.DataSourceWriteOptions._
 import org.apache.hudi.DefaultSparkRecordMerger
 import org.apache.hudi.common.config.{HoodieCommonConfig, HoodieMetadataConfig}
 import org.apache.hudi.common.engine.HoodieLocalEngineContext
-import org.apache.hudi.common.model.HoodieTableType
+import org.apache.hudi.common.model.{HoodieBaseFile, HoodieTableType}
 import org.apache.hudi.common.schema.HoodieSchema
 import org.apache.hudi.common.table.{HoodieTableConfig, HoodieTableMetaClient}
 import org.apache.hudi.common.table.view.{FileSystemViewManager, FileSystemViewStorageConfig}
@@ -1088,23 +1088,8 @@ class TestLanceDataSource extends HoodieSparkClientTestBase {
   private def vectorMetadata(descriptor: String): Metadata =
     new MetadataBuilder().putString(HoodieSchema.TYPE_METADATA_FIELD, descriptor).build()
 
-  /**
-   * Opens the raw Lance base file(s) for the given Hudi table and asserts that the
-   * named field is encoded as an Arrow FixedSizeList with the expected listSize.
-   * This proves that the write path used Lance's native vector column encoding
-   * rather than a plain variable-length list.
-   */
-  /**
-   * Opens the raw Lance base file(s) for the given Hudi table and asserts that the
-   * Arrow schema's custom metadata carries `hoodie.vector.columns` with the given
-   * expected descriptor list. This is the forward-compat guard — future readers
-   * can recover the exact Hudi VECTOR descriptor from the footer without
-   * re-deriving from the Arrow type.
-   *
-   * <p>Descriptor list order is writer-determined (matches Spark schema field
-   * order), so callers must pass the entries in that order.
-   */
-  private def assertLanceFooterHasVectorColumns(tablePath: String, expected: String): Unit = {
+  /** Runs `check` against each Lance base file's Arrow schema. */
+  private def forEachLanceSchema(tablePath: String)(check: (org.apache.arrow.vector.types.pojo.Schema, String) => Unit): Unit = {
     val metaClient = HoodieTableMetaClient.builder()
       .setConf(HoodieTestUtils.getDefaultStorageConf)
       .setBasePath(tablePath)
@@ -1126,13 +1111,7 @@ class TestLanceDataSource extends HoodieSparkClientTestBase {
         baseFiles.asScala.foreach { bf =>
           val reader = LanceFileReader.open(bf.getPath, allocator)
           try {
-            val meta = reader.schema().getCustomMetadata
-            assertNotNull(meta, s"Lance footer metadata null for ${bf.getPath}")
-            val key = HoodieSchema.PARQUET_VECTOR_COLUMNS_METADATA_KEY
-            assertTrue(meta.containsKey(key),
-              s"Lance file ${bf.getPath} should have footer key $key, got keys ${meta.keySet()}")
-            assertEquals(expected, meta.get(key),
-              s"Lance file ${bf.getPath} footer $key mismatch")
+            check(reader.schema(), bf.getPath)
           } finally {
             reader.close()
           }
@@ -1145,47 +1124,29 @@ class TestLanceDataSource extends HoodieSparkClientTestBase {
     }
   }
 
+  private def assertLanceFooterHasVectorColumns(tablePath: String, expected: String): Unit = {
+    forEachLanceSchema(tablePath) { (schema, path) =>
+      val meta = schema.getCustomMetadata
+      assertNotNull(meta, s"Lance footer metadata null for $path")
+      val key = HoodieSchema.VECTOR_COLUMNS_METADATA_KEY
+      assertTrue(meta.containsKey(key),
+        s"Lance file $path should have footer key $key, got keys ${meta.keySet()}")
+      assertEquals(expected, meta.get(key), s"Lance file $path footer $key mismatch")
+    }
+  }
+
   private def assertLanceFieldIsFixedSizeList(tablePath: String, fieldName: String, expectedDim: Int): Unit = {
-    val metaClient = HoodieTableMetaClient.builder()
-      .setConf(HoodieTestUtils.getDefaultStorageConf)
-      .setBasePath(tablePath)
-      .build()
-    val engineContext = new HoodieLocalEngineContext(metaClient.getStorageConf)
-    val metadataConfig = HoodieMetadataConfig.newBuilder.build
-    val viewManager = FileSystemViewManager.createViewManager(
-      engineContext, metadataConfig, FileSystemViewStorageConfig.newBuilder.build,
-      HoodieCommonConfig.newBuilder.build,
-      (mc: HoodieTableMetaClient) => metaClient.getTableFormat
-        .getMetadataFactory.create(engineContext, mc.getStorage, metadataConfig, tablePath))
-    val fsView = viewManager.getFileSystemView(metaClient)
-    try {
-      val baseFiles = fsView.getLatestBaseFiles("")
-        .collect(Collectors.toList[org.apache.hudi.common.model.HoodieBaseFile])
-      assertTrue(baseFiles.size() > 0, "Expected at least one Lance base file")
-      val allocator = new RootAllocator()
-      try {
-        baseFiles.asScala.foreach { bf =>
-          val reader = LanceFileReader.open(bf.getPath, allocator)
-          try {
-            val field = reader.schema().findField(fieldName)
-            assertNotNull(field, s"Field $fieldName not found in Lance schema for ${bf.getPath}")
-            field.getType match {
-              case fsl: ArrowType.FixedSizeList =>
-                assertEquals(expectedDim, fsl.getListSize,
-                  s"Lance field $fieldName in ${bf.getPath} should be FixedSizeList of size $expectedDim")
-              case other =>
-                throw new AssertionError(
-                  s"Lance field $fieldName in ${bf.getPath} should be FixedSizeList but was $other")
-            }
-          } finally {
-            reader.close()
-          }
-        }
-      } finally {
-        allocator.close()
+    forEachLanceSchema(tablePath) { (schema, path) =>
+      val field = schema.findField(fieldName)
+      assertNotNull(field, s"Field $fieldName not found in Lance schema for $path")
+      field.getType match {
+        case fsl: ArrowType.FixedSizeList =>
+          assertEquals(expectedDim, fsl.getListSize,
+            s"Lance field $fieldName in $path should be FixedSizeList of size $expectedDim")
+        case other =>
+          throw new AssertionError(
+            s"Lance field $fieldName in $path should be FixedSizeList but was $other")
       }
-    } finally {
-      fsView.close()
     }
   }
 

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestLanceDataSource.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestLanceDataSource.scala
@@ -816,6 +816,7 @@ class TestLanceDataSource extends HoodieSparkClientTestBase {
     assertEquals(
       ArrayType(FloatType, containsNull = false),
       readDf.schema("embedding").dataType)
+    assertHudiTypeMetadata(readDf.schema("embedding"), s"VECTOR($dim)")
 
     val actualByKey = readDf.collect().map(r =>
       r.getInt(0) -> r.getAs[Seq[Float]](1).toSeq).toMap
@@ -853,6 +854,7 @@ class TestLanceDataSource extends HoodieSparkClientTestBase {
     assertEquals(
       ArrayType(DoubleType, containsNull = false),
       readDf.schema("embedding").dataType)
+    assertHudiTypeMetadata(readDf.schema("embedding"), s"VECTOR($dim, DOUBLE)")
 
     val actualByKey = readDf.collect().map(r =>
       r.getInt(0) -> r.getAs[Seq[Double]](1).toSeq).toMap
@@ -900,9 +902,18 @@ class TestLanceDataSource extends HoodieSparkClientTestBase {
         r.getAs[Array[Double]](2).toSeq)
     }.toSet
     assertEquals(expected, rows)
+    assertHudiTypeMetadata(readDf.schema("embedding"), s"VECTOR($embeddingDim)")
+    assertHudiTypeMetadata(readDf.schema("features"), s"VECTOR($featuresDim, DOUBLE)")
 
     assertLanceFieldIsFixedSizeList(tablePath, "embedding", embeddingDim)
     assertLanceFieldIsFixedSizeList(tablePath, "features", featuresDim)
+  }
+
+  private def assertHudiTypeMetadata(field: StructField, expectedDescriptor: String): Unit = {
+    assertTrue(field.metadata.contains(HoodieSchema.TYPE_METADATA_FIELD),
+      s"Expected field ${field.name} to carry ${HoodieSchema.TYPE_METADATA_FIELD} metadata after read")
+    assertEquals(expectedDescriptor, field.metadata.getString(HoodieSchema.TYPE_METADATA_FIELD),
+      s"Expected ${HoodieSchema.TYPE_METADATA_FIELD}=$expectedDescriptor on field ${field.name}")
   }
 
   private def vectorMetadata(descriptor: String): Metadata =

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestLanceDataSource.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestLanceDataSource.scala
@@ -825,6 +825,7 @@ class TestLanceDataSource extends HoodieSparkClientTestBase {
     assertEquals(expectedByKey, actualByKey)
 
     assertLanceFieldIsFixedSizeList(tablePath, "embedding", dim)
+    assertLanceFooterHasVectorColumns(tablePath, s"embedding:VECTOR($dim)")
   }
 
   @ParameterizedTest
@@ -863,6 +864,7 @@ class TestLanceDataSource extends HoodieSparkClientTestBase {
     assertEquals(expectedByKey, actualByKey)
 
     assertLanceFieldIsFixedSizeList(tablePath, "embedding", dim)
+    assertLanceFooterHasVectorColumns(tablePath, s"embedding:VECTOR($dim, DOUBLE)")
   }
 
   @ParameterizedTest
@@ -907,6 +909,8 @@ class TestLanceDataSource extends HoodieSparkClientTestBase {
 
     assertLanceFieldIsFixedSizeList(tablePath, "embedding", embeddingDim)
     assertLanceFieldIsFixedSizeList(tablePath, "features", featuresDim)
+    assertLanceFooterHasVectorColumns(tablePath,
+      s"embedding:VECTOR($embeddingDim),features:VECTOR($featuresDim, DOUBLE)")
   }
 
   private def assertHudiTypeMetadata(field: StructField, expectedDescriptor: String): Unit = {
@@ -925,6 +929,57 @@ class TestLanceDataSource extends HoodieSparkClientTestBase {
    * This proves that the write path used Lance's native vector column encoding
    * rather than a plain variable-length list.
    */
+  /**
+   * Opens the raw Lance base file(s) for the given Hudi table and asserts that the
+   * Arrow schema's custom metadata carries `hoodie.vector.columns` with the given
+   * expected descriptor list. This is the forward-compat guard — future readers
+   * can recover the exact Hudi VECTOR descriptor from the footer without
+   * re-deriving from the Arrow type.
+   *
+   * <p>Descriptor list order is writer-determined (matches Spark schema field
+   * order), so callers must pass the entries in that order.
+   */
+  private def assertLanceFooterHasVectorColumns(tablePath: String, expected: String): Unit = {
+    val metaClient = HoodieTableMetaClient.builder()
+      .setConf(HoodieTestUtils.getDefaultStorageConf)
+      .setBasePath(tablePath)
+      .build()
+    val engineContext = new HoodieLocalEngineContext(metaClient.getStorageConf)
+    val metadataConfig = HoodieMetadataConfig.newBuilder.build
+    val viewManager = FileSystemViewManager.createViewManager(
+      engineContext, metadataConfig, FileSystemViewStorageConfig.newBuilder.build,
+      HoodieCommonConfig.newBuilder.build,
+      (mc: HoodieTableMetaClient) => metaClient.getTableFormat
+        .getMetadataFactory.create(engineContext, mc.getStorage, metadataConfig, tablePath))
+    val fsView = viewManager.getFileSystemView(metaClient)
+    try {
+      val baseFiles = fsView.getLatestBaseFiles("")
+        .collect(Collectors.toList[org.apache.hudi.common.model.HoodieBaseFile])
+      assertTrue(baseFiles.size() > 0, "Expected at least one Lance base file")
+      val allocator = new RootAllocator()
+      try {
+        baseFiles.asScala.foreach { bf =>
+          val reader = LanceFileReader.open(bf.getPath, allocator)
+          try {
+            val meta = reader.schema().getCustomMetadata
+            assertNotNull(meta, s"Lance footer metadata null for ${bf.getPath}")
+            val key = HoodieSchema.PARQUET_VECTOR_COLUMNS_METADATA_KEY
+            assertTrue(meta.containsKey(key),
+              s"Lance file ${bf.getPath} should have footer key $key, got keys ${meta.keySet()}")
+            assertEquals(expected, meta.get(key),
+              s"Lance file ${bf.getPath} footer $key mismatch")
+          } finally {
+            reader.close()
+          }
+        }
+      } finally {
+        allocator.close()
+      }
+    } finally {
+      fsView.close()
+    }
+  }
+
   private def assertLanceFieldIsFixedSizeList(tablePath: String, fieldName: String, expectedDim: Int): Unit = {
     val metaClient = HoodieTableMetaClient.builder()
       .setConf(HoodieTestUtils.getDefaultStorageConf)

--- a/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestVectorDataSource.scala
+++ b/hudi-spark-datasource/hudi-spark/src/test/scala/org/apache/hudi/functional/TestVectorDataSource.scala
@@ -770,10 +770,10 @@ class TestVectorDataSource extends HoodieSparkClientTestBase {
     val reader = ParquetFileReader.open(HadoopInputFile.fromPath(parquetFiles.head.getPath, conf))
     try {
       val footerMeta = reader.getFileMetaData.getKeyValueMetaData.asScala
-      assertTrue(footerMeta.contains(HoodieSchema.PARQUET_VECTOR_COLUMNS_METADATA_KEY),
-        s"Footer should contain ${HoodieSchema.PARQUET_VECTOR_COLUMNS_METADATA_KEY}, got keys: ${footerMeta.keys.mkString(", ")}")
+      assertTrue(footerMeta.contains(HoodieSchema.VECTOR_COLUMNS_METADATA_KEY),
+        s"Footer should contain ${HoodieSchema.VECTOR_COLUMNS_METADATA_KEY}, got keys: ${footerMeta.keys.mkString(", ")}")
 
-      val value = footerMeta(HoodieSchema.PARQUET_VECTOR_COLUMNS_METADATA_KEY)
+      val value = footerMeta(HoodieSchema.VECTOR_COLUMNS_METADATA_KEY)
       assertTrue(value.contains("embedding"), s"Footer value should reference 'embedding' column, got: $value")
       assertTrue(value.contains("VECTOR"), s"Footer value should contain 'VECTOR' descriptor, got: $value")
     } finally {


### PR DESCRIPTION
Mirror of https://github.com/apache/hudi/pull/18497 for automated bot review.

**Original author:** @rahil-c
**Base branch:** master


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced vector column support with improved metadata preservation across file formats.
  * Vector data now properly round-trips when reading and writing storage formats.

* **Bug Fixes**
  * Vector metadata is now correctly restored during read operations.
  * Vector field metadata is properly enriched before storage conversion.

* **Tests**
  * Added comprehensive functional tests for vector data handling and format compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->