### PR TITLE
chore: test co-author validation with violating commits (do not merge)

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -50,6 +50,7 @@ github:
           - validate-source
           - validate-pr
           - validate-pr-title
+          - validate-commit-coauthor
           - test-hudi-trino-plugin
           - test-spark-client-and-hadoop-common (scala-2.12, spark3.5, flink2.1)
           - test-utilities (scala-2.12, spark3.5, flink2.1)

--- a/.github/workflows/commit_coauthor_validation.yml
+++ b/.github/workflows/commit_coauthor_validation.yml
@@ -1,0 +1,38 @@
+name: Commit Co-author Validation
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize]
+    branches:
+      - master
+      - branch-0.x
+
+concurrency:
+  group: commit-coauthor-validation-${{ github.ref }}
+  cancel-in-progress: ${{ !contains(github.ref, 'master') && !contains(github.ref, 'branch-0.x') }}
+
+jobs:
+  validate-commit-coauthor:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check commits for Claude co-author trailers
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          echo "Checking commits of PR #${PR_NUMBER} for Claude co-author trailers..."
+          flagged=$(gh api "repos/${REPO}/pulls/${PR_NUMBER}/commits" --paginate \
+            --jq '.[] | select(.commit.message | test("(^|\\n)co-authored-by:.*(\\bclaude\\b|anthropic\\.com)"; "i")) | .sha')
+
+          if [[ -n "$flagged" ]]; then
+            echo "❌ The following commits contain a Claude co-author trailer:"
+            echo "$flagged"
+            echo ""
+            echo "Commits must not credit Claude as a co-author."
+            echo "Remove the 'Co-authored-by: Claude ...' trailer from the commit message(s),"
+            echo "e.g., by amending the commit or rebasing, and force-push the branch."
+            exit 1
+          fi
+
+          echo "✅ No Claude co-author trailers found."

--- a/.github/workflows/commit_coauthor_validation.yml
+++ b/.github/workflows/commit_coauthor_validation.yml
@@ -23,7 +23,7 @@ jobs:
         run: |
           echo "Checking commits of PR #${PR_NUMBER} for Claude co-author trailers..."
           flagged=$(gh api "repos/${REPO}/pulls/${PR_NUMBER}/commits" --paginate \
-            --jq '.[] | select(.commit.message | test("(^|\\n)co-authored-by:\\s*(claude\\s*<|[^\\n]*<noreply@anthropic\\.com>)"; "i")) | .sha')
+            --jq '.[] | select(.commit.message | test("(^|\\n)co-authored-by:[^\\n]*<noreply@anthropic\\.com>"; "i")) | .sha')
 
           if [[ -n "$flagged" ]]; then
             echo "❌ The following commits contain a Claude co-author trailer:"

--- a/.github/workflows/commit_coauthor_validation.yml
+++ b/.github/workflows/commit_coauthor_validation.yml
@@ -23,7 +23,7 @@ jobs:
         run: |
           echo "Checking commits of PR #${PR_NUMBER} for Claude co-author trailers..."
           flagged=$(gh api "repos/${REPO}/pulls/${PR_NUMBER}/commits" --paginate \
-            --jq '.[] | select(.commit.message | test("(^|\\n)co-authored-by:.*(\\bclaude\\b|anthropic\\.com)"; "i")) | .sha')
+            --jq '.[] | select(.commit.message | test("(^|\\n)co-authored-by:\\s*(claude\\s*<|[^\\n]*<noreply@anthropic\\.com>)"; "i")) | .sha')
 
           if [[ -n "$flagged" ]]; then
             echo "❌ The following commits contain a Claude co-author trailer:"

--- a/.github/workflows/commit_coauthor_validation.yml
+++ b/.github/workflows/commit_coauthor_validation.yml
@@ -23,7 +23,7 @@ jobs:
         run: |
           echo "Checking commits of PR #${PR_NUMBER} for Claude co-author trailers..."
           flagged=$(gh api "repos/${REPO}/pulls/${PR_NUMBER}/commits" --paginate \
-            --jq '.[] | select(.commit.message | test("(^|\\n)co-authored-by:[^\\n]*<noreply@anthropic\\.com>"; "i")) | .sha')
+            --jq '.[] | select(.commit.message | test("(^|\\n)co-authored-by:\\s*(claude\\s+(opus|sonnet|haiku|fable|mythos|instant|code|[0-9])|[^\\n]*<noreply@anthropic\\.com>)"; "i")) | .sha')
 
           if [[ -n "$flagged" ]]; then
             echo "❌ The following commits contain a Claude co-author trailer:"


### PR DESCRIPTION
Test PR for the validate-commit-coauthor check. Contains two commits that must FAIL the check: one with a noreply@anthropic.com co-author trailer, one with a Claude model name trailer. Will be closed after verification.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new validation check for pull request commits.
  * Pull requests targeting supported branches now fail if commit messages include an unsupported co-author credit.
  * Updated branch protection so this validation must pass before merging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->