### PR TITLE
[OSS PR #18468] feat(flink): Support emit watermark in the end of each split

### DIFF
--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/configuration/FlinkOptions.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/configuration/FlinkOptions.java
@@ -465,6 +465,12 @@ public class FlinkOptions extends HoodieConfig {
       .defaultValue(false)
       .withDescription("Whether to use Flink FLIP27 new source to consume data files.");
 
+  public static final ConfigOption<Boolean> READ_COMMIT_TIME_WATERMARK_ENABLED = ConfigOptions
+      .key("read.commit.time.watermark.enabled")
+      . booleanType()
+      .defaultValue(false)
+      .withDescription("Whether to emit hoodie commit time as watermark at the end of each split of source-v2.");
+
   @AdvancedConfig
   public static final ConfigOption<Boolean> READ_CDC_FROM_CHANGELOG = ConfigOptions
       .key("read.cdc.from.changelog")

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/source/reader/BatchRecords.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/source/reader/BatchRecords.java
@@ -42,6 +42,14 @@ public class BatchRecords<T> implements RecordsWithSplitIds<HoodieRecordWithPosi
   // point to current read position within the records list
   private int position;
 
+  // Cache the result of the post-next() hasNext() call so the next iteration's outer
+  // if-check can reuse it without calling hasNext() again.  Several CDC iterators
+  // (AddBaseFileIterator, DataLogFileIterator, BaseImageIterator) pre-fetch the next
+  // record inside hasNext(), so calling hasNext() twice between two next() calls would
+  // skip records.  The cache avoids the double-call.
+  private boolean hasNextCache;
+  private boolean hasNextCacheValid;
+
   BatchRecords(
       String splitId,
       ClosableIterator<T> recordIterator,
@@ -60,6 +68,8 @@ public class BatchRecords<T> implements RecordsWithSplitIds<HoodieRecordWithPosi
     this.recordAndPosition = new HoodieRecordWithPosition<>();
     this.recordAndPosition.set(null, fileOffset, startingRecordOffset);
     this.position = 0;
+    this.hasNextCache = false;
+    this.hasNextCacheValid = false;
   }
 
   @Nullable
@@ -78,8 +88,20 @@ public class BatchRecords<T> implements RecordsWithSplitIds<HoodieRecordWithPosi
   @Nullable
   @Override
   public HoodieRecordWithPosition<T> nextRecordFromSplit() {
-    if (recordIterator.hasNext()) {
+    // Use the cached hasNext() result from the previous iteration when available.
+    // Several CDC iterators pre-fetch the next record inside hasNext() (e.g.
+    // AddBaseFileIterator calls nested.next() there), so calling hasNext() twice
+    // between two next() calls would silently skip the pre-fetched record.
+    boolean moreRecords = hasNextCacheValid ? hasNextCache : recordIterator.hasNext();
+    hasNextCacheValid = false;
+
+    if (moreRecords) {
       recordAndPosition.record(recordIterator.next());
+      // Call hasNext() once and cache the result for the next iteration's outer check.
+      hasNextCache = recordIterator.hasNext();
+      hasNextCacheValid = true;
+      // Mark the last record in the split so the emitter can emit a split-end watermark.
+      recordAndPosition.setLastInSplit(!hasNextCache);
       position = position + 1;
       return recordAndPosition;
     } else {

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/source/reader/HoodieRecordEmitter.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/source/reader/HoodieRecordEmitter.java
@@ -18,21 +18,54 @@
 
 package org.apache.hudi.source.reader;
 
+import org.apache.flink.api.common.eventtime.Watermark;
 import org.apache.flink.api.connector.source.SourceOutput;
 import org.apache.flink.connector.base.source.reader.RecordEmitter;
+import org.apache.hudi.common.table.timeline.HoodieInstantTimeGenerator;
 import org.apache.hudi.source.split.HoodieSourceSplit;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.Serializable;
+import java.text.ParseException;
 
 /**
  * Default Hoodie record emitter.
- * @param <T>
+ *
+ * <p>In addition to forwarding each record downstream, this emitter advances the Flink
+ * watermark to the split's {@code latestCommit} epoch when the last record of the split
+ * is processed.  Downstream operators can rely on this watermark to trigger time-based
+ * windows or gauge read progress in bounded Hudi pipelines.
+ *
+ * @param <T> record type
  */
 public class HoodieRecordEmitter<T> implements RecordEmitter<HoodieRecordWithPosition<T>, T, HoodieSourceSplit>, Serializable {
+  private static final Logger LOG = LoggerFactory.getLogger(HoodieRecordEmitter.class);
 
   @Override
   public void emitRecord(HoodieRecordWithPosition<T> record, SourceOutput<T> output, HoodieSourceSplit split) throws Exception {
     output.collect(record.record());
     split.updatePosition(record.fileOffset(), record.recordOffset());
+    if (record.isLastInSplit()) {
+      emitSplitWatermark(output, split);
+    }
+  }
+
+  /**
+   * Parses the split's {@code latestCommit} Hudi instant string into epoch milliseconds and
+   * emits a Flink {@link Watermark}, signalling that all records belonging to this split have
+   * been produced.
+   */
+  private void emitSplitWatermark(SourceOutput<T> output, HoodieSourceSplit split) {
+    String latestCommit = split.getLatestCommit();
+    try {
+      long watermarkMs = HoodieInstantTimeGenerator.parseDateFromInstantTime(latestCommit).getTime();
+      output.emitWatermark(new Watermark(watermarkMs));
+      LOG.debug("Emitted split-end watermark {} ms for split {} (latestCommit={})",
+          watermarkMs, split.splitId(), latestCommit);
+    } catch (ParseException e) {
+      LOG.warn("Could not parse latestCommit '{}' as a watermark timestamp for split {}; "
+          + "no watermark emitted.", latestCommit, split.splitId(), e);
+    }
   }
 }

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/source/reader/HoodieRecordEmitter.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/source/reader/HoodieRecordEmitter.java
@@ -41,12 +41,17 @@ import java.text.ParseException;
  */
 public class HoodieRecordEmitter<T> implements RecordEmitter<HoodieRecordWithPosition<T>, T, HoodieSourceSplit>, Serializable {
   private static final Logger LOG = LoggerFactory.getLogger(HoodieRecordEmitter.class);
+  private final boolean emitCommitTimeWatermark;
+
+  public HoodieRecordEmitter(boolean emitCommitTimeWatermark) {
+    this.emitCommitTimeWatermark = emitCommitTimeWatermark;
+  }
 
   @Override
   public void emitRecord(HoodieRecordWithPosition<T> record, SourceOutput<T> output, HoodieSourceSplit split) throws Exception {
     output.collect(record.record());
     split.updatePosition(record.fileOffset(), record.recordOffset());
-    if (record.isLastInSplit()) {
+    if (emitCommitTimeWatermark && record.isLastInSplit()) {
       emitSplitWatermark(output, split);
     }
   }
@@ -58,14 +63,16 @@ public class HoodieRecordEmitter<T> implements RecordEmitter<HoodieRecordWithPos
    */
   private void emitSplitWatermark(SourceOutput<T> output, HoodieSourceSplit split) {
     String latestCommit = split.getLatestCommit();
-    try {
-      long watermarkMs = HoodieInstantTimeGenerator.parseDateFromInstantTime(latestCommit).getTime();
-      output.emitWatermark(new Watermark(watermarkMs));
-      LOG.debug("Emitted split-end watermark {} ms for split {} (latestCommit={})",
-          watermarkMs, split.splitId(), latestCommit);
-    } catch (ParseException e) {
-      LOG.warn("Could not parse latestCommit '{}' as a watermark timestamp for split {}; "
-          + "no watermark emitted.", latestCommit, split.splitId(), e);
+    if (latestCommit != null) {
+      try {
+        long watermarkMs = HoodieInstantTimeGenerator.parseDateFromInstantTime(latestCommit).getTime();
+        output.emitWatermark(new Watermark(watermarkMs));
+        LOG.debug("Emitted split-end watermark {} ms for split {} (latestCommit={})",
+                watermarkMs, split.splitId(), latestCommit);
+      } catch (ParseException e) {
+        LOG.warn("Could not parse latestCommit '{}' as a watermark timestamp for split {}; "
+                + "no watermark emitted.", latestCommit, split.splitId(), e);
+      }
     }
   }
 }

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/source/reader/HoodieRecordWithPosition.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/source/reader/HoodieRecordWithPosition.java
@@ -34,6 +34,7 @@ public class HoodieRecordWithPosition<T> {
     this.record = record;
     this.fileOffset = fileOffset;
     this.recordOffset = recordOffset;
+    this.lastInSplit = false;
   }
 
   public HoodieRecordWithPosition() {
@@ -59,6 +60,7 @@ public class HoodieRecordWithPosition<T> {
     this.record = newRecord;
     this.fileOffset = newFileOffset;
     this.recordOffset = newRecordOffset;
+    this.lastInSplit = false;
   }
 
   public boolean isLastInSplit() {

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/source/reader/HoodieRecordWithPosition.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/source/reader/HoodieRecordWithPosition.java
@@ -27,6 +27,8 @@ public class HoodieRecordWithPosition<T> {
   private T record;
   private int fileOffset;
   private long recordOffset;
+  /** True for the final record in a split; triggers watermark emission in the emitter. */
+  private boolean lastInSplit;
 
   public HoodieRecordWithPosition(T record, int fileOffset, long recordOffset) {
     this.record = record;
@@ -59,10 +61,19 @@ public class HoodieRecordWithPosition<T> {
     this.recordOffset = newRecordOffset;
   }
 
+  public boolean isLastInSplit() {
+    return lastInSplit;
+  }
+
+  public void setLastInSplit(boolean lastInSplit) {
+    this.lastInSplit = lastInSplit;
+  }
+
   /** Sets the next record of a sequence. This increments the {@code recordOffset} by one. */
   public void record(T nextRecord) {
     this.record = nextRecord;
     this.recordOffset++;
+    this.lastInSplit = false;
   }
 
   @Override

--- a/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/HoodieTableSource.java
+++ b/hudi-flink-datasource/hudi-flink/src/main/java/org/apache/hudi/table/HoodieTableSource.java
@@ -311,6 +311,7 @@ public class HoodieTableSource extends FileIndexReader implements
             HoodieSchemaConverter.convertToSchema(requiredRowType).toString(),
             new ArrayList<>());
     boolean emitDelete = tableType == HoodieTableType.MERGE_ON_READ;
+    boolean emitCommitTimeWatermark = conf.get(FlinkOptions.READ_COMMIT_TIME_WATERMARK_ENABLED);
     if (conf.get(FlinkOptions.CDC_ENABLED)) {
       List<DataType> fieldTypes = rowDataType.getChildren();
       splitReaderFunction = new HoodieCdcSplitReaderFunction(
@@ -330,7 +331,7 @@ public class HoodieTableSource extends FileIndexReader implements
           predicates,
           emitDelete);
     }
-    return new HoodieSource<>(context, splitReaderFunction, new HoodieSourceSplitComparator(), metaClient, new HoodieRecordEmitter<>());
+    return new HoodieSource<>(context, splitReaderFunction, new HoodieSourceSplitComparator(), metaClient, new HoodieRecordEmitter<>(emitCommitTimeWatermark));
   }
 
   /**

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/source/TestHoodieSource.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/source/TestHoodieSource.java
@@ -427,6 +427,6 @@ public class TestHoodieSource {
         splitReaderFunction,
         new HoodieSourceSplitComparator(),
         metaClient,
-        new HoodieRecordEmitter<>());
+        new HoodieRecordEmitter<>(conf.get(FlinkOptions.READ_COMMIT_TIME_WATERMARK_ENABLED)));
   }
 }

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/source/reader/TestBatchRecords.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/source/reader/TestBatchRecords.java
@@ -23,6 +23,7 @@ import org.apache.hudi.common.util.collection.ClosableIterator;
 import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -30,8 +31,9 @@ import java.util.List;
 import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -362,7 +364,7 @@ public class TestBatchRecords {
     BatchRecords<String> batchRecords = BatchRecords.forRecords(splitId, prefetchingIterator, 0, 0L);
     batchRecords.nextSplit();
 
-    List<String> collected = new java.util.ArrayList<>();
+    List<String> collected = new ArrayList<>();
     HoodieRecordWithPosition<String> r;
     while ((r = batchRecords.nextRecordFromSplit()) != null) {
       collected.add(r.record());
@@ -383,12 +385,12 @@ public class TestBatchRecords {
     HoodieRecordWithPosition<String> first = batchRecords.nextRecordFromSplit();
     assertNotNull(first);
     assertEquals("x", first.record());
-    assertEquals(false, first.isLastInSplit(), "First record must NOT be marked as last");
+    assertFalse(first.isLastInSplit(), "First record must NOT be marked as last");
 
     HoodieRecordWithPosition<String> last = batchRecords.nextRecordFromSplit();
     assertNotNull(last);
     assertEquals("y", last.record());
-    assertEquals(true, last.isLastInSplit(), "Second (last) record MUST be marked as last");
+    assertTrue(last.isLastInSplit(), "Second (last) record MUST be marked as last");
 
     assertNull(batchRecords.nextRecordFromSplit(), "No more records expected");
   }

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/source/reader/TestBatchRecords.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/source/reader/TestBatchRecords.java
@@ -345,6 +345,94 @@ public class TestBatchRecords {
   }
 
   /**
+   * Verifies that BatchRecords correctly handles iterators that pre-fetch the next element
+   * inside hasNext() (like the CDC AddBaseFileIterator).  The bug was that
+   * nextRecordFromSplit() called hasNext() twice between consecutive next() calls — once
+   * for the outer guard and once for setLastInSplit — causing every other record to be
+   * skipped when hasNext() has side-effects.
+   */
+  @Test
+  public void testAllRecordsReturnedWithPrefetchingIterator() {
+    String splitId = "test-split-prefetch";
+    List<String> records = Arrays.asList("a", "b", "c", "d");
+    // Iterator that pre-fetches the next element inside hasNext(), mirroring
+    // CdcIterators.AddBaseFileIterator behaviour.
+    ClosableIterator<String> prefetchingIterator = new PrefetchingClosableIterator<>(records);
+
+    BatchRecords<String> batchRecords = BatchRecords.forRecords(splitId, prefetchingIterator, 0, 0L);
+    batchRecords.nextSplit();
+
+    List<String> collected = new java.util.ArrayList<>();
+    HoodieRecordWithPosition<String> r;
+    while ((r = batchRecords.nextRecordFromSplit()) != null) {
+      collected.add(r.record());
+    }
+
+    assertEquals(records, collected, "All records must be returned without skipping");
+  }
+
+  @Test
+  public void testLastInSplitFlagWithPrefetchingIterator() {
+    String splitId = "test-split-prefetch-last";
+    List<String> records = Arrays.asList("x", "y");
+    ClosableIterator<String> prefetchingIterator = new PrefetchingClosableIterator<>(records);
+
+    BatchRecords<String> batchRecords = BatchRecords.forRecords(splitId, prefetchingIterator, 0, 0L);
+    batchRecords.nextSplit();
+
+    HoodieRecordWithPosition<String> first = batchRecords.nextRecordFromSplit();
+    assertNotNull(first);
+    assertEquals("x", first.record());
+    assertEquals(false, first.isLastInSplit(), "First record must NOT be marked as last");
+
+    HoodieRecordWithPosition<String> last = batchRecords.nextRecordFromSplit();
+    assertNotNull(last);
+    assertEquals("y", last.record());
+    assertEquals(true, last.isLastInSplit(), "Second (last) record MUST be marked as last");
+
+    assertNull(batchRecords.nextRecordFromSplit(), "No more records expected");
+  }
+
+  /**
+   * A ClosableIterator that pre-fetches the next element inside hasNext(), mimicking
+   * the behaviour of CdcIterators.AddBaseFileIterator.
+   */
+  private static class PrefetchingClosableIterator<T> implements ClosableIterator<T> {
+    private final Iterator<T> delegate;
+    private T prefetched;
+    private boolean hasPrefetched;
+
+    PrefetchingClosableIterator(List<T> items) {
+      this.delegate = items.iterator();
+    }
+
+    @Override
+    public boolean hasNext() {
+      if (delegate.hasNext()) {
+        prefetched = delegate.next(); // pre-fetch side-effect
+        hasPrefetched = true;
+        return true;
+      }
+      hasPrefetched = false;
+      return false;
+    }
+
+    @Override
+    public T next() {
+      if (!hasPrefetched) {
+        throw new java.util.NoSuchElementException();
+      }
+      hasPrefetched = false;
+      return prefetched;
+    }
+
+    @Override
+    public void close() {
+      // no-op
+    }
+  }
+
+  /**
    * Mock closable iterator for testing close behavior.
    */
   private static class MockClosableIterator<T> implements ClosableIterator<T> {

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/source/reader/TestHoodieRecordEmitter.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/source/reader/TestHoodieRecordEmitter.java
@@ -18,6 +18,7 @@
 
 package org.apache.hudi.source.reader;
 
+import org.apache.hudi.common.table.timeline.HoodieInstantTimeGenerator;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.source.split.HoodieSourceSplit;
 
@@ -33,6 +34,7 @@ import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
@@ -49,7 +51,7 @@ public class TestHoodieRecordEmitter {
 
   @BeforeEach
   public void setUp() {
-    emitter = new HoodieRecordEmitter<>();
+    emitter = new HoodieRecordEmitter<>(true);
     mockOutput = mock(SourceOutput.class);
     mockSplit = createTestSplit();
   }
@@ -145,7 +147,7 @@ public class TestHoodieRecordEmitter {
 
   @Test
   public void testEmitRecordWithDifferentRecordTypes() throws Exception {
-    HoodieRecordEmitter<Integer> intEmitter = new HoodieRecordEmitter<>();
+    HoodieRecordEmitter<Integer> intEmitter = new HoodieRecordEmitter<>(false);
     SourceOutput<Integer> intOutput = mock(SourceOutput.class);
 
     HoodieRecordWithPosition<Integer> intRecord =
@@ -242,6 +244,134 @@ public class TestHoodieRecordEmitter {
     // Three records collected, but watermark emitted only once (for r3).
     verify(mockOutput, times(3)).collect(org.mockito.ArgumentMatchers.anyString());
     verify(mockOutput, times(1)).emitWatermark(org.mockito.ArgumentMatchers.any(Watermark.class));
+  }
+
+  // -------------------------------------------------------------------------
+  // Additional coverage tests
+  // -------------------------------------------------------------------------
+
+  @Test
+  public void testWatermarkNotEmittedWhenFlagDisabled() throws Exception {
+    HoodieRecordEmitter<String> noWatermarkEmitter = new HoodieRecordEmitter<>(false);
+    HoodieRecordWithPosition<String> lastRecord = new HoodieRecordWithPosition<>("last", 0, 5L);
+    lastRecord.setLastInSplit(true);
+
+    noWatermarkEmitter.emitRecord(lastRecord, mockOutput, mockSplit);
+
+    verify(mockOutput, times(1)).collect("last");
+    verify(mockOutput, never()).emitWatermark(org.mockito.ArgumentMatchers.any());
+  }
+
+  @Test
+  public void testWatermarkNotEmittedForUnparsableLatestCommit() throws Exception {
+    HoodieSourceSplit badCommitSplit = new HoodieSourceSplit(
+        2, "some-base", Option.of(Collections.emptyList()),
+        "/table", "/partition", "read_optimized",
+        "not-a-valid-instant", "file-2", Option.empty());
+
+    HoodieRecordWithPosition<String> lastRecord = new HoodieRecordWithPosition<>("last", 0, 0L);
+    lastRecord.setLastInSplit(true);
+
+    // Must not throw; ParseException is swallowed internally.
+    emitter.emitRecord(lastRecord, mockOutput, badCommitSplit);
+
+    verify(mockOutput, times(1)).collect("last");
+    verify(mockOutput, never()).emitWatermark(org.mockito.ArgumentMatchers.any());
+  }
+
+  @Test
+  public void testWatermarkTimestampMatchesLatestCommit() throws Exception {
+    long expectedWatermarkMs =
+        HoodieInstantTimeGenerator.parseDateFromInstantTime("19700101000000000").getTime();
+
+    HoodieRecordWithPosition<String> lastRecord = new HoodieRecordWithPosition<>("last", 0, 0L);
+    lastRecord.setLastInSplit(true);
+
+    emitter.emitRecord(lastRecord, mockOutput, mockSplit);
+
+    ArgumentCaptor<Watermark> captor = ArgumentCaptor.forClass(Watermark.class);
+    verify(mockOutput, times(1)).emitWatermark(captor.capture());
+    assertEquals(expectedWatermarkMs, captor.getValue().getTimestamp());
+  }
+
+  @Test
+  public void testHoodieRecordWithPositionNoArgConstructorAndSet() throws Exception {
+    HoodieRecordWithPosition<String> record = new HoodieRecordWithPosition<>();
+    record.set("set-record", 3, 42L);
+
+    emitter.emitRecord(record, mockOutput, mockSplit);
+
+    verify(mockOutput, times(1)).collect("set-record");
+    assertEquals(3, mockSplit.getFileOffset());
+    assertEquals(42L, mockSplit.getConsumed());
+  }
+
+  @Test
+  public void testEmitLastRecordBothCollectsAndEmitsWatermark() throws Exception {
+    HoodieRecordWithPosition<String> lastRecord =
+        new HoodieRecordWithPosition<>("only-record", 0, 1L);
+    lastRecord.setLastInSplit(true);
+
+    emitter.emitRecord(lastRecord, mockOutput, mockSplit);
+
+    verify(mockOutput, times(1)).collect("only-record");
+    verify(mockOutput, times(1)).emitWatermark(org.mockito.ArgumentMatchers.any(Watermark.class));
+    assertEquals(0, mockSplit.getFileOffset());
+    assertEquals(1L, mockSplit.getConsumed());
+  }
+
+  @Test
+  public void testWatermarkEmittedIndependentlyPerSplit() throws Exception {
+    HoodieSourceSplit split1 = createTestSplit();
+    HoodieSourceSplit split2 = new HoodieSourceSplit(
+        2, "base2", Option.of(Collections.emptyList()),
+        "/table2", "/partition2", "read_optimized",
+        "20210101000000000", "file-2", Option.empty());
+
+    HoodieRecordWithPosition<String> lastOfSplit1 = new HoodieRecordWithPosition<>("s1-last", 0, 1L);
+    lastOfSplit1.setLastInSplit(true);
+    HoodieRecordWithPosition<String> lastOfSplit2 = new HoodieRecordWithPosition<>("s2-last", 0, 2L);
+    lastOfSplit2.setLastInSplit(true);
+
+    emitter.emitRecord(lastOfSplit1, mockOutput, split1);
+    emitter.emitRecord(lastOfSplit2, mockOutput, split2);
+
+    verify(mockOutput, times(2)).collect(org.mockito.ArgumentMatchers.anyString());
+    verify(mockOutput, times(2)).emitWatermark(org.mockito.ArgumentMatchers.any(Watermark.class));
+  }
+
+  @Test
+  public void testRecordMethodIncreasesOffsetAndClearsLastInSplit() throws Exception {
+    HoodieRecordWithPosition<String> record = new HoodieRecordWithPosition<>("init", 0, 5L);
+    record.setLastInSplit(true);
+
+    // record() increments recordOffset by 1 and resets lastInSplit to false.
+    record.record("next");
+
+    emitter.emitRecord(record, mockOutput, mockSplit);
+
+    verify(mockOutput, times(1)).collect("next");
+    assertEquals(0, mockSplit.getFileOffset());
+    assertEquals(6L, mockSplit.getConsumed());
+    verify(mockOutput, never()).emitWatermark(org.mockito.ArgumentMatchers.any());
+  }
+
+  @Test
+  public void testEmitterIsSerializable() throws Exception {
+    byte[] bytes;
+    try (java.io.ByteArrayOutputStream bos = new java.io.ByteArrayOutputStream();
+         java.io.ObjectOutputStream oos = new java.io.ObjectOutputStream(bos)) {
+      oos.writeObject(emitter);
+      bytes = bos.toByteArray();
+    }
+
+    HoodieRecordEmitter<?> deserialized;
+    try (java.io.ByteArrayInputStream bis = new java.io.ByteArrayInputStream(bytes);
+         java.io.ObjectInputStream ois = new java.io.ObjectInputStream(bis)) {
+      deserialized = (HoodieRecordEmitter<?>) ois.readObject();
+    }
+
+    assertNotNull(deserialized);
   }
 
   /**

--- a/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/source/reader/TestHoodieRecordEmitter.java
+++ b/hudi-flink-datasource/hudi-flink/src/test/java/org/apache/hudi/source/reader/TestHoodieRecordEmitter.java
@@ -21,6 +21,7 @@ package org.apache.hudi.source.reader;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.source.split.HoodieSourceSplit;
 
+import org.apache.flink.api.common.eventtime.Watermark;
 import org.apache.flink.api.connector.source.SourceOutput;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -31,7 +32,9 @@ import java.util.Collections;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
@@ -194,6 +197,51 @@ public class TestHoodieRecordEmitter {
     assertEquals(0L, mockSplit.getConsumed());
 
     verify(mockOutput, times(6)).collect(org.mockito.ArgumentMatchers.anyString());
+  }
+
+  // -------------------------------------------------------------------------
+  // Watermark tests
+  // -------------------------------------------------------------------------
+
+  @Test
+  public void testWatermarkEmittedForLastRecordInSplit() throws Exception {
+    // "19700101000000000" parses to epoch 0 ms in the local timezone of the JVM;
+    // we only verify that emitWatermark was invoked exactly once.
+    HoodieRecordWithPosition<String> lastRecord = new HoodieRecordWithPosition<>("last", 0, 1L);
+    lastRecord.setLastInSplit(true);
+
+    emitter.emitRecord(lastRecord, mockOutput, mockSplit);
+
+    ArgumentCaptor<Watermark> watermarkCaptor = ArgumentCaptor.forClass(Watermark.class);
+    verify(mockOutput, times(1)).emitWatermark(watermarkCaptor.capture());
+    // The watermark must be non-null and captured exactly once.
+    assertFalse(watermarkCaptor.getAllValues().isEmpty());
+  }
+
+  @Test
+  public void testNoWatermarkEmittedForNonLastRecord() throws Exception {
+    HoodieRecordWithPosition<String> record = new HoodieRecordWithPosition<>("mid", 0, 0L);
+    // lastInSplit defaults to false
+
+    emitter.emitRecord(record, mockOutput, mockSplit);
+
+    verify(mockOutput, never()).emitWatermark(org.mockito.ArgumentMatchers.any());
+  }
+
+  @Test
+  public void testWatermarkEmittedOnlyForLastOfMultipleRecords() throws Exception {
+    HoodieRecordWithPosition<String> r1 = new HoodieRecordWithPosition<>("r1", 0, 0L);
+    HoodieRecordWithPosition<String> r2 = new HoodieRecordWithPosition<>("r2", 0, 1L);
+    HoodieRecordWithPosition<String> r3 = new HoodieRecordWithPosition<>("r3", 0, 2L);
+    r3.setLastInSplit(true);
+
+    emitter.emitRecord(r1, mockOutput, mockSplit);
+    emitter.emitRecord(r2, mockOutput, mockSplit);
+    emitter.emitRecord(r3, mockOutput, mockSplit);
+
+    // Three records collected, but watermark emitted only once (for r3).
+    verify(mockOutput, times(3)).collect(org.mockito.ArgumentMatchers.anyString());
+    verify(mockOutput, times(1)).emitWatermark(org.mockito.ArgumentMatchers.any(Watermark.class));
   }
 
   /**


### PR DESCRIPTION
Mirror of https://github.com/apache/hudi/pull/18468 for automated bot review.

**Original author:** @HuangZhenQiu
**Base branch:** master


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a configuration option to enable commit time watermark emission from source splits. When enabled, Hoodie commit timestamps are emitted as Flink watermarks at the end of each split (disabled by default).

* **Performance Improvements**
  * Optimized record iteration by caching iterator state to eliminate redundant checks during record retrieval.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->